### PR TITLE
Write correct status code

### DIFF
--- a/generated/models/outputs.go
+++ b/generated/models/outputs.go
@@ -32,7 +32,7 @@ func (o GetBookByID200Output) GetBookByIDStatus() int {
 	return 200
 }
 
-type GetBookByID204Output string
+type GetBookByID204Output struct{}
 
 func (o GetBookByID204Output) GetBookByIDStatus() int {
 	return 204
@@ -43,7 +43,7 @@ type GetBookByIDError interface {
 	GetBookByIDStatusCode() int
 }
 
-type GetBookByID401Output string
+type GetBookByID401Output struct{}
 
 func (o GetBookByID401Output) GetBookByIDData() interface{} {
 	return o

--- a/generated/server/handlers.go
+++ b/generated/server/handlers.go
@@ -82,13 +82,14 @@ func (h handler) GetBooksHandler(ctx context.Context, w http.ResponseWriter, r *
 		}
 	}
 
+	w.WriteHeader(200)
+
 	respBytes, err := json.Marshal(resp)
 	if err != nil {
 		http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
 		return
 	}
 
-	w.WriteHeader(200)
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(respBytes)
 
@@ -224,13 +225,14 @@ func (h handler) GetBookByIDHandler(ctx context.Context, w http.ResponseWriter, 
 		}
 	}
 
+	w.WriteHeader(resp.GetBookByIDStatus())
+
 	respBytes, err := json.Marshal(resp)
 	if err != nil {
 		http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
 		return
 	}
 
-	w.WriteHeader(resp.GetBookByIDStatus())
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(respBytes)
 
@@ -303,13 +305,14 @@ func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r
 		}
 	}
 
+	w.WriteHeader(200)
+
 	respBytes, err := json.Marshal(resp)
 	if err != nil {
 		http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
 		return
 	}
 
-	w.WriteHeader(200)
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(respBytes)
 
@@ -357,6 +360,7 @@ func (h handler) HealthCheckHandler(ctx context.Context, w http.ResponseWriter, 
 	}
 
 	w.WriteHeader(200)
+
 	w.Write([]byte(""))
 
 }

--- a/generated/server/handlers.go
+++ b/generated/server/handlers.go
@@ -88,6 +88,7 @@ func (h handler) GetBooksHandler(ctx context.Context, w http.ResponseWriter, r *
 		return
 	}
 
+	w.WriteHeader(200)
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(respBytes)
 
@@ -229,6 +230,7 @@ func (h handler) GetBookByIDHandler(ctx context.Context, w http.ResponseWriter, 
 		return
 	}
 
+	w.WriteHeader(resp.GetBookByIDStatus())
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(respBytes)
 
@@ -307,6 +309,7 @@ func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r
 		return
 	}
 
+	w.WriteHeader(200)
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(respBytes)
 
@@ -353,6 +356,7 @@ func (h handler) HealthCheckHandler(ctx context.Context, w http.ResponseWriter, 
 		}
 	}
 
+	w.WriteHeader(200)
 	w.Write([]byte(""))
 
 }

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -320,6 +320,7 @@ var handlerTemplate = `func (h handler) {{.Op}}Handler(ctx context.Context, w ht
 		}
 	}
 
+	w.WriteHeader({{.StatusCode}})
 {{if .SuccessReturnType}}
 	respBytes, err := json.Marshal(resp)
 	if err != nil {
@@ -327,11 +328,9 @@ var handlerTemplate = `func (h handler) {{.Op}}Handler(ctx context.Context, w ht
 		return
 	}
 
-	w.WriteHeader({{.StatusCode}})
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(respBytes)
 {{else}}
-	w.WriteHeader(200)
 	w.Write([]byte(""))
 {{end}}
 }

--- a/swagger/operation.go
+++ b/swagger/operation.go
@@ -16,8 +16,9 @@ func Interface(op *spec.Operation) string {
 
 	successCodes := SuccessStatusCodes(op)
 	successType := ""
-	singleSchema := op.Responses.StatusCodeResponses[successCodes[0]].Schema
-	if singleSchema != nil {
+
+	if len(successCodes) == 1 {
+		singleSchema := op.Responses.StatusCodeResponses[successCodes[0]].Schema
 		var err error
 		successType, err = TypeFromSchema(singleSchema, true)
 		if err != nil {
@@ -76,12 +77,12 @@ func NoSuccessType(op *spec.Operation) bool {
 // then it returns models.TYPE
 func TypeFromSchema(schema *spec.Schema, includeModels bool) (string, error) {
 	// We support three types of schemas
-	// 1. An empty schema, which we represent by an empty string by default
+	// 1. An empty schema, which we represent by the empty struct
 	// 2. A schema with one element, the $ref key
 	// 3. A schema with two elements. One a type with value 'array' and another items field
 	// referencing the $ref
 	if schema == nil {
-		return "string", nil
+		return "struct{}", nil
 	} else if schema.Ref.String() != "" {
 		ref := schema.Ref.String()
 		if !strings.HasPrefix(ref, "#/definitions/") {

--- a/test/sample_server.go
+++ b/test/sample_server.go
@@ -24,7 +24,12 @@ func (c *ControllerImpl) GetBookByID(ctx context.Context, input *models.GetBookB
 	if !ok {
 		return nil, models.GetBookByID404Output{}
 	}
-	return models.GetBookByID200Output(*book), nil
+	if input.BookID%4 == 0 {
+		return models.GetBookByID200Output(*book), nil
+	} else {
+		return models.GetBookByID204Output{}, nil
+	}
+
 }
 func (c *ControllerImpl) CreateBook(ctx context.Context, input *models.CreateBookInput) (*models.Book, error) {
 	c.books[input.NewBook.ID] = input.NewBook

--- a/test/sample_server.go
+++ b/test/sample_server.go
@@ -24,10 +24,10 @@ func (c *ControllerImpl) GetBookByID(ctx context.Context, input *models.GetBookB
 	if !ok {
 		return nil, models.GetBookByID404Output{}
 	}
-	if input.BookID%4 == 0 {
-		return models.GetBookByID200Output(*book), nil
-	} else {
+	if input.BookID%4 == 2 {
 		return models.GetBookByID204Output{}, nil
+	} else {
+		return models.GetBookByID200Output(*book), nil
 	}
 
 }

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -40,6 +40,20 @@ func TestBasicEndToEnd(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, bookID, singleBook.ID)
 	assert.Equal(t, bookName, singleBook.Name)
+
+	// If we have a bookID == 2mod4 then it returns a 204
+	otherBookID := int64(126)
+
+	createdBook, err = c.CreateBook(
+		context.Background(), &models.CreateBookInput{NewBook: &models.Book{ID: otherBookID, Name: bookName}})
+	assert.NoError(t, err)
+	assert.Equal(t, otherBookID, createdBook.ID)
+	assert.Equal(t, bookName, createdBook.Name)
+
+	singleBookOutput, err = c.GetBookByID(context.Background(), &models.GetBookByIDInput{BookID: otherBookID})
+	assert.NoError(t, err)
+	_, ok = singleBookOutput.(models.GetBookByID204Output)
+	require.True(t, ok)
 }
 
 func TestUserDefinedErrorResponse(t *testing.T) {


### PR DESCRIPTION
Before this change we were writing a 200 for all success responses. This changes this to actually return the right values.

Along the way I also changed the empty response from `string` to `struct{}` since I thought that made the code a bit clearer.