### PR TITLE
Support for default values

### DIFF
--- a/generated/models/inputs.go
+++ b/generated/models/inputs.go
@@ -41,7 +41,7 @@ func (i GetBooksInput) Validate() error {
 		}
 	}
 	if i.MaxPages != nil {
-		if err := validate.Maximum("maxPages", "query", float64(*i.MaxPages), 1.000000, false); err != nil {
+		if err := validate.Maximum("maxPages", "query", float64(*i.MaxPages), 1000.000000, false); err != nil {
 			return err
 		}
 	}

--- a/generated/server/handlers.go
+++ b/generated/server/handlers.go
@@ -106,6 +106,10 @@ func NewGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 
 	}
 	availableStr := r.URL.Query().Get("available")
+	if len(availableStr) == 0 {
+		// Use the default value
+		availableStr = "true"
+	}
 	if len(availableStr) != 0 {
 		var availableTmp bool
 		availableTmp, err = strconv.ParseBool(availableStr)
@@ -116,6 +120,10 @@ func NewGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 
 	}
 	stateStr := r.URL.Query().Get("state")
+	if len(stateStr) == 0 {
+		// Use the default value
+		stateStr = "finished"
+	}
 	if len(stateStr) != 0 {
 		var stateTmp string
 		stateTmp, err = stateStr, error(nil)
@@ -146,6 +154,10 @@ func NewGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 
 	}
 	maxPagesStr := r.URL.Query().Get("maxPages")
+	if len(maxPagesStr) == 0 {
+		// Use the default value
+		maxPagesStr = "5.005E+02"
+	}
 	if len(maxPagesStr) != 0 {
 		var maxPagesTmp float64
 		maxPagesTmp, err = swag.ConvertFloat64(maxPagesStr)
@@ -156,6 +168,10 @@ func NewGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 
 	}
 	minPagesStr := r.URL.Query().Get("minPages")
+	if len(minPagesStr) == 0 {
+		// Use the default value
+		minPagesStr = "5"
+	}
 	if len(minPagesStr) != 0 {
 		var minPagesTmp int32
 		minPagesTmp, err = swag.ConvertInt32(minPagesStr)

--- a/swagger.yml
+++ b/swagger.yml
@@ -2,7 +2,6 @@ swagger: '2.0'
 info:
   title: Swagger Test
   description: Testing Swagger Codegen
-  # TODO: Understand this...
   version: 0.1.0
 basePath: /v1
 schemes:
@@ -80,6 +79,7 @@ paths:
         - name: available
           in: query
           type: boolean
+          default: true
         - name: state
           in: query
           type: string
@@ -87,6 +87,7 @@ paths:
           enum:
             - finished
             - inprogress
+          default: finished
         - name: published
           in: query
           type: string
@@ -100,13 +101,15 @@ paths:
           # Probably makes more sense for this to be an integer, but I couldn't figure out
           # a good example for books that really would need a float
           type: number
-          maximum: 1
+          maximum: 1000
           minimum: -5
           multipleOf: 0.5
+          default: 500.5
         - name: minPages
           in: query
           type: integer
           format: int32
+          default: 5
         - name: pagesToTime
           in: query
           type: number

--- a/swagger/parameter.go
+++ b/swagger/parameter.go
@@ -2,6 +2,7 @@ package swagger
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/go-openapi/spec"
@@ -235,4 +236,23 @@ func accessString(param spec.Parameter) string {
 		pointer = "*"
 	}
 	return fmt.Sprintf("%si.%s", pointer, Capitalize(param.Name))
+}
+
+// DefaultAsString returns the default value as a string. We convert it into a string so it's easier to insert
+// into the generated code and it doesn't make this logic really any different.
+func DefaultAsString(param spec.Parameter) string {
+	switch param.Default.(type) {
+	case string:
+		return param.Default.(string)
+	case float64:
+		if param.Type == "integer" {
+			return strconv.FormatInt(int64(param.Default.(float64)), 10)
+		} else {
+			return strconv.FormatFloat(param.Default.(float64), 'E', -1, 64)
+		}
+	case bool:
+		return strconv.FormatBool(param.Default.(bool))
+	default:
+		panic(fmt.Errorf("Unknown param type: %T", param))
+	}
 }


### PR DESCRIPTION
This change adds support for default values from the swagger schema. It converts the default value to a string and sets it as the value if it isn't specified.

In go-swagger adding a default to a input parameter doesn't make it a non-pointer. My intuition is that it should because the client should never see a nil value, but I held off on implemented that until I got buy-in.
