### PR TITLE
Support no return types

### DIFF
--- a/generated/client/client.go
+++ b/generated/client/client.go
@@ -93,17 +93,19 @@ func (c Client) GetBooks(ctx context.Context, i *models.GetBooksInput) ([]models
 
 	client := &http.Client{Transport: c.transport}
 	req, err := http.NewRequest("GET", path, bytes.NewBuffer(body))
-	if err != nil {
 
+	if err != nil {
 		return nil, err
 	}
 
 	// Add the opname for doers like tracing
 	ctx = context.WithValue(ctx, opNameCtx{}, "getBooks")
 	resp, err := c.requestDoer.Do(client, req.WithContext(ctx))
+
 	if err != nil {
 		return nil, models.DefaultInternalError{Msg: err.Error()}
 	}
+
 	switch resp.StatusCode {
 	case 200:
 
@@ -129,7 +131,6 @@ func (c Client) GetBooks(ctx context.Context, i *models.GetBooksInput) ([]models
 
 	default:
 		return nil, models.DefaultInternalError{Msg: "Unknown response"}
-
 	}
 }
 
@@ -146,10 +147,11 @@ func (c Client) GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (mo
 
 	client := &http.Client{Transport: c.transport}
 	req, err := http.NewRequest("GET", path, bytes.NewBuffer(body))
-	if err != nil {
 
+	if err != nil {
 		return nil, err
 	}
+
 	if i.Authorization != nil {
 		req.Header.Set("authorization", *i.Authorization)
 	}
@@ -157,9 +159,11 @@ func (c Client) GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (mo
 	// Add the opname for doers like tracing
 	ctx = context.WithValue(ctx, opNameCtx{}, "getBookByID")
 	resp, err := c.requestDoer.Do(client, req.WithContext(ctx))
+
 	if err != nil {
 		return nil, models.DefaultInternalError{Msg: err.Error()}
 	}
+
 	switch resp.StatusCode {
 	case 200:
 
@@ -193,7 +197,6 @@ func (c Client) GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (mo
 
 	default:
 		return nil, models.DefaultInternalError{Msg: "Unknown response"}
-
 	}
 }
 
@@ -208,24 +211,28 @@ func (c Client) CreateBook(ctx context.Context, i *models.CreateBookInput) (*mod
 
 		var err error
 		body, err = json.Marshal(i.NewBook)
+
 		if err != nil {
 			return nil, err
 		}
+
 	}
 
 	client := &http.Client{Transport: c.transport}
 	req, err := http.NewRequest("POST", path, bytes.NewBuffer(body))
-	if err != nil {
 
+	if err != nil {
 		return nil, err
 	}
 
 	// Add the opname for doers like tracing
 	ctx = context.WithValue(ctx, opNameCtx{}, "createBook")
 	resp, err := c.requestDoer.Do(client, req.WithContext(ctx))
+
 	if err != nil {
 		return nil, models.DefaultInternalError{Msg: err.Error()}
 	}
+
 	switch resp.StatusCode {
 	case 200:
 
@@ -251,7 +258,6 @@ func (c Client) CreateBook(ctx context.Context, i *models.CreateBookInput) (*mod
 
 	default:
 		return nil, models.DefaultInternalError{Msg: "Unknown response"}
-
 	}
 }
 
@@ -264,17 +270,19 @@ func (c Client) HealthCheck(ctx context.Context, i *models.HealthCheckInput) err
 
 	client := &http.Client{Transport: c.transport}
 	req, err := http.NewRequest("GET", path, bytes.NewBuffer(body))
-	if err != nil {
 
-		return nil, err
+	if err != nil {
+		return err
 	}
 
 	// Add the opname for doers like tracing
 	ctx = context.WithValue(ctx, opNameCtx{}, "healthCheck")
 	resp, err := c.requestDoer.Do(client, req.WithContext(ctx))
+
 	if err != nil {
-		return nil, models.DefaultInternalError{Msg: err.Error()}
+		return models.DefaultInternalError{Msg: err.Error()}
 	}
+
 	switch resp.StatusCode {
 	case 200:
 		return nil
@@ -282,19 +290,18 @@ func (c Client) HealthCheck(ctx context.Context, i *models.HealthCheckInput) err
 	case 400:
 		var output models.DefaultBadRequest
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
-			return nil, models.DefaultInternalError{Msg: err.Error()}
+			return models.DefaultInternalError{Msg: err.Error()}
 		}
-		return nil, output
+		return output
 
 	case 500:
 		var output models.DefaultInternalError
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
-			return nil, models.DefaultInternalError{Msg: err.Error()}
+			return models.DefaultInternalError{Msg: err.Error()}
 		}
-		return nil, output
+		return output
 
 	default:
-		return nil, models.DefaultInternalError{Msg: "Unknown response"}
-
+		return models.DefaultInternalError{Msg: "Unknown response"}
 	}
 }

--- a/generated/models/inputs.go
+++ b/generated/models/inputs.go
@@ -123,3 +123,10 @@ func (i CreateBookInput) Validate() error {
 
 	return nil
 }
+
+type HealthCheckInput struct {
+}
+
+func (i HealthCheckInput) Validate() error {
+	return nil
+}

--- a/generated/models/outputs.go
+++ b/generated/models/outputs.go
@@ -79,3 +79,8 @@ type CreateBookError interface {
 	error // Extend the error interface
 	CreateBookStatusCode() int
 }
+
+type HealthCheckError interface {
+	error // Extend the error interface
+	HealthCheckStatusCode() int
+}

--- a/generated/server/handlers.go
+++ b/generated/server/handlers.go
@@ -70,6 +70,7 @@ func (h handler) GetBooksHandler(ctx context.Context, w http.ResponseWriter, r *
 	}
 
 	resp, err := h.GetBooks(ctx, input)
+
 	if err != nil {
 		if respErr, ok := err.(models.GetBooksError); ok {
 			http.Error(w, respErr.Error(), respErr.GetBooksStatusCode())
@@ -88,6 +89,7 @@ func (h handler) GetBooksHandler(ctx context.Context, w http.ResponseWriter, r *
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(respBytes)
+
 }
 func NewGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 	var input models.GetBooksInput
@@ -209,6 +211,7 @@ func (h handler) GetBookByIDHandler(ctx context.Context, w http.ResponseWriter, 
 	}
 
 	resp, err := h.GetBookByID(ctx, input)
+
 	if err != nil {
 		if respErr, ok := err.(models.GetBookByIDError); ok {
 			http.Error(w, respErr.Error(), respErr.GetBookByIDStatusCode())
@@ -227,6 +230,7 @@ func (h handler) GetBookByIDHandler(ctx context.Context, w http.ResponseWriter, 
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(respBytes)
+
 }
 func NewGetBookByIDInput(r *http.Request) (*models.GetBookByIDInput, error) {
 	var input models.GetBookByIDInput
@@ -285,6 +289,7 @@ func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r
 	}
 
 	resp, err := h.CreateBook(ctx, input)
+
 	if err != nil {
 		if respErr, ok := err.(models.CreateBookError); ok {
 			http.Error(w, respErr.Error(), respErr.CreateBookStatusCode())
@@ -303,6 +308,7 @@ func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(respBytes)
+
 }
 func NewCreateBookInput(r *http.Request) (*models.CreateBookInput, error) {
 	var input models.CreateBookInput
@@ -334,7 +340,8 @@ func (h handler) HealthCheckHandler(ctx context.Context, w http.ResponseWriter, 
 		return
 	}
 
-	resp, err := h.HealthCheck(ctx, input)
+	err = h.HealthCheck(ctx, input)
+
 	if err != nil {
 		if respErr, ok := err.(models.HealthCheckError); ok {
 			http.Error(w, respErr.Error(), respErr.HealthCheckStatusCode())
@@ -345,14 +352,8 @@ func (h handler) HealthCheckHandler(ctx context.Context, w http.ResponseWriter, 
 		}
 	}
 
-	respBytes, err := json.Marshal(resp)
-	if err != nil {
-		http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
-		return
-	}
+	w.Write([]byte(""))
 
-	w.Header().Set("Content-Type", "application/json")
-	w.Write(respBytes)
 }
 func NewHealthCheckInput(r *http.Request) (*models.HealthCheckInput, error) {
 	var input models.HealthCheckInput

--- a/generated/server/interface.go
+++ b/generated/server/interface.go
@@ -11,4 +11,5 @@ type Controller interface {
 	GetBooks(ctx context.Context, i *models.GetBooksInput) ([]models.Book, error)
 	GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (models.GetBookByIDOutput, error)
 	CreateBook(ctx context.Context, i *models.CreateBookInput) (*models.Book, error)
+	HealthCheck(ctx context.Context, i *models.HealthCheckInput) error
 }

--- a/generated/server/mock_controller.go
+++ b/generated/server/mock_controller.go
@@ -62,3 +62,13 @@ func (_m *MockController) CreateBook(ctx context.Context, i *models.CreateBookIn
 func (_mr *_MockControllerRecorder) CreateBook(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateBook", arg0, arg1)
 }
+
+func (_m *MockController) HealthCheck(ctx context.Context, i *models.HealthCheckInput) error {
+	ret := _m.ctrl.Call(_m, "HealthCheck", ctx, i)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockControllerRecorder) HealthCheck(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "HealthCheck", arg0, arg1)
+}

--- a/generated/server/router.go
+++ b/generated/server/router.go
@@ -42,6 +42,10 @@ func New(c Controller, addr string) Server {
 	r.Methods("POST").Path("/v1/books/{bookID}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h.CreateBookHandler(r.Context(), w, r)
 	})
+
+	r.Methods("GET").Path("/v1/health/check").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		h.HealthCheckHandler(r.Context(), w, r)
+	})
 	handler := withMiddleware("Swagger Test", r)
 	return Server{Handler: handler, addr: addr}
 }

--- a/swagger.yml
+++ b/swagger.yml
@@ -11,6 +11,15 @@ produces:
 consumes:
   - application/json
 paths:
+  /health/check:
+    get:
+      operationId: healthCheck
+      description: Checks if the service is healthy
+      tags:
+        - Infra
+      responses:
+        200:
+          description: OK response
   /books/{bookID}:
     get:
       operationId: getBookByID

--- a/swagger/operation.go
+++ b/swagger/operation.go
@@ -71,7 +71,8 @@ func singleSuccessOutputType(op *spec.Operation) *spec.Schema {
 	}
 }
 
-// TODO: Add a nice comment!!!
+// NoSuccessType returns true if the operation has no-success response type. This includes
+// either no 200-399 response code or a 200-399 response code without a schema.
 func NoSuccessType(op *spec.Operation) bool {
 	successCodes := make([]int, 0)
 	for statusCode, _ := range op.Responses.StatusCodeResponses {

--- a/swagger/operation.go
+++ b/swagger/operation.go
@@ -17,6 +17,10 @@ func Interface(op *spec.Operation) string {
 	}
 
 	capOpID := Capitalize(op.ID)
+	if NoSuccessType(op) {
+		return fmt.Sprintf("%s(ctx context.Context, i *models.%sInput) error", capOpID, capOpID)
+	}
+
 	singleSchema := singleSuccessOutputType(op)
 	successType := ""
 	if singleSchema != nil {
@@ -65,6 +69,23 @@ func singleSuccessOutputType(op *spec.Operation) *spec.Schema {
 	} else {
 		return nil
 	}
+}
+
+// TODO: Add a nice comment!!!
+func NoSuccessType(op *spec.Operation) bool {
+	successCodes := make([]int, 0)
+	for statusCode, _ := range op.Responses.StatusCodeResponses {
+		if statusCode < 400 {
+			successCodes = append(successCodes, statusCode)
+		}
+	}
+	if len(successCodes) > 1 {
+		return false
+	}
+	if len(successCodes) == 0 {
+		return true
+	}
+	return op.Responses.StatusCodeResponses[successCodes[0]].Schema == nil
 }
 
 // TypeFromSchema returns the type of a Swagger schema as a string. If includeModels is true

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -35,6 +35,10 @@ func (c *ClientContextTest) CreateBook(ctx context.Context, input *models.Create
 	return &models.Book{}, nil
 }
 
+func (c *ClientContextTest) HealthCheck(ctx context.Context, input *models.HealthCheckInput) error {
+	return nil
+}
+
 func TestDefaultClientRetries(t *testing.T) {
 	controller := ClientContextTest{}
 	s := server.New(&controller, ":8080")

--- a/test/sample_server.go
+++ b/test/sample_server.go
@@ -30,6 +30,9 @@ func (c *ControllerImpl) CreateBook(ctx context.Context, input *models.CreateBoo
 	c.books[input.NewBook.ID] = input.NewBook
 	return input.NewBook, nil
 }
+func (c *ControllerImpl) HealthCheck(ctx context.Context, input *models.HealthCheckInput) error {
+	return nil
+}
 
 func setupServer() *httptest.Server {
 	controller := ControllerImpl{books: make(map[int64]*models.Book)}

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -96,6 +96,9 @@ func (d *LastCallServer) GetBookByID(ctx context.Context, input *models.GetBookB
 func (d *LastCallServer) CreateBook(ctx context.Context, input *models.CreateBookInput) (*models.Book, error) {
 	return nil, nil
 }
+func (c *LastCallServer) HealthCheck(ctx context.Context, input *models.HealthCheckInput) error {
+	return nil
+}
 
 func TestDefaultValue(t *testing.T) {
 	d := LastCallServer{}
@@ -138,6 +141,9 @@ func (m *MiddlewareContextTest) GetBookByID(ctx context.Context, input *models.G
 }
 func (m *MiddlewareContextTest) CreateBook(ctx context.Context, input *models.CreateBookInput) (*models.Book, error) {
 	return nil, nil
+}
+func (m *MiddlewareContextTest) HealthCheck(ctx context.Context, input *models.HealthCheckInput) error {
+	return nil
 }
 
 type testContextKey struct{}


### PR DESCRIPTION
Before we would convert a single, empty response into a string type. This was a bit confusing for implementers, so we decided that if you didn't have any response type it should be left out of the interface.

This made the generation code a bit more complicated, but I think it's probably worth it given that a decent number of endpoints won't have a return type associated with them (health checks and potentially posts).

I want to clean up the templating a bit in the client library since the code is a bit harder to follow than i would like, but I will do that in a follow up change.