### PR TITLE
change port to an address string

### DIFF
--- a/generated/server/router.go
+++ b/generated/server/router.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"errors"
 	"net/http"
 	"time"
 
@@ -17,18 +16,15 @@ type contextKey struct{}
 
 type Server struct {
 	Handler http.Handler
-	port    int
+	addr    string
 }
 
 func (s Server) Serve() error {
 	// Give the sever 30 seconds to shut down
-	graceful.Run(":"+string(s.port), 30*time.Second, s.Handler)
-
-	// This should never return
-	return errors.New("This should never happen")
+	return graceful.RunWithErr(s.addr, 30*time.Second, s.Handler)
 }
 
-func New(c Controller, port int) Server {
+func New(c Controller, addr string) Server {
 	controller = c // TODO: get rid of global variable?
 	r := mux.NewRouter()
 
@@ -47,5 +43,5 @@ func New(c Controller, port int) Server {
 		CreateBookHandler(ctx, w, r)
 	})
 	handler := withMiddleware(r)
-	return Server{Handler: handler, port: port}
+	return Server{Handler: handler, addr: addr}
 }

--- a/impl/main.go
+++ b/impl/main.go
@@ -11,6 +11,6 @@ import (
 func main() {
 
 	controller := server.ControllerImpl{}
-	s := server.New(controller, 8080)
+	s := server.New(controller, ":8080")
 	log.Fatal(s.Serve())
 }

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -36,7 +36,6 @@ func generateRouter(packageName string, basePath string, paths *spec.Paths) erro
 		`package server
 
 import (
-	"errors"
 	"net/http"
 	"time"
 
@@ -52,18 +51,15 @@ type contextKey struct{}
 
 type Server struct {
 	Handler http.Handler
-	port int
+	addr string
 }
 
 func (s Server) Serve() error {
 	// Give the sever 30 seconds to shut down
-	graceful.Run(":" + string(s.port),30*time.Second,s.Handler)
-
-	// This should never return
-	return errors.New("This should never happen")
+	return graceful.RunWithErr(s.addr,30*time.Second,s.Handler)
 }
 
-func New(c Controller, port int) Server {
+func New(c Controller, addr string) Server {
 	controller = c // TODO: get rid of global variable?
 	r := mux.NewRouter()
 `)
@@ -92,7 +88,7 @@ func New(c Controller, port int) Server {
 	}
 	// TODO: It's a bit weird that this returns a pointer that it modifies...
 	g.Printf("\thandler := withMiddleware(r)\n")
-	g.Printf("\treturn Server{Handler: handler, port : port}\n")
+	g.Printf("\treturn Server{Handler: handler, addr: addr}\n")
 	g.Printf("}\n")
 
 	return g.WriteFile("server/router.go")

--- a/test/sample_server.go
+++ b/test/sample_server.go
@@ -34,7 +34,7 @@ func (c *ControllerImpl) CreateBook(ctx context.Context, input *models.CreateBoo
 func setupServer() *httptest.Server {
 	controller := ControllerImpl{books: make(map[int64]models.Book)}
 
-	s := server.New(&controller)
+	s := server.New(&controller, ":8080")
 
 	return httptest.NewServer(s.Handler)
 }


### PR DESCRIPTION
This seems more in line with what `Listen` functions take in, and also avoids having to do int -> string conversions (before this change we were doing it incorrectly).