### PR TITLE
Camel case params

### DIFF
--- a/client/genclients.go
+++ b/client/genclients.go
@@ -111,7 +111,7 @@ func buildRequestCode(op *spec.Operation, method string) string {
 			if param.Required {
 				buf.WriteString(fmt.Sprintf(queryAddCode))
 			} else {
-				buf.WriteString(fmt.Sprintf("\tif i.%s != nil {\n", swagger.SnakeToCamelCase(param.Name)))
+				buf.WriteString(fmt.Sprintf("\tif i.%s != nil {\n", swagger.StructParamName(param)))
 				buf.WriteString(fmt.Sprintf(queryAddCode))
 				buf.WriteString(fmt.Sprintf("\t}\n"))
 			}
@@ -126,11 +126,11 @@ func buildRequestCode(op *spec.Operation, method string) string {
 	var err error
 	body, err = json.Marshal(i.%s)
 	%s
-`, swagger.SnakeToCamelCase(param.Name), errorMessage("err", op))
+`, swagger.StructParamName(param), errorMessage("err", op))
 			if param.Required {
 				buf.WriteString(fmt.Sprintf(bodyMarshalCode))
 			} else {
-				buf.WriteString(fmt.Sprintf("\tif i.%s != nil {\n", swagger.SnakeToCamelCase(param.Name)))
+				buf.WriteString(fmt.Sprintf("\tif i.%s != nil {\n", swagger.StructParamName(param)))
 				buf.WriteString(fmt.Sprintf(bodyMarshalCode))
 				buf.WriteString(fmt.Sprintf("\t}\n"))
 			}
@@ -151,7 +151,7 @@ func buildRequestCode(op *spec.Operation, method string) string {
 			if param.Required {
 				buf.WriteString(fmt.Sprintf(headerAddCode))
 			} else {
-				buf.WriteString(fmt.Sprintf("\tif i.%s != nil {\n", swagger.SnakeToCamelCase(param.Name)))
+				buf.WriteString(fmt.Sprintf("\tif i.%s != nil {\n", swagger.StructParamName(param)))
 				buf.WriteString(fmt.Sprintf(headerAddCode))
 				buf.WriteString(fmt.Sprintf("\t}\n"))
 			}

--- a/client/genclients.go
+++ b/client/genclients.go
@@ -111,7 +111,7 @@ func buildRequestCode(op *spec.Operation, method string) string {
 			if param.Required {
 				buf.WriteString(fmt.Sprintf(queryAddCode))
 			} else {
-				buf.WriteString(fmt.Sprintf("\tif i.%s != nil {\n", swagger.Capitalize(param.Name)))
+				buf.WriteString(fmt.Sprintf("\tif i.%s != nil {\n", swagger.SnakeToCamelCase(param.Name)))
 				buf.WriteString(fmt.Sprintf(queryAddCode))
 				buf.WriteString(fmt.Sprintf("\t}\n"))
 			}
@@ -126,11 +126,11 @@ func buildRequestCode(op *spec.Operation, method string) string {
 	var err error
 	body, err = json.Marshal(i.%s)
 	%s
-`, swagger.Capitalize(param.Name), errorMessage("err", op))
+`, swagger.SnakeToCamelCase(param.Name), errorMessage("err", op))
 			if param.Required {
 				buf.WriteString(fmt.Sprintf(bodyMarshalCode))
 			} else {
-				buf.WriteString(fmt.Sprintf("\tif i.%s != nil {\n", swagger.Capitalize(param.Name)))
+				buf.WriteString(fmt.Sprintf("\tif i.%s != nil {\n", swagger.SnakeToCamelCase(param.Name)))
 				buf.WriteString(fmt.Sprintf(bodyMarshalCode))
 				buf.WriteString(fmt.Sprintf("\t}\n"))
 			}
@@ -151,7 +151,7 @@ func buildRequestCode(op *spec.Operation, method string) string {
 			if param.Required {
 				buf.WriteString(fmt.Sprintf(headerAddCode))
 			} else {
-				buf.WriteString(fmt.Sprintf("\tif i.%s != nil {\n", swagger.Capitalize(param.Name)))
+				buf.WriteString(fmt.Sprintf("\tif i.%s != nil {\n", swagger.SnakeToCamelCase(param.Name)))
 				buf.WriteString(fmt.Sprintf(headerAddCode))
 				buf.WriteString(fmt.Sprintf("\t}\n"))
 			}

--- a/generated/client/client.go
+++ b/generated/client/client.go
@@ -84,7 +84,7 @@ func (c Client) GetBooks(ctx context.Context, i *models.GetBooksInput) ([]models
 		urlVals.Add("maxPages", strconv.FormatFloat(*i.MaxPages, 'E', -1, 64))
 	}
 	if i.MinPages != nil {
-		urlVals.Add("minPages", strconv.FormatInt(int64(*i.MinPages), 10))
+		urlVals.Add("min_pages", strconv.FormatInt(int64(*i.MinPages), 10))
 	}
 	if i.PagesToTime != nil {
 		urlVals.Add("pagesToTime", strconv.FormatFloat(float64(*i.PagesToTime), 'E', -1, 32))
@@ -135,11 +135,11 @@ func (c Client) GetBooks(ctx context.Context, i *models.GetBooksInput) ([]models
 }
 
 func (c Client) GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
-	path := c.BasePath + "/v1/books/{bookID}"
+	path := c.BasePath + "/v1/books/{book_id}"
 	urlVals := url.Values{}
 	var body []byte
 
-	path = strings.Replace(path, "{bookID}", strconv.FormatInt(i.BookID, 10), -1)
+	path = strings.Replace(path, "{book_id}", strconv.FormatInt(i.BookID, 10), -1)
 	if i.RandomBytes != nil {
 		urlVals.Add("randomBytes", string(*i.RandomBytes))
 	}
@@ -201,7 +201,7 @@ func (c Client) GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (mo
 }
 
 func (c Client) CreateBook(ctx context.Context, i *models.CreateBookInput) (*models.Book, error) {
-	path := c.BasePath + "/v1/books/{bookID}"
+	path := c.BasePath + "/v1/books/{book_id}"
 	urlVals := url.Values{}
 	var body []byte
 

--- a/generated/models/inputs.go
+++ b/generated/models/inputs.go
@@ -80,13 +80,13 @@ type GetBookByIDInput struct {
 }
 
 func (i GetBookByIDInput) Validate() error {
-	if err := validate.MaximumInt("bookID", "path", i.BookID, int64(10000000), false); err != nil {
+	if err := validate.MaximumInt("book_id", "path", i.BookID, int64(10000000), false); err != nil {
 		return err
 	}
-	if err := validate.MinimumInt("bookID", "path", i.BookID, int64(2), false); err != nil {
+	if err := validate.MinimumInt("book_id", "path", i.BookID, int64(2), false); err != nil {
 		return err
 	}
-	if err := validate.MultipleOf("bookID", "path", float64(i.BookID), 2.000000); err != nil {
+	if err := validate.MultipleOf("book_id", "path", float64(i.BookID), 2.000000); err != nil {
 		return err
 	}
 	if i.Authorization != nil {

--- a/generated/server/handlers.go
+++ b/generated/server/handlers.go
@@ -172,18 +172,18 @@ func NewGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 		input.MaxPages = &maxPagesTmp
 
 	}
-	minPagesStr := r.URL.Query().Get("minPages")
-	if len(minPagesStr) == 0 {
+	min_pagesStr := r.URL.Query().Get("min_pages")
+	if len(min_pagesStr) == 0 {
 		// Use the default value
-		minPagesStr = "5"
+		min_pagesStr = "5"
 	}
-	if len(minPagesStr) != 0 {
-		var minPagesTmp int32
-		minPagesTmp, err = swag.ConvertInt32(minPagesStr)
+	if len(min_pagesStr) != 0 {
+		var min_pagesTmp int32
+		min_pagesTmp, err = swag.ConvertInt32(min_pagesStr)
 		if err != nil {
 			return nil, err
 		}
-		input.MinPages = &minPagesTmp
+		input.MinPages = &min_pagesTmp
 
 	}
 	pagesToTimeStr := r.URL.Query().Get("pagesToTime")
@@ -243,17 +243,17 @@ func NewGetBookByIDInput(r *http.Request) (*models.GetBookByIDInput, error) {
 	var err error
 	_ = err
 
-	bookIDStr := mux.Vars(r)["bookID"]
-	if len(bookIDStr) == 0 {
+	book_idStr := mux.Vars(r)["book_id"]
+	if len(book_idStr) == 0 {
 		return nil, errors.New("Parameter must be specified")
 	}
-	if len(bookIDStr) != 0 {
-		var bookIDTmp int64
-		bookIDTmp, err = swag.ConvertInt64(bookIDStr)
+	if len(book_idStr) != 0 {
+		var book_idTmp int64
+		book_idTmp, err = swag.ConvertInt64(book_idStr)
 		if err != nil {
 			return nil, err
 		}
-		input.BookID = bookIDTmp
+		input.BookID = book_idTmp
 
 	}
 	authorizationStr := r.Header.Get("authorization")

--- a/generated/server/handlers.go
+++ b/generated/server/handlers.go
@@ -172,18 +172,18 @@ func NewGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 		input.MaxPages = &maxPagesTmp
 
 	}
-	min_pagesStr := r.URL.Query().Get("min_pages")
-	if len(min_pagesStr) == 0 {
+	minPagesStr := r.URL.Query().Get("min_pages")
+	if len(minPagesStr) == 0 {
 		// Use the default value
-		min_pagesStr = "5"
+		minPagesStr = "5"
 	}
-	if len(min_pagesStr) != 0 {
-		var min_pagesTmp int32
-		min_pagesTmp, err = swag.ConvertInt32(min_pagesStr)
+	if len(minPagesStr) != 0 {
+		var minPagesTmp int32
+		minPagesTmp, err = swag.ConvertInt32(minPagesStr)
 		if err != nil {
 			return nil, err
 		}
-		input.MinPages = &min_pagesTmp
+		input.MinPages = &minPagesTmp
 
 	}
 	pagesToTimeStr := r.URL.Query().Get("pagesToTime")
@@ -243,17 +243,17 @@ func NewGetBookByIDInput(r *http.Request) (*models.GetBookByIDInput, error) {
 	var err error
 	_ = err
 
-	book_idStr := mux.Vars(r)["book_id"]
-	if len(book_idStr) == 0 {
+	bookIDStr := mux.Vars(r)["book_id"]
+	if len(bookIDStr) == 0 {
 		return nil, errors.New("Parameter must be specified")
 	}
-	if len(book_idStr) != 0 {
-		var book_idTmp int64
-		book_idTmp, err = swag.ConvertInt64(book_idStr)
+	if len(bookIDStr) != 0 {
+		var bookIDTmp int64
+		bookIDTmp, err = swag.ConvertInt64(bookIDStr)
 		if err != nil {
 			return nil, err
 		}
-		input.BookID = book_idTmp
+		input.BookID = bookIDTmp
 
 	}
 	authorizationStr := r.Header.Get("authorization")

--- a/generated/server/router.go
+++ b/generated/server/router.go
@@ -35,11 +35,11 @@ func New(c Controller, addr string) Server {
 		h.GetBooksHandler(r.Context(), w, r)
 	})
 
-	r.Methods("GET").Path("/v1/books/{bookID}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods("GET").Path("/v1/books/{book_id}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h.GetBookByIDHandler(r.Context(), w, r)
 	})
 
-	r.Methods("POST").Path("/v1/books/{bookID}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods("POST").Path("/v1/books/{book_id}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h.CreateBookHandler(r.Context(), w, r)
 	})
 

--- a/models/genmodels.go
+++ b/models/genmodels.go
@@ -94,7 +94,7 @@ func printInputStruct(g *swagger.Generator, op *spec.Operation) error {
 			typeName = "*" + typeName
 		}
 
-		g.Printf("\t%s %s\n", swagger.SnakeToCamelCase(param.Name), typeName)
+		g.Printf("\t%s %s\n", swagger.StructParamName(param), typeName)
 	}
 	g.Printf("}\n\n")
 

--- a/models/genmodels.go
+++ b/models/genmodels.go
@@ -94,7 +94,7 @@ func printInputStruct(g *swagger.Generator, op *spec.Operation) error {
 			typeName = "*" + typeName
 		}
 
-		g.Printf("\t%s %s\n", swagger.Capitalize(param.Name), typeName)
+		g.Printf("\t%s %s\n", swagger.SnakeToCamelCase(param.Name), typeName)
 	}
 	g.Printf("}\n\n")
 

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -133,7 +133,7 @@ func printNewInput(g *swagger.Generator, op *spec.Operation) error {
 
 	for _, param := range op.Parameters {
 
-		camelParamName := swagger.SnakeToCamelCase(param.Name)
+		camelParamName := swagger.StructParamName(param)
 		if param.In != "body" {
 			extractCode := ""
 			switch param.In {

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -133,7 +133,7 @@ func printNewInput(g *swagger.Generator, op *spec.Operation) error {
 
 	for _, param := range op.Parameters {
 
-		capParamName := swagger.Capitalize(param.Name)
+		camelParamName := swagger.SnakeToCamelCase(param.Name)
 		if param.In != "body" {
 			extractCode := ""
 			switch param.In {
@@ -175,9 +175,9 @@ func printNewInput(g *swagger.Generator, op *spec.Operation) error {
 
 			// TODO: Factor this out...
 			if param.Required || param.Type == "array" {
-				g.Printf("\t\tinput.%s = %sTmp\n\n", capParamName, param.Name)
+				g.Printf("\t\tinput.%s = %sTmp\n\n", camelParamName, param.Name)
 			} else {
-				g.Printf("\t\tinput.%s = &%sTmp\n\n", capParamName, param.Name)
+				g.Printf("\t\tinput.%s = &%sTmp\n\n", camelParamName, param.Name)
 			}
 
 			g.Printf("\t}\n")
@@ -201,8 +201,8 @@ func printNewInput(g *swagger.Generator, op *spec.Operation) error {
 
 			g.Printf("\tif len(data) > 0 {")
 			// Initialize the pointer in the object
-			g.Printf("\t\tinput.%s = &%s{}\n", capParamName, typeName)
-			g.Printf("\t\tif err := json.NewDecoder(bytes.NewReader(data)).Decode(input.%s); err != nil {\n", capParamName)
+			g.Printf("\t\tinput.%s = &%s{}\n", camelParamName, typeName)
+			g.Printf("\t\tif err := json.NewDecoder(bytes.NewReader(data)).Decode(input.%s); err != nil {\n", camelParamName)
 			g.Printf("\t\t\treturn nil, err\n")
 			g.Printf("\t\t}\n")
 			g.Printf("\t}\n")

--- a/swagger.yml
+++ b/swagger.yml
@@ -20,12 +20,12 @@ paths:
       responses:
         200:
           description: OK response
-  /books/{bookID}:
+  /books/{book_id}:
     get:
       operationId: getBookByID
       description: Returns a book
       parameters:
-        - name: bookID
+        - name: book_id
           in: path
           type: integer
           required: true
@@ -119,7 +119,7 @@ paths:
           minimum: -5
           multipleOf: 0.5
           default: 500.5
-        - name: minPages
+        - name: min_pages
           in: query
           type: integer
           format: int32

--- a/swagger/parameter.go
+++ b/swagger/parameter.go
@@ -51,7 +51,7 @@ func JoinByFormat(data []string, format string) string {
 // it into a string (for serialization). For example, a integer named 'Size' becomes
 // `strconv.FormatInt(i.Size, 10)`
 func ParamToStringCode(param spec.Parameter) string {
-	valToSet := fmt.Sprintf("i.%s", Capitalize(param.Name))
+	valToSet := fmt.Sprintf("i.%s", SnakeToCamelCase(param.Name))
 	if !param.Required && param.Type != "array" {
 		valToSet = "*" + valToSet
 	}
@@ -295,7 +295,8 @@ func accessString(param spec.Parameter) string {
 	if !param.Required && param.Type != "array" {
 		pointer = "*"
 	}
-	return fmt.Sprintf("%si.%s", pointer, Capitalize(param.Name))
+	// TODO: Use this everywhere...
+	return fmt.Sprintf("%si.%s", pointer, SnakeToCamelCase(param.Name))
 }
 
 // DefaultAsString returns the default value as a string. We convert it into a string so it's easier to insert

--- a/swagger/parameter.go
+++ b/swagger/parameter.go
@@ -51,7 +51,7 @@ func JoinByFormat(data []string, format string) string {
 // it into a string (for serialization). For example, a integer named 'Size' becomes
 // `strconv.FormatInt(i.Size, 10)`
 func ParamToStringCode(param spec.Parameter) string {
-	valToSet := fmt.Sprintf("i.%s", SnakeToCamelCase(param.Name))
+	valToSet := fmt.Sprintf("i.%s", StructParamName(param))
 	if !param.Required && param.Type != "array" {
 		valToSet = "*" + valToSet
 	}
@@ -295,8 +295,29 @@ func accessString(param spec.Parameter) string {
 	if !param.Required && param.Type != "array" {
 		pointer = "*"
 	}
-	// TODO: Use this everywhere...
-	return fmt.Sprintf("%si.%s", pointer, SnakeToCamelCase(param.Name))
+	return fmt.Sprintf("%si.%s", pointer, snakeToCamelCase(param.Name))
+}
+
+// snakeToCamelCase converts a string from snake_case into camel case. It leaves
+// non-snake-case strings as is.
+func snakeToCamelCase(input string) string {
+	output := ""
+	parts := strings.Split(input, "_")
+	for _, part := range parts {
+		// Special case ID since it comes up so often and go's best practices are to
+		// make it captial ID
+		if part == "id" {
+			output += "ID"
+		} else {
+			output += Capitalize(part)
+		}
+	}
+	return output
+}
+
+// StructParamName returns the name of the struct as used in the model struct
+func StructParamName(param spec.Parameter) string {
+	return snakeToCamelCase(param.Name)
 }
 
 // DefaultAsString returns the default value as a string. We convert it into a string so it's easier to insert

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -83,23 +83,6 @@ func Capitalize(input string) string {
 	return strings.ToUpper(input[0:1]) + input[1:]
 }
 
-// CapitalCamelCase converts a string from snake_case into camel case. It leaves
-// non-snake-case strings as is.
-func SnakeToCamelCase(input string) string {
-	output := ""
-	parts := strings.Split(input, "_")
-	for _, part := range parts {
-		// Special case ID since it comes up so often and go's best practices are to
-		// make it captial ID
-		if part == "id" {
-			output += "ID"
-		} else {
-			output += Capitalize(part)
-		}
-	}
-	return output
-}
-
 func PathItemOperations(item spec.PathItem) map[string]*spec.Operation {
 	ops := make(map[string]*spec.Operation)
 	if item.Get != nil {

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -83,6 +83,23 @@ func Capitalize(input string) string {
 	return strings.ToUpper(input[0:1]) + input[1:]
 }
 
+// CapitalCamelCase converts a string from snake_case into camel case. It leaves
+// non-snake-case strings as is.
+func SnakeToCamelCase(input string) string {
+	output := ""
+	parts := strings.Split(input, "_")
+	for _, part := range parts {
+		// Special case ID since it comes up so often and go's best practices are to
+		// make it captial ID
+		if part == "id" {
+			output += "ID"
+		} else {
+			output += Capitalize(part)
+		}
+	}
+	return output
+}
+
 func PathItemOperations(item spec.PathItem) map[string]*spec.Operation {
 	ops := make(map[string]*spec.Operation)
 	if item.Get != nil {


### PR DESCRIPTION
This change converts all the input params to camel case because that's idiomatic in Go.

We didn't just force all consumers to use camel case parameter names because that wouldn't necessarily work in all languages, and being able to support snake case variable names makes migrating some services easier.