### PR TITLE
minor tracing improvements

### DIFF
--- a/generated/server/middleware.go
+++ b/generated/server/middleware.go
@@ -76,12 +76,16 @@ func tracingMiddleware(c ContextHandler) ContextHandler {
 		var sp opentracing.Span
 		if sc, err := opentracing.GlobalTracer().
 			Extract(opentracing.HTTPHeaders,
-			opentracing.HTTPHeadersCarrier(r.Header)); err != nil {
+				opentracing.HTTPHeadersCarrier(r.Header)); err != nil {
 			sp = opentracing.StartSpan(opName)
 		} else {
 			sp = opentracing.StartSpan(opName, opentracing.ChildOf(sc))
 		}
 		defer sp.Finish()
+		sp.LogEvent("request_received")
+		defer func() {
+			sp.LogEvent("request_finished")
+		}()
 		c.ServeHTTPContext(opentracing.ContextWithSpan(ctx, sp), w, r)
 	})
 }

--- a/hardcoded/middleware.go
+++ b/hardcoded/middleware.go
@@ -76,12 +76,16 @@ func tracingMiddleware(c ContextHandler) ContextHandler {
 		var sp opentracing.Span
 		if sc, err := opentracing.GlobalTracer().
 			Extract(opentracing.HTTPHeaders,
-			opentracing.HTTPHeadersCarrier(r.Header)); err != nil {
+				opentracing.HTTPHeadersCarrier(r.Header)); err != nil {
 			sp = opentracing.StartSpan(opName)
 		} else {
 			sp = opentracing.StartSpan(opName, opentracing.ChildOf(sc))
 		}
 		defer sp.Finish()
+		sp.LogEvent("request_received")
+		defer func() {
+			sp.LogEvent("request_finished")
+		}()
 		c.ServeHTTPContext(opentracing.ContextWithSpan(ctx, sp), w, r)
 	})
 }


### PR DESCRIPTION
log an event for request received / finished

Tested these yesterday when E2E testing tracing in matchmaker (https://github.com/Clever/matchmaker-service/pull/84/files#diff-bc2869a6d7980c9bd4cd9fb0188584d8R76)