### PR TITLE
Use raw model type if only one success response type

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,9 @@ c := client.New("https://url_of_your_service:port")
 
 Make an API call
 ```
-output, err := c.GetBookByID(ctx, GetBookByIDInput{ID: 1234})
+books, err := c.GetBooks(ctx, GetBookByIDInput{Authors: []string{"Twain"}})
 if err != nil {
   // Do something with the error
-}
-book, ok := output.(models.GetBookByID200Output)
-if !ok {
-  // The only success value this returns is a 200, so anything else would be unexpected
 }
 ```
 

--- a/generated/client/client.go
+++ b/generated/client/client.go
@@ -60,7 +60,7 @@ func JoinByFormat(data []string, format string) string {
 	}
 	return strings.Join(data, sep)
 }
-func (c Client) GetBooks(ctx context.Context, i *models.GetBooksInput) (*[]models.Book, error) {
+func (c Client) GetBooks(ctx context.Context, i *models.GetBooksInput) ([]models.Book, error) {
 	path := c.BasePath + "/v1/books"
 	urlVals := url.Values{}
 	var body []byte
@@ -111,7 +111,7 @@ func (c Client) GetBooks(ctx context.Context, i *models.GetBooksInput) (*[]model
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
-		return &output, nil
+		return output, nil
 
 	case 400:
 		var output models.DefaultBadRequest
@@ -170,7 +170,7 @@ func (c Client) GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (mo
 		return &output, nil
 	case 204:
 		var output models.GetBookByID204Output
-		return &output, nil
+		return output, nil
 	case 401:
 		var output models.GetBookByID401Output
 		return nil, output

--- a/generated/client/client.go
+++ b/generated/client/client.go
@@ -60,7 +60,7 @@ func JoinByFormat(data []string, format string) string {
 	}
 	return strings.Join(data, sep)
 }
-func (c Client) GetBooks(ctx context.Context, i *models.GetBooksInput) (models.GetBooksOutput, error) {
+func (c Client) GetBooks(ctx context.Context, i *models.GetBooksInput) (*[]models.Book, error) {
 	path := c.BasePath + "/v1/books"
 	urlVals := url.Values{}
 	var body []byte
@@ -94,6 +94,7 @@ func (c Client) GetBooks(ctx context.Context, i *models.GetBooksInput) (models.G
 	client := &http.Client{Transport: c.transport}
 	req, err := http.NewRequest("GET", path, bytes.NewBuffer(body))
 	if err != nil {
+
 		return nil, err
 	}
 
@@ -106,11 +107,11 @@ func (c Client) GetBooks(ctx context.Context, i *models.GetBooksInput) (models.G
 	switch resp.StatusCode {
 	case 200:
 
-		var output models.GetBooks200Output
+		var output []models.Book
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
-		return output, nil
+		return &output, nil
 
 	case 400:
 		var output models.DefaultBadRequest
@@ -146,6 +147,7 @@ func (c Client) GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (mo
 	client := &http.Client{Transport: c.transport}
 	req, err := http.NewRequest("GET", path, bytes.NewBuffer(body))
 	if err != nil {
+
 		return nil, err
 	}
 	if i.Authorization != nil {
@@ -165,10 +167,10 @@ func (c Client) GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (mo
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
-		return output, nil
+		return &output, nil
 	case 204:
 		var output models.GetBookByID204Output
-		return output, nil
+		return &output, nil
 	case 401:
 		var output models.GetBookByID401Output
 		return nil, output
@@ -195,7 +197,7 @@ func (c Client) GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (mo
 	}
 }
 
-func (c Client) CreateBook(ctx context.Context, i *models.CreateBookInput) (models.CreateBookOutput, error) {
+func (c Client) CreateBook(ctx context.Context, i *models.CreateBookInput) (*models.Book, error) {
 	path := c.BasePath + "/v1/books/{bookID}"
 	urlVals := url.Values{}
 	var body []byte
@@ -214,6 +216,7 @@ func (c Client) CreateBook(ctx context.Context, i *models.CreateBookInput) (mode
 	client := &http.Client{Transport: c.transport}
 	req, err := http.NewRequest("POST", path, bytes.NewBuffer(body))
 	if err != nil {
+
 		return nil, err
 	}
 
@@ -226,11 +229,11 @@ func (c Client) CreateBook(ctx context.Context, i *models.CreateBookInput) (mode
 	switch resp.StatusCode {
 	case 200:
 
-		var output models.CreateBook200Output
+		var output models.Book
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
-		return output, nil
+		return &output, nil
 
 	case 400:
 		var output models.DefaultBadRequest

--- a/generated/models/outputs.go
+++ b/generated/models/outputs.go
@@ -24,25 +24,15 @@ type GetBooksError interface {
 
 type GetBookByIDOutput interface {
 	GetBookByIDStatus() int
-	// Data is the underlying model object. We know it is json serializable
-	GetBookByIDData() interface{}
 }
 
 type GetBookByID200Output Book
-
-func (o GetBookByID200Output) GetBookByIDData() interface{} {
-	return o
-}
 
 func (o GetBookByID200Output) GetBookByIDStatus() int {
 	return 200
 }
 
 type GetBookByID204Output string
-
-func (o GetBookByID204Output) GetBookByIDData() interface{} {
-	return o
-}
 
 func (o GetBookByID204Output) GetBookByIDStatus() int {
 	return 204

--- a/generated/models/outputs.go
+++ b/generated/models/outputs.go
@@ -17,36 +17,15 @@ func (d DefaultBadRequest) Error() string {
 	return d.Msg
 }
 
-type GetBooksOutput interface {
-	GetBooksStatus() int
-	// Data is the underlying model object. We know it is json serializable
-	GetBooksData() interface{}
-}
-
 type GetBooksError interface {
 	error // Extend the error interface
 	GetBooksStatusCode() int
-}
-
-type GetBooks200Output []Book
-
-func (o GetBooks200Output) GetBooksData() interface{} {
-	return o
-}
-
-func (o GetBooks200Output) GetBooksStatus() int {
-	return 200
 }
 
 type GetBookByIDOutput interface {
 	GetBookByIDStatus() int
 	// Data is the underlying model object. We know it is json serializable
 	GetBookByIDData() interface{}
-}
-
-type GetBookByIDError interface {
-	error // Extend the error interface
-	GetBookByIDStatusCode() int
 }
 
 type GetBookByID200Output Book
@@ -67,6 +46,11 @@ func (o GetBookByID204Output) GetBookByIDData() interface{} {
 
 func (o GetBookByID204Output) GetBookByIDStatus() int {
 	return 204
+}
+
+type GetBookByIDError interface {
+	error // Extend the error interface
+	GetBookByIDStatusCode() int
 }
 
 type GetBookByID401Output string
@@ -101,23 +85,7 @@ func (o GetBookByID404Output) GetBookByIDStatusCode() int {
 	return 404
 }
 
-type CreateBookOutput interface {
-	CreateBookStatus() int
-	// Data is the underlying model object. We know it is json serializable
-	CreateBookData() interface{}
-}
-
 type CreateBookError interface {
 	error // Extend the error interface
 	CreateBookStatusCode() int
-}
-
-type CreateBook200Output Book
-
-func (o CreateBook200Output) CreateBookData() interface{} {
-	return o
-}
-
-func (o CreateBook200Output) CreateBookStatus() int {
-	return 200
 }

--- a/generated/server/handlers.go
+++ b/generated/server/handlers.go
@@ -219,7 +219,7 @@ func (h handler) GetBookByIDHandler(ctx context.Context, w http.ResponseWriter, 
 		}
 	}
 
-	respBytes, err := json.Marshal(resp.GetBookByIDData())
+	respBytes, err := json.Marshal(resp)
 	if err != nil {
 		http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
 		return

--- a/generated/server/handlers.go
+++ b/generated/server/handlers.go
@@ -80,7 +80,7 @@ func (h handler) GetBooksHandler(ctx context.Context, w http.ResponseWriter, r *
 		}
 	}
 
-	respBytes, err := json.Marshal(resp.GetBooksData())
+	respBytes, err := json.Marshal(resp)
 	if err != nil {
 		http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
 		return
@@ -295,7 +295,7 @@ func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r
 		}
 	}
 
-	respBytes, err := json.Marshal(resp.CreateBookData())
+	respBytes, err := json.Marshal(resp)
 	if err != nil {
 		http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
 		return

--- a/generated/server/interface.go
+++ b/generated/server/interface.go
@@ -8,7 +8,7 @@ import (
 //go:generate $GOPATH/bin/mockgen -source=$GOFILE -destination=mock_controller.go -package=server
 
 type Controller interface {
-	GetBooks(ctx context.Context, i *models.GetBooksInput) (*[]models.Book, error)
+	GetBooks(ctx context.Context, i *models.GetBooksInput) ([]models.Book, error)
 	GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (models.GetBookByIDOutput, error)
 	CreateBook(ctx context.Context, i *models.CreateBookInput) (*models.Book, error)
 }

--- a/generated/server/interface.go
+++ b/generated/server/interface.go
@@ -8,7 +8,7 @@ import (
 //go:generate $GOPATH/bin/mockgen -source=$GOFILE -destination=mock_controller.go -package=server
 
 type Controller interface {
-	GetBooks(ctx context.Context, input *models.GetBooksInput) (models.GetBooksOutput, error)
-	GetBookByID(ctx context.Context, input *models.GetBookByIDInput) (models.GetBookByIDOutput, error)
-	CreateBook(ctx context.Context, input *models.CreateBookInput) (models.CreateBookOutput, error)
+	GetBooks(ctx context.Context, i *models.GetBooksInput) (*[]models.Book, error)
+	GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (models.GetBookByIDOutput, error)
+	CreateBook(ctx context.Context, i *models.CreateBookInput) (*models.Book, error)
 }

--- a/generated/server/mock_controller.go
+++ b/generated/server/mock_controller.go
@@ -30,9 +30,9 @@ func (_m *MockController) EXPECT() *_MockControllerRecorder {
 	return _m.recorder
 }
 
-func (_m *MockController) GetBooks(ctx context.Context, input *models.GetBooksInput) (models.GetBooksOutput, error) {
-	ret := _m.ctrl.Call(_m, "GetBooks", ctx, input)
-	ret0, _ := ret[0].(models.GetBooksOutput)
+func (_m *MockController) GetBooks(ctx context.Context, i *models.GetBooksInput) (*[]models.Book, error) {
+	ret := _m.ctrl.Call(_m, "GetBooks", ctx, i)
+	ret0, _ := ret[0].(*[]models.Book)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -41,8 +41,8 @@ func (_mr *_MockControllerRecorder) GetBooks(arg0, arg1 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetBooks", arg0, arg1)
 }
 
-func (_m *MockController) GetBookByID(ctx context.Context, input *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
-	ret := _m.ctrl.Call(_m, "GetBookByID", ctx, input)
+func (_m *MockController) GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
+	ret := _m.ctrl.Call(_m, "GetBookByID", ctx, i)
 	ret0, _ := ret[0].(models.GetBookByIDOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -52,9 +52,9 @@ func (_mr *_MockControllerRecorder) GetBookByID(arg0, arg1 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetBookByID", arg0, arg1)
 }
 
-func (_m *MockController) CreateBook(ctx context.Context, input *models.CreateBookInput) (models.CreateBookOutput, error) {
-	ret := _m.ctrl.Call(_m, "CreateBook", ctx, input)
-	ret0, _ := ret[0].(models.CreateBookOutput)
+func (_m *MockController) CreateBook(ctx context.Context, i *models.CreateBookInput) (*models.Book, error) {
+	ret := _m.ctrl.Call(_m, "CreateBook", ctx, i)
+	ret0, _ := ret[0].(*models.Book)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/generated/server/mock_controller.go
+++ b/generated/server/mock_controller.go
@@ -30,9 +30,9 @@ func (_m *MockController) EXPECT() *_MockControllerRecorder {
 	return _m.recorder
 }
 
-func (_m *MockController) GetBooks(ctx context.Context, i *models.GetBooksInput) (*[]models.Book, error) {
+func (_m *MockController) GetBooks(ctx context.Context, i *models.GetBooksInput) ([]models.Book, error) {
 	ret := _m.ctrl.Call(_m, "GetBooks", ctx, i)
-	ret0, _ := ret[0].(*[]models.Book)
+	ret0, _ := ret[0].([]models.Book)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/models/genmodels.go
+++ b/models/genmodels.go
@@ -199,8 +199,6 @@ func generateSuccessTypes(capOpID string, responses map[int]spec.Response) (stri
 	var buf bytes.Buffer
 	buf.WriteString(fmt.Sprintf("type %sOutput interface {\n", capOpID))
 	buf.WriteString(fmt.Sprintf("\t%sStatus() int\n", capOpID))
-	buf.WriteString(fmt.Sprintf("\t// Data is the underlying model object. We know it is json serializable\n"))
-	buf.WriteString(fmt.Sprintf("\t%sData() interface{}\n", capOpID))
 	buf.WriteString(fmt.Sprintf("}\n\n"))
 
 	successStatusCodes := make([]int, 0)
@@ -225,10 +223,6 @@ func generateSuccessTypes(capOpID string, responses map[int]spec.Response) (stri
 			return "", err
 		}
 		buf.WriteString(fmt.Sprintf("type %s %s\n\n", outputName, typeName))
-		buf.WriteString(fmt.Sprintf("func (o %s) %sData() interface{} {\n", outputName, capOpID))
-		buf.WriteString(fmt.Sprintf("\treturn o\n"))
-		buf.WriteString(fmt.Sprintf("}\n\n"))
-
 		buf.WriteString(fmt.Sprintf("func (o %s) %sStatus() int {\n", outputName, capOpID))
 		buf.WriteString(fmt.Sprintf("\treturn %d\n", statusCode))
 		buf.WriteString(fmt.Sprintf("}\n\n"))

--- a/models/genmodels.go
+++ b/models/genmodels.go
@@ -229,9 +229,7 @@ func generateSuccessTypes(capOpID string, responses map[int]spec.Response) (stri
 		buf.WriteString(fmt.Sprintf("\treturn o\n"))
 		buf.WriteString(fmt.Sprintf("}\n\n"))
 
-		// TODO: Do we really want to have that as part of the interface?
 		buf.WriteString(fmt.Sprintf("func (o %s) %sStatus() int {\n", outputName, capOpID))
-		// TODO: Use the right status code...
 		buf.WriteString(fmt.Sprintf("\treturn %d\n", statusCode))
 		buf.WriteString(fmt.Sprintf("}\n\n"))
 	}

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -245,14 +245,7 @@ func generateHandlers(packageName string, paths *spec.Paths) error {
 				return err
 			}
 			var tmpBuf bytes.Buffer
-			marshalFunction := ""
-			if swagger.SingleSuccessOutputType(op) != nil {
-				marshalFunction = "resp"
-			} else {
-				marshalFunction = fmt.Sprintf("resp.%sData()", swagger.Capitalize(op.ID))
-			}
-			err = tmpl.Execute(&tmpBuf,
-				handlerOp{Op: swagger.Capitalize(op.ID), MarshalFunction: marshalFunction})
+			err = tmpl.Execute(&tmpBuf, handlerOp{Op: swagger.Capitalize(op.ID)})
 			if err != nil {
 				return err
 			}
@@ -268,8 +261,7 @@ func generateHandlers(packageName string, paths *spec.Paths) error {
 }
 
 type handlerOp struct {
-	Op              string
-	MarshalFunction string
+	Op string
 }
 
 var jsonMarshalString = `
@@ -307,7 +299,7 @@ var handlerTemplate = `func (h handler) {{.Op}}Handler(ctx context.Context, w ht
 		}
 	}
 
-	respBytes, err := json.Marshal({{.MarshalFunction}})
+	respBytes, err := json.Marshal(resp)
 	if err != nil {
 		http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
 		return

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/go-openapi/spec"
 
-	"github.com/Clever/wag/models"
 	"github.com/Clever/wag/swagger"
 
 	"text/template"
@@ -115,11 +114,7 @@ func generateInterface(packageName string, paths *spec.Paths) error {
 		path := paths.Paths[pathKey]
 		pathItemOps := swagger.PathItemOperations(path)
 		for _, opKey := range swagger.SortedOperationsKeys(pathItemOps) {
-			op := pathItemOps[opKey]
-			capOpID := swagger.Capitalize(op.ID)
-			definition := fmt.Sprintf("%s(ctx context.Context, input *models.%sInput) (models.%sOutput, error)",
-				capOpID, capOpID, capOpID)
-			g.Printf("\t%s\n", definition)
+			g.Printf("\t%s\n", swagger.Interface(pathItemOps[opKey]))
 		}
 	}
 	g.Printf("}\n")
@@ -191,7 +186,7 @@ func printNewInput(g *swagger.Generator, op *spec.Operation) error {
 			if param.Schema == nil {
 				return fmt.Errorf("Body parameters must have a schema defined")
 			}
-			typeName, err := models.TypeFromSchema(param.Schema)
+			typeName, err := swagger.TypeFromSchema(param.Schema, true)
 			if err != nil {
 				return err
 			}
@@ -206,7 +201,7 @@ func printNewInput(g *swagger.Generator, op *spec.Operation) error {
 
 			g.Printf("\tif len(data) > 0 {")
 			// Initialize the pointer in the object
-			g.Printf("\t\tinput.%s = &models.%s{}\n", capParamName, typeName)
+			g.Printf("\t\tinput.%s = &%s{}\n", capParamName, typeName)
 			g.Printf("\t\tif err := json.NewDecoder(bytes.NewReader(data)).Decode(input.%s); err != nil {\n", capParamName)
 			g.Printf("\t\t\treturn nil, err\n")
 			g.Printf("\t\t}\n")
@@ -250,7 +245,14 @@ func generateHandlers(packageName string, paths *spec.Paths) error {
 				return err
 			}
 			var tmpBuf bytes.Buffer
-			err = tmpl.Execute(&tmpBuf, handlerOp{Op: swagger.Capitalize(op.ID)})
+			marshalFunction := ""
+			if swagger.SingleSuccessOutputType(op) != nil {
+				marshalFunction = "resp"
+			} else {
+				marshalFunction = fmt.Sprintf("resp.%sData()", swagger.Capitalize(op.ID))
+			}
+			err = tmpl.Execute(&tmpBuf,
+				handlerOp{Op: swagger.Capitalize(op.ID), MarshalFunction: marshalFunction})
 			if err != nil {
 				return err
 			}
@@ -266,7 +268,8 @@ func generateHandlers(packageName string, paths *spec.Paths) error {
 }
 
 type handlerOp struct {
-	Op string
+	Op              string
+	MarshalFunction string
 }
 
 var jsonMarshalString = `
@@ -304,7 +307,7 @@ var handlerTemplate = `func (h handler) {{.Op}}Handler(ctx context.Context, w ht
 		}
 	}
 
-	respBytes, err := json.Marshal(resp.{{.Op}}Data())
+	respBytes, err := json.Marshal({{.MarshalFunction}})
 	if err != nil {
 		http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
 		return

--- a/swagger/operation.go
+++ b/swagger/operation.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-openapi/spec"
 )
 
-// TOOD: Add a nice comment!!!
+// Interface returns the interface for an operation
 func Interface(op *spec.Operation) string {
 	successCodes := make([]int, 0)
 	for statusCode, _ := range op.Responses.StatusCodeResponses {
@@ -29,7 +29,7 @@ func Interface(op *spec.Operation) string {
 		capOpID, capOpID, successType)
 }
 
-// TODO: Add a nice comment!
+// OutputType returns the output type for a given status code of an operation
 func OutputType(op *spec.Operation, statusCode int) string {
 	singleSuccessType := singleSuccessOutputType(op)
 	if singleSuccessType != nil && statusCode < 400 {
@@ -38,7 +38,8 @@ func OutputType(op *spec.Operation, statusCode int) string {
 	return fmt.Sprintf("models.%s%dOutput", Capitalize(op.ID), statusCode)
 }
 
-// TODO: Nice comment. Returns non-nil if only one success output
+// singleSuccessOutputType returns nil if there is more than one success output type for an
+// operation. If there is only one, then it returns its name as a string pointer.
 func singleSuccessOutputType(op *spec.Operation) *string {
 	successCodes := make([]int, 0)
 	for statusCode, _ := range op.Responses.StatusCodeResponses {
@@ -60,6 +61,8 @@ func singleSuccessOutputType(op *spec.Operation) *string {
 	}
 }
 
+// TypeFromSchema returns the type of a Swagger schema as a string. If includeModels is true
+// then it returns models.TYPE
 func TypeFromSchema(schema *spec.Schema, includeModels bool) (string, error) {
 	// We support three types of schemas
 	// 1. An empty schema, which we represent by an empty string by default

--- a/swagger/operation.go
+++ b/swagger/operation.go
@@ -17,7 +17,7 @@ func Interface(op *spec.Operation) string {
 	}
 
 	capOpID := Capitalize(op.ID)
-	singleType := SingleSuccessOutputType(op)
+	singleType := singleSuccessOutputType(op)
 	successType := ""
 	if singleType != nil {
 		successType = "*" + *singleType
@@ -31,7 +31,7 @@ func Interface(op *spec.Operation) string {
 
 // TODO: Add a nice comment!
 func OutputType(op *spec.Operation, statusCode int) string {
-	singleSuccessType := SingleSuccessOutputType(op)
+	singleSuccessType := singleSuccessOutputType(op)
 	if singleSuccessType != nil && statusCode < 400 {
 		return *singleSuccessType
 	}
@@ -39,7 +39,7 @@ func OutputType(op *spec.Operation, statusCode int) string {
 }
 
 // TODO: Nice comment. Returns non-nil if only one success output
-func SingleSuccessOutputType(op *spec.Operation) *string {
+func singleSuccessOutputType(op *spec.Operation) *string {
 	successCodes := make([]int, 0)
 	for statusCode, _ := range op.Responses.StatusCodeResponses {
 		if statusCode < 400 {

--- a/swagger/operation.go
+++ b/swagger/operation.go
@@ -1,0 +1,100 @@
+package swagger
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-openapi/spec"
+)
+
+// TOOD: Add a nice comment!!!
+func Interface(op *spec.Operation) string {
+	successCodes := make([]int, 0)
+	for statusCode, _ := range op.Responses.StatusCodeResponses {
+		if statusCode < 400 {
+			successCodes = append(successCodes, statusCode)
+		}
+	}
+
+	capOpID := Capitalize(op.ID)
+	singleType := SingleSuccessOutputType(op)
+	successType := ""
+	if singleType != nil {
+		successType = "*" + *singleType
+	} else {
+		successType = fmt.Sprintf("models.%sOutput", capOpID)
+	}
+
+	return fmt.Sprintf("%s(ctx context.Context, i *models.%sInput) (%s, error)",
+		capOpID, capOpID, successType)
+}
+
+// TODO: Add a nice comment!
+func OutputType(op *spec.Operation, statusCode int) string {
+	singleSuccessType := SingleSuccessOutputType(op)
+	if singleSuccessType != nil && statusCode < 400 {
+		return *singleSuccessType
+	}
+	return fmt.Sprintf("models.%s%dOutput", Capitalize(op.ID), statusCode)
+}
+
+// TODO: Nice comment. Returns non-nil if only one success output
+func SingleSuccessOutputType(op *spec.Operation) *string {
+	successCodes := make([]int, 0)
+	for statusCode, _ := range op.Responses.StatusCodeResponses {
+		if statusCode < 400 {
+			successCodes = append(successCodes, statusCode)
+		}
+	}
+
+	successType := ""
+	if len(successCodes) == 1 {
+		var err error
+		successType, err = TypeFromSchema(op.Responses.StatusCodeResponses[successCodes[0]].Schema, true)
+		if err != nil {
+			panic(fmt.Errorf("Could not convert operation to type %s", err))
+		}
+		return &successType
+	} else {
+		return nil
+	}
+}
+
+func TypeFromSchema(schema *spec.Schema, includeModels bool) (string, error) {
+	// We support three types of schemas
+	// 1. An empty schema, which we represent by an empty string by default
+	// 2. A schema with one element, the $ref key
+	// 3. A schema with two elements. One a type with value 'array' and another items field
+	// referencing the $ref
+	if schema == nil {
+		return "string", nil
+	} else if schema.Ref.String() != "" {
+		ref := schema.Ref.String()
+		if !strings.HasPrefix(ref, "#/definitions/") {
+			return "", fmt.Errorf("schema.$ref has undefined reference type. Must start with #/definitions")
+		}
+		def := ref[len("#/definitions/"):]
+		if includeModels {
+			def = "models." + def
+		}
+		return def, nil
+	} else {
+		schemaType := schema.Type
+		if len(schemaType) != 1 || schemaType[0] != "array" {
+			return "", fmt.Errorf("Two element schemas must have a 'type' field with the value 'array'")
+		}
+		items := schema.Items
+		if items == nil || items.Schema == nil {
+			return "", fmt.Errorf("Two element schemas must have a '$ref' field in the 'items' descriptions")
+		}
+		ref := items.Schema.Ref.String()
+		if !strings.HasPrefix(ref, "#/definitions/") {
+			return "", fmt.Errorf("schema.$ref has undefined reference type. Must start with #/definitions")
+		}
+		def := ref[len("#/definitions/"):]
+		if includeModels {
+			def = "models." + def
+		}
+		return "[]" + def, nil
+	}
+}

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -20,22 +20,22 @@ type ClientContextTest struct {
 	postCount int
 }
 
-func (c *ClientContextTest) GetBooks(ctx context.Context, input *models.GetBooksInput) (models.GetBooksOutput, error) {
+func (c *ClientContextTest) GetBooks(ctx context.Context, input *models.GetBooksInput) (*[]models.Book, error) {
 	c.getCount++
 	if c.getCount == 1 {
 		return nil, fmt.Errorf("Error count: %d", c.getCount)
 	}
-	return &models.GetBooks200Output{}, nil
+	return &[]models.Book{}, nil
 }
 func (c *ClientContextTest) GetBookByID(ctx context.Context, input *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
 	return nil, nil
 }
-func (c *ClientContextTest) CreateBook(ctx context.Context, input *models.CreateBookInput) (models.CreateBookOutput, error) {
+func (c *ClientContextTest) CreateBook(ctx context.Context, input *models.CreateBookInput) (*models.Book, error) {
 	c.postCount++
 	if c.postCount == 1 {
 		return nil, fmt.Errorf("Error count: %d", c.postCount)
 	}
-	return &models.CreateBook200Output{}, nil
+	return &models.Book{}, nil
 }
 
 func TestDefaultClientRetries(t *testing.T) {

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -20,12 +20,12 @@ type ClientContextTest struct {
 	postCount int
 }
 
-func (c *ClientContextTest) GetBooks(ctx context.Context, input *models.GetBooksInput) (*[]models.Book, error) {
+func (c *ClientContextTest) GetBooks(ctx context.Context, input *models.GetBooksInput) ([]models.Book, error) {
 	c.getCount++
 	if c.getCount == 1 {
 		return nil, fmt.Errorf("Error count: %d", c.getCount)
 	}
-	return &[]models.Book{}, nil
+	return []models.Book{}, nil
 }
 func (c *ClientContextTest) GetBookByID(ctx context.Context, input *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
 	return nil, nil

--- a/test/sample_server.go
+++ b/test/sample_server.go
@@ -12,12 +12,12 @@ type ControllerImpl struct {
 	books map[int64]*models.Book
 }
 
-func (c *ControllerImpl) GetBooks(ctx context.Context, input *models.GetBooksInput) (models.GetBooksOutput, error) {
+func (c *ControllerImpl) GetBooks(ctx context.Context, input *models.GetBooksInput) (*[]models.Book, error) {
 	bookList := make([]models.Book, 0)
 	for _, book := range c.books {
 		bookList = append(bookList, *book)
 	}
-	return models.GetBooks200Output(bookList), nil
+	return &bookList, nil
 }
 func (c *ControllerImpl) GetBookByID(ctx context.Context, input *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
 	book, ok := c.books[input.BookID]
@@ -26,9 +26,9 @@ func (c *ControllerImpl) GetBookByID(ctx context.Context, input *models.GetBookB
 	}
 	return models.GetBookByID200Output(*book), nil
 }
-func (c *ControllerImpl) CreateBook(ctx context.Context, input *models.CreateBookInput) (models.CreateBookOutput, error) {
+func (c *ControllerImpl) CreateBook(ctx context.Context, input *models.CreateBookInput) (*models.Book, error) {
 	c.books[input.NewBook.ID] = input.NewBook
-	return models.CreateBook200Output(*input.NewBook), nil
+	return input.NewBook, nil
 }
 
 func setupServer() *httptest.Server {

--- a/test/sample_server.go
+++ b/test/sample_server.go
@@ -12,12 +12,12 @@ type ControllerImpl struct {
 	books map[int64]*models.Book
 }
 
-func (c *ControllerImpl) GetBooks(ctx context.Context, input *models.GetBooksInput) (*[]models.Book, error) {
+func (c *ControllerImpl) GetBooks(ctx context.Context, input *models.GetBooksInput) ([]models.Book, error) {
 	bookList := make([]models.Book, 0)
 	for _, book := range c.books {
 		bookList = append(bookList, *book)
 	}
-	return &bookList, nil
+	return bookList, nil
 }
 func (c *ControllerImpl) GetBookByID(ctx context.Context, input *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
 	book, ok := c.books[input.BookID]

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -24,25 +24,20 @@ func TestBasicEndToEnd(t *testing.T) {
 	bookID := int64(124)
 	bookName := "Test"
 
-	createOutput, err := c.CreateBook(
+	createdBook, err := c.CreateBook(
 		context.Background(), &models.CreateBookInput{NewBook: &models.Book{ID: bookID, Name: bookName}})
 	assert.NoError(t, err)
-	createdBook, ok := createOutput.(models.CreateBook200Output)
-	require.True(t, ok)
 	assert.Equal(t, bookID, createdBook.ID)
 	assert.Equal(t, bookName, createdBook.Name)
 
 	booksOutput, err := c.GetBooks(context.Background(), &models.GetBooksInput{})
-	assert.NoError(t, err)
-	getBooks, ok := booksOutput.(models.GetBooks200Output)
-	require.True(t, ok)
-	require.Equal(t, 1, len(getBooks))
-	assert.Equal(t, bookID, getBooks[0].ID)
-	assert.Equal(t, bookName, getBooks[0].Name)
+	require.Equal(t, 1, len(*booksOutput))
+	assert.Equal(t, bookID, (*booksOutput)[0].ID)
+	assert.Equal(t, bookName, (*booksOutput)[0].Name)
 
 	singleBookOutput, err := c.GetBookByID(context.Background(), &models.GetBookByIDInput{BookID: bookID})
 	assert.NoError(t, err)
-	singleBook, ok := singleBookOutput.(models.GetBookByID200Output)
+	singleBook, ok := singleBookOutput.(*models.GetBookByID200Output)
 	require.True(t, ok)
 	assert.Equal(t, bookID, singleBook.ID)
 	assert.Equal(t, bookName, singleBook.Name)
@@ -88,18 +83,18 @@ type LastCallServer struct {
 	lastAuthors   []string
 }
 
-func (d *LastCallServer) GetBooks(ctx context.Context, input *models.GetBooksInput) (models.GetBooksOutput, error) {
+func (d *LastCallServer) GetBooks(ctx context.Context, input *models.GetBooksInput) (*[]models.Book, error) {
 	d.lastState = *input.State
 	d.lastAvailable = *input.Available
 	d.lastMaxPages = *input.MaxPages
 	d.lastMinPages = *input.MinPages
 	d.lastAuthors = input.Authors
-	return &models.GetBooks200Output{}, nil
+	return &[]models.Book{}, nil
 }
 func (d *LastCallServer) GetBookByID(ctx context.Context, input *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
 	return nil, nil
 }
-func (d *LastCallServer) CreateBook(ctx context.Context, input *models.CreateBookInput) (models.CreateBookOutput, error) {
+func (d *LastCallServer) CreateBook(ctx context.Context, input *models.CreateBookInput) (*models.Book, error) {
 	return nil, nil
 }
 
@@ -135,14 +130,14 @@ type MiddlewareContextTest struct {
 	foundKey string
 }
 
-func (m *MiddlewareContextTest) GetBooks(ctx context.Context, input *models.GetBooksInput) (models.GetBooksOutput, error) {
+func (m *MiddlewareContextTest) GetBooks(ctx context.Context, input *models.GetBooksInput) (*[]models.Book, error) {
 	m.foundKey = ctx.Value(testContextKey{}).(string)
-	return &models.GetBooks200Output{}, nil
+	return &[]models.Book{}, nil
 }
 func (m *MiddlewareContextTest) GetBookByID(ctx context.Context, input *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
 	return nil, nil
 }
-func (m *MiddlewareContextTest) CreateBook(ctx context.Context, input *models.CreateBookInput) (models.CreateBookOutput, error) {
+func (m *MiddlewareContextTest) CreateBook(ctx context.Context, input *models.CreateBookInput) (*models.Book, error) {
 	return nil, nil
 }
 

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -31,9 +31,9 @@ func TestBasicEndToEnd(t *testing.T) {
 	assert.Equal(t, bookName, createdBook.Name)
 
 	booksOutput, err := c.GetBooks(context.Background(), &models.GetBooksInput{})
-	require.Equal(t, 1, len(*booksOutput))
-	assert.Equal(t, bookID, (*booksOutput)[0].ID)
-	assert.Equal(t, bookName, (*booksOutput)[0].Name)
+	require.Equal(t, 1, len(booksOutput))
+	assert.Equal(t, bookID, (booksOutput)[0].ID)
+	assert.Equal(t, bookName, (booksOutput)[0].Name)
 
 	singleBookOutput, err := c.GetBookByID(context.Background(), &models.GetBookByIDInput{BookID: bookID})
 	assert.NoError(t, err)
@@ -83,13 +83,13 @@ type LastCallServer struct {
 	lastAuthors   []string
 }
 
-func (d *LastCallServer) GetBooks(ctx context.Context, input *models.GetBooksInput) (*[]models.Book, error) {
+func (d *LastCallServer) GetBooks(ctx context.Context, input *models.GetBooksInput) ([]models.Book, error) {
 	d.lastState = *input.State
 	d.lastAvailable = *input.Available
 	d.lastMaxPages = *input.MaxPages
 	d.lastMinPages = *input.MinPages
 	d.lastAuthors = input.Authors
-	return &[]models.Book{}, nil
+	return []models.Book{}, nil
 }
 func (d *LastCallServer) GetBookByID(ctx context.Context, input *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
 	return nil, nil
@@ -130,9 +130,9 @@ type MiddlewareContextTest struct {
 	foundKey string
 }
 
-func (m *MiddlewareContextTest) GetBooks(ctx context.Context, input *models.GetBooksInput) (*[]models.Book, error) {
+func (m *MiddlewareContextTest) GetBooks(ctx context.Context, input *models.GetBooksInput) ([]models.Book, error) {
 	m.foundKey = ctx.Value(testContextKey{}).(string)
-	return &[]models.Book{}, nil
+	return []models.Book{}, nil
 }
 func (m *MiddlewareContextTest) GetBookByID(ctx context.Context, input *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
 	return nil, nil


### PR DESCRIPTION
This change makes it so that an operation's interface uses the raw type if there's only one success response type. This makes the code easier to deal with (see both the sample server and client code).

To do that I separated out the code common to the interface and types into a separate package. Then I changed that code to be smart about when to use the raw type and when to add an interface. I also changed the gen models code to not generate the interface types when they weren't necessary.