### PR TITLE
Support string array input parameters

### DIFF
--- a/client/genclients.go
+++ b/client/genclients.go
@@ -47,6 +47,8 @@ func (c Client) WithRetries(retries int) Client {
 
 `)
 
+	g.Printf(swagger.BaseParamToStringCode())
+
 	for _, path := range swagger.SortedPathItemKeys(s.Paths.Paths) {
 		pathItem := s.Paths.Paths[path]
 		pathItemOps := swagger.PathItemOperations(pathItem)

--- a/generated/client/client.go
+++ b/generated/client/client.go
@@ -38,13 +38,35 @@ func (c Client) WithRetries(retries int) Client {
 	return c
 }
 
+// JoinByFormat joins a string array by a known format:
+//		ssv: space separated value
+//		tsv: tab separated value
+//		pipes: pipe (|) separated value
+//		csv: comma separated value (default)
+func JoinByFormat(data []string, format string) string {
+	if len(data) == 0 {
+		return ""
+	}
+	var sep string
+	switch format {
+	case "ssv":
+		sep = " "
+	case "tsv":
+		sep = "\t"
+	case "pipes":
+		sep = "|"
+	default:
+		sep = ","
+	}
+	return strings.Join(data, sep)
+}
 func (c Client) GetBooks(ctx context.Context, i *models.GetBooksInput) (models.GetBooksOutput, error) {
 	path := c.BasePath + "/v1/books"
 	urlVals := url.Values{}
 	var body []byte
 
-	if i.Author != nil {
-		urlVals.Add("author", *i.Author)
+	if i.Authors != nil {
+		urlVals.Add("authors", JoinByFormat(i.Authors, ""))
 	}
 	if i.Available != nil {
 		urlVals.Add("available", strconv.FormatBool(*i.Available))

--- a/generated/models/inputs.go
+++ b/generated/models/inputs.go
@@ -14,7 +14,7 @@ var _ = validate.Maximum
 var _ = strfmt.NewFormats
 
 type GetBooksInput struct {
-	Author      *string
+	Authors     []string
 	Available   *bool
 	State       *string
 	Published   *strfmt.Date
@@ -25,6 +25,21 @@ type GetBooksInput struct {
 }
 
 func (i GetBooksInput) Validate() error {
+	if i.Authors != nil {
+		if err := validate.MaxItems("authors", "query", int64(len(i.Authors)), 2); err != nil {
+			return err
+		}
+	}
+	if i.Authors != nil {
+		if err := validate.MinItems("authors", "query", int64(len(i.Authors)), 1); err != nil {
+			return err
+		}
+	}
+	if i.Authors != nil {
+		if err := validate.UniqueItems("authors", "query", i.Authors); err != nil {
+			return err
+		}
+	}
 	if i.State != nil {
 		if err := validate.Enum("state", "query", *i.State, []interface{}{"finished", "inprogress"}); err != nil {
 			return err

--- a/generated/server/handlers.go
+++ b/generated/server/handlers.go
@@ -96,14 +96,14 @@ func NewGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 	var err error
 	_ = err
 
-	authorStr := r.URL.Query().Get("author")
-	if len(authorStr) != 0 {
-		var authorTmp string
-		authorTmp, err = authorStr, error(nil)
+	authorsStr := r.URL.Query().Get("authors")
+	if len(authorsStr) != 0 {
+		var authorsTmp []string
+		authorsTmp, err = swag.SplitByFormat(authorsStr, ""), error(nil)
 		if err != nil {
 			return nil, err
 		}
-		input.Author = &authorTmp
+		input.Authors = authorsTmp
 
 	}
 	availableStr := r.URL.Query().Get("available")

--- a/models/genmodels.go
+++ b/models/genmodels.go
@@ -81,12 +81,9 @@ func printInputStruct(g *swagger.Generator, op *spec.Operation) error {
 		var typeName string
 		var err error
 		if param.In != "body" {
-			typeName, err = swagger.ParamToType(param)
+			typeName, err = swagger.ParamToType(param, true)
 			if err != nil {
 				return err
-			}
-			if !param.Required {
-				typeName = "*" + typeName
 			}
 		} else {
 			typeName, err = TypeFromSchema(param.Schema)

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -161,7 +161,7 @@ func printNewInput(g *swagger.Generator, op *spec.Operation) error {
 
 			g.Printf("\tif len(%sStr) != 0 {\n", param.Name)
 
-			typeName, err := swagger.ParamToType(param)
+			typeName, err := swagger.ParamToType(param, false)
 			if err != nil {
 				return err
 			}
@@ -175,7 +175,8 @@ func printNewInput(g *swagger.Generator, op *spec.Operation) error {
 			g.Printf("\t\t\treturn nil, err\n")
 			g.Printf("\t\t}\n")
 
-			if param.Required {
+			// TODO: Factor this out...
+			if param.Required || param.Type == "array" {
 				g.Printf("\t\tinput.%s = %sTmp\n\n", capParamName, param.Name)
 			} else {
 				g.Printf("\t\tinput.%s = &%sTmp\n\n", capParamName, param.Name)

--- a/swagger.yml
+++ b/swagger.yml
@@ -73,9 +73,14 @@ paths:
       operationId: getBooks
       description: Returns a list of books
       parameters:
-        - name: author
+        - name: authors
           in: query
-          type: string
+          type: array
+          items:
+            type: string
+          maxItems: 2
+          minItems: 1
+          uniqueItems: true
         - name: available
           in: query
           type: boolean

--- a/swagger/parameter.go
+++ b/swagger/parameter.go
@@ -19,12 +19,40 @@ import (
 // 3. String -> Go type
 // 4. Validation logic
 
+// TODO: Add a nice comment on this...
+func BaseParamToStringCode() string {
+	return `
+// JoinByFormat joins a string array by a known format:
+//		ssv: space separated value
+//		tsv: tab separated value
+//		pipes: pipe (|) separated value
+//		csv: comma separated value (default)
+func JoinByFormat(data []string, format string) string {
+	if len(data) == 0 {
+		return ""
+	}
+	var sep string
+	switch format {
+	case "ssv":
+		sep = " "
+	case "tsv":
+		sep = "\t"
+	case "pipes":
+		sep = "|"
+	default:
+		sep = ","
+	}
+	return strings.Join(data, sep)
+}
+`
+}
+
 // ParamToStringCode returns a function that converts a Parameter into the code to convert
 // it into a string (for serialization). For example, a integer named 'Size' becomes
 // `strconv.FormatInt(i.Size, 10)`
 func ParamToStringCode(param spec.Parameter) string {
 	valToSet := fmt.Sprintf("i.%s", Capitalize(param.Name))
-	if !param.Required {
+	if !param.Required && param.Type != "array" {
 		valToSet = "*" + valToSet
 	}
 	switch param.Type {
@@ -53,14 +81,20 @@ func ParamToStringCode(param spec.Parameter) string {
 		return fmt.Sprintf("strconv.FormatFloat(%s, 'E', -1, 64)", valToSet)
 	case "boolean":
 		return fmt.Sprintf("strconv.FormatBool(%s)", valToSet)
+	case "array":
+		if param.Items.Type != "string" {
+			panic(fmt.Errorf("Array parameters must have string sub-types"))
+		}
+		return fmt.Sprintf("JoinByFormat(%s, \"%s\")", valToSet, param.Format)
 	default:
 		// Theoretically should have validated before getting here
 		panic(fmt.Errorf("Unsupported parameter type %s", param.Type))
 	}
 }
 
-// ParamToType converts a parameter into its Go type
-func ParamToType(param spec.Parameter) (string, error) {
+// ParamToType converts a parameter into its Go type. If withPointer is true
+// it will make the variable a pointer if it's not required and not an array type
+func ParamToType(param spec.Parameter, withPointer bool) (string, error) {
 	var typeName string
 	switch param.Type {
 	case "string":
@@ -90,10 +124,18 @@ func ParamToType(param spec.Parameter) (string, error) {
 		} else {
 			typeName = "float64"
 		}
+	case "array":
+		if param.Items.Type != "string" {
+			return "", fmt.Errorf("Array parameters must have string sub-types")
+		}
+		typeName = "[]string"
 	default:
 		// Note. We don't support 'array' or 'file' types even though they're in the
 		// Swagger spec.
 		return "", fmt.Errorf("Unsupported param type")
+	}
+	if withPointer && !param.Required && param.Type != "array" {
+		typeName = "*" + typeName
 	}
 	return typeName, nil
 }
@@ -164,6 +206,11 @@ func StringToTypeCode(strField string, param spec.Parameter) (string, error) {
 		default:
 			return "", fmt.Errorf("Param format %s not supported", param.Format)
 		}
+	case "array":
+		if param.Items.Type != "string" {
+			return "", fmt.Errorf("Array parameters must have string sub-types")
+		}
+		return fmt.Sprintf("swag.SplitByFormat(%s, \"%s\"), error(nil)", strField, param.Format), nil
 	default:
 		return "", fmt.Errorf("Param type %s not supported", param.Type)
 	}
@@ -224,6 +271,19 @@ func ParamToValidationCode(param spec.Parameter) ([]string, error) {
 			validations = append(validations, fmt.Sprintf("validate.MultipleOf(\"%s\", \"%s\", float64(%s), %f)",
 				param.Name, param.In, accessString(param), *param.MultipleOf))
 		}
+	} else if param.Type == "array" {
+		if param.MaxItems != nil {
+			validations = append(validations, fmt.Sprintf("validate.MaxItems(\"%s\", \"%s\", int64(len(%s)), %d)",
+				param.Name, param.In, accessString(param), *param.MaxItems))
+		}
+		if param.MinItems != nil {
+			validations = append(validations, fmt.Sprintf("validate.MinItems(\"%s\", \"%s\", int64(len(%s)), %d)",
+				param.Name, param.In, accessString(param), *param.MinItems))
+		}
+		if param.UniqueItems {
+			validations = append(validations, fmt.Sprintf("validate.UniqueItems(\"%s\", \"%s\", %s)",
+				param.Name, param.In, accessString(param)))
+		}
 	}
 	return validations, nil
 }
@@ -232,7 +292,7 @@ func ParamToValidationCode(param spec.Parameter) ([]string, error) {
 // *i.Length
 func accessString(param spec.Parameter) string {
 	pointer := ""
-	if !param.Required {
+	if !param.Required && param.Type != "array" {
 		pointer = "*"
 	}
 	return fmt.Sprintf("%si.%s", pointer, Capitalize(param.Name))


### PR DESCRIPTION
Adds support for string arrays as input parameters. There are a couple limitations that I'm punting on for a bit so we can unblock timeline.

1. It doesn't escape characters correctly. For example if a parameter has a comma in it, it will treat that as two input parameters. This is a problem with go-swagger and will require us changing what they have a bit
2. It only supports strings. At some point we may want to support arbitrary fields, but supporting things like nested arrays is a bit tricker, so I put it off.