### PR TITLE
Un-hardcode the generated/ path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ build: hardcoded.go
 	CGO_ENABLED=0 go build -installsuffix cgo -o bin/wag
 
 test: build
-	rm -rf generated/*
+	rm -rf generated
 	./bin/wag -file swagger.yml -package $(PKG)/generated
 	cd impl && go build
 	# Temporarily run the client here since it isn't used in impl

--- a/client/genclients.go
+++ b/client/genclients.go
@@ -12,7 +12,7 @@ import (
 // Generate generates a client
 func Generate(packageName string, s spec.Swagger) error {
 
-	var g swagger.Generator
+	g := swagger.Generator{PackageName: packageName}
 
 	g.Printf("package client\n\n")
 	g.Printf(swagger.ImportStatements([]string{"golang.org/x/net/context", "strings", "bytes",
@@ -146,7 +146,7 @@ func (c Client) WithRetries(retries int) Client {
 		}
 	}
 
-	return g.WriteFile("generated/client/client.go")
+	return g.WriteFile("client/client.go")
 }
 
 var badRequestCode = `

--- a/hardcoded.go
+++ b/hardcoded.go
@@ -84,7 +84,7 @@ func hardcoded_doerGo() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "hardcoded/_doer.go", size: 2468, mode: os.FileMode(436), modTime: time.Unix(1470961073, 0)}
+	info := bindataFileInfo{name: "hardcoded/_doer.go", size: 2468, mode: os.FileMode(436), modTime: time.Unix(1470964511, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/main.go
+++ b/main.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
-	"go/format"
-	"io/ioutil"
 	"log"
 	"os"
 	"sort"
@@ -18,6 +15,7 @@ import (
 	"github.com/Clever/wag/client"
 	"github.com/Clever/wag/models"
 	"github.com/Clever/wag/server"
+	"github.com/Clever/wag/swagger"
 )
 
 func pathItemOperations(item spec.PathItem) map[string]*spec.Operation {
@@ -73,59 +71,44 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error loading swagger file: %s", err)
 	}
-	swagger := *doc.Spec()
+	swaggerSpec := *doc.Spec()
 
-	if err := validate(swagger); err != nil {
+	if err := validate(swaggerSpec); err != nil {
 		log.Fatalf("Swagger file not valid: %s", err)
 	}
 
 	for _, dir := range []string{"server", "client", "models"} {
 		dirName := os.Getenv("GOPATH") + "/src/" + *packageName + "/" + dir
-		if err := os.Mkdir(dirName, 0700); err != nil {
+		if err := os.MkdirAll(dirName, 0700); err != nil {
 			if !os.IsExist(err.(*os.PathError)) {
 				log.Fatalf("Could not create directory: %s, error: %s", dirName, err)
 			}
 		}
 	}
 
-	if err := models.Generate(*packageName, *swaggerFile, swagger); err != nil {
+	if err := models.Generate(*packageName, *swaggerFile, swaggerSpec); err != nil {
 		log.Fatalf("Error generating models: %s", err)
 	}
 
-	if err := server.Generate(*packageName, swagger); err != nil {
+	if err := server.Generate(*packageName, swaggerSpec); err != nil {
 		log.Fatalf("Failed to generate server: %s", err)
 	}
 
-	if err := client.Generate(*packageName, swagger); err != nil {
+	if err := client.Generate(*packageName, swaggerSpec); err != nil {
 		log.Fatalf("Failed generating clients %s", err)
 	}
 
-	if err := ioutil.WriteFile("generated/server/middleware.go", MustAsset("hardcoded/_middleware.go"), 0644); err != nil {
+	middlewareGenerator := swagger.Generator{PackageName: *packageName}
+	middlewareGenerator.Write(MustAsset("hardcoded/_middleware.go"))
+	if err := middlewareGenerator.WriteFile("server/middleware.go"); err != nil {
 		log.Fatalf("Failed to copy middleware.go: %s", err)
 	}
 
-	if err := ioutil.WriteFile("generated/client/doer.go", MustAsset("hardcoded/_doer.go"), 0644); err != nil {
+	doerGenerator := swagger.Generator{PackageName: *packageName}
+	doerGenerator.Write(MustAsset("hardcoded/_doer.go"))
+	if err := doerGenerator.WriteFile("client/doer.go"); err != nil {
 		log.Fatalf("Failed to copy doer.go: %s", err)
 	}
-}
-
-type Generator struct {
-	buf bytes.Buffer
-}
-
-func (g *Generator) Printf(format string, args ...interface{}) {
-	fmt.Fprintf(&g.buf, format, args...)
-}
-
-func (g *Generator) WriteFile(path string) error {
-	fileBytes, err := format.Source(g.buf.Bytes())
-	if err != nil {
-		// This will error if the code isn't valid so let's print it to make it
-		// easier to debug
-		fmt.Printf("BAD CODE\n%s\n", string(g.buf.Bytes()))
-		return err
-	}
-	return ioutil.WriteFile(path, fileBytes, 0644)
 }
 
 func sortedPathItemKeys(m map[string]spec.PathItem) []string {

--- a/models/genmodels.go
+++ b/models/genmodels.go
@@ -29,12 +29,12 @@ func Generate(packageName, swaggerFile string, swagger spec.Swagger) error {
 	if err := generateOutputs(packageName, swagger.Paths); err != nil {
 		return err
 	}
-	return generateInputs(swagger.Paths)
+	return generateInputs(packageName, swagger.Paths)
 }
 
-func generateInputs(paths *spec.Paths) error {
+func generateInputs(packageName string, paths *spec.Paths) error {
 
-	var g swagger.Generator
+	g := swagger.Generator{PackageName: packageName}
 
 	g.Printf(`
 package models
@@ -63,7 +63,7 @@ var _ = strconv.FormatInt
 		}
 	}
 
-	return g.WriteFile("generated/models/inputs.go")
+	return g.WriteFile("models/inputs.go")
 }
 
 func printInputStruct(g *swagger.Generator, op *spec.Operation) error {
@@ -122,7 +122,7 @@ func printInputValidation(g *swagger.Generator, op *spec.Operation) error {
 }
 
 func generateOutputs(packageName string, paths *spec.Paths) error {
-	var g swagger.Generator
+	g := swagger.Generator{PackageName: packageName}
 
 	g.Printf("package models\n\n")
 
@@ -204,7 +204,7 @@ func generateOutputs(packageName string, paths *spec.Paths) error {
 			}
 		}
 	}
-	return g.WriteFile("generated/models/outputs.go")
+	return g.WriteFile("models/outputs.go")
 }
 
 // defaultOutputTypes returns the string defining the default output type

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -13,7 +13,7 @@ import (
 
 func Generate(packageName string, swagger spec.Swagger) error {
 
-	if err := generateRouter(swagger.BasePath, swagger.Paths); err != nil {
+	if err := generateRouter(packageName, swagger.BasePath, swagger.Paths); err != nil {
 		return err
 	}
 
@@ -27,8 +27,8 @@ func Generate(packageName string, swagger spec.Swagger) error {
 	return nil
 }
 
-func generateRouter(basePath string, paths *spec.Paths) error {
-	var g swagger.Generator
+func generateRouter(packageName string, basePath string, paths *spec.Paths) error {
+	g := swagger.Generator{PackageName: packageName}
 
 	// TODO: Add something to all these about being auto-generated
 
@@ -95,7 +95,7 @@ func New(c Controller, port int) Server {
 	g.Printf("\treturn Server{Handler: handler, port : port}\n")
 	g.Printf("}\n")
 
-	return g.WriteFile("generated/server/router.go")
+	return g.WriteFile("server/router.go")
 }
 
 type routerTemplate struct {
@@ -119,12 +119,12 @@ func generateContextsAndControllers(packageName string, paths *spec.Paths) error
 	//	return nil
 	//}
 
-	var interfaceGenerator swagger.Generator
+	interfaceGenerator := swagger.Generator{PackageName: packageName}
 	interfaceGenerator.Printf("package server\n\n")
 	interfaceGenerator.Printf(swagger.ImportStatements([]string{"golang.org/x/net/context", packageName + "/models"}))
 	interfaceGenerator.Printf("type Controller interface {\n")
 
-	var controllerGenerator swagger.Generator
+	controllerGenerator := swagger.Generator{PackageName: packageName}
 	controllerGenerator.Printf("package server\n\n")
 	controllerGenerator.Printf(swagger.ImportStatements([]string{"golang.org/x/net/context",
 		"errors", packageName + "/models"}))
@@ -152,10 +152,10 @@ func generateContextsAndControllers(packageName string, paths *spec.Paths) error
 	}
 	interfaceGenerator.Printf("}\n")
 
-	if err := interfaceGenerator.WriteFile("generated/server/interface.go"); err != nil {
+	if err := interfaceGenerator.WriteFile("server/interface.go"); err != nil {
 		return err
 	}
-	return controllerGenerator.WriteFile("generated/server/controller.go")
+	return controllerGenerator.WriteFile("server/controller.go")
 }
 
 func printNewInput(g *swagger.Generator, op *spec.Operation) error {
@@ -230,7 +230,7 @@ func printNewInput(g *swagger.Generator, op *spec.Operation) error {
 }
 
 func generateHandlers(packageName string, paths *spec.Paths) error {
-	var g swagger.Generator
+	g := swagger.Generator{PackageName: packageName}
 
 	g.Printf("package server\n\n")
 	g.Printf(swagger.ImportStatements([]string{"golang.org/x/net/context", "github.com/gorilla/mux",
@@ -265,7 +265,7 @@ func generateHandlers(packageName string, paths *spec.Paths) error {
 		}
 	}
 
-	return g.WriteFile("generated/server/handlers.go")
+	return g.WriteFile("server/handlers.go")
 }
 
 type handlerOp struct {


### PR DESCRIPTION
This changes the `Generator` object to only write files relative to the
package name passed in as an input.

It also removes the old `Generator` object from main.go. Since there was
some direct access to the `bytes.Buffer` contained in this `Generator`,
I added a passthrough `Write` method so that the `Generator` can be used as an `io.Writer`