### PR TITLE
Don't require produces / consumes

### DIFF
--- a/swagger/parameter.go
+++ b/swagger/parameter.go
@@ -93,7 +93,7 @@ func ParamToType(param spec.Parameter) (string, error) {
 	default:
 		// Note. We don't support 'array' or 'file' types even though they're in the
 		// Swagger spec.
-		return "", fmt.Errorf("Unsupported param type")
+		return "", fmt.Errorf("Unsupported param type: \"%s\"", param.Type)
 	}
 	return typeName, nil
 }

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -54,11 +54,11 @@ func Validate(s spec.Swagger) error {
 		return fmt.Errorf("Schemes only supports 'http'")
 	}
 
-	if len(s.Consumes) != 1 || s.Consumes[0] != "application/json" {
+	if len(s.Consumes) > 1 || (len(s.Produces) == 0 && s.Consumes[0] != "application/json") {
 		return fmt.Errorf("Consumes only supports 'application/json'")
 	}
 
-	if len(s.Produces) != 1 || s.Produces[0] != "application/json" {
+	if len(s.Produces) > 1 || (len(s.Produces) == 0 && s.Produces[0] != "application/json") {
 		return fmt.Errorf("Produces only supports 'application/json'")
 	}
 


### PR DESCRIPTION
Hit this when trying to migrate the timeline service. Didn't seem like we really needed it so I relaxed the constraint.