### PR TITLE
build and publish a docker image with wag binary

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,5 +11,18 @@ notify:
     on_started: false
     on_success: false
     webhook_url: $$slack_webhook
+publish:
+  docker:
+    docker_host: $$docker_server
+    email: $$docker_email
+    image_name: clever/wag
+    password: $$docker_password
+    registry_login: true
+    tags:
+    - $(git rev-parse --short HEAD)
+    username: $$docker_username
+    when:
+      branch: master
 script:
 - make test
+- make build

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ _testmain.go
 *.prof
 
 impl/impl
+
+bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.1
+
+# need to mount your $GOPATH/src
+VOLUME  /gopath/src
+ENV GOPATH /gopath
+
+ENTRYPOINT ["/bin/wag"]
+
+ADD ./bin/wag /bin/wag

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,17 @@
 include golang.mk
 .DEFAULT_GOAL := test # override default goal set in library makefile
-.PHONY: test
+.PHONY: test build
 PKG := github.com/Clever/wag
 PKGS := $(shell go list ./... | grep -v /vendor)
 $(eval $(call golang-version-check,1.6))
 
-test:
+build:
+	# disable CGO and link completely statically (this is to enable us to run in containers that don't use glibc)
+	CGO_ENABLED=0 go build -installsuffix cgo -o bin/wag
+
+test: build
 	rm -rf generated/*
-	go run main.go validation.go -file swagger.yml -package $(PKG)/generated
+	./bin/wag -file swagger.yml -package $(PKG)/generated
 	cd impl && go build
 	# Temporarily run the client here since it isn't used in impl
 	cd generated/client && go build


### PR DESCRIPTION
Usage is slightly awkward, but I think a docker image will be most convenient while we're making changes frequently:

`docker run -v $(GOPATH)/src:/gopath/src -w /gopath/src/$(PKG) -i -t clever/wag:<commit> -file swagger.yml -package $(PKG)/generated`

Next up is a PR on dev-handbook with a swagger.mk that runs this command ^