### PR TITLE
Don't add input parameter argument if not necessary

### DIFF
--- a/generated/client/client.go
+++ b/generated/client/client.go
@@ -261,7 +261,7 @@ func (c Client) CreateBook(ctx context.Context, i *models.CreateBookInput) (*mod
 	}
 }
 
-func (c Client) HealthCheck(ctx context.Context, i *models.HealthCheckInput) error {
+func (c Client) HealthCheck(ctx context.Context) error {
 	path := c.BasePath + "/v1/health/check"
 	urlVals := url.Values{}
 	var body []byte

--- a/generated/server/handlers.go
+++ b/generated/server/handlers.go
@@ -58,6 +58,7 @@ func jsonMarshalNoError(i interface{}) string {
 	return string(bytes)
 }
 func (h handler) GetBooksHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+
 	input, err := NewGetBooksInput(r)
 	if err != nil {
 		http.Error(w, jsonMarshalNoError(models.DefaultBadRequest{Msg: err.Error()}), http.StatusBadRequest)
@@ -201,6 +202,7 @@ func NewGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 }
 
 func (h handler) GetBookByIDHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+
 	input, err := NewGetBookByIDInput(r)
 	if err != nil {
 		http.Error(w, jsonMarshalNoError(models.DefaultBadRequest{Msg: err.Error()}), http.StatusBadRequest)
@@ -281,6 +283,7 @@ func NewGetBookByIDInput(r *http.Request) (*models.GetBookByIDInput, error) {
 }
 
 func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+
 	input, err := NewCreateBookInput(r)
 	if err != nil {
 		http.Error(w, jsonMarshalNoError(models.DefaultBadRequest{Msg: err.Error()}), http.StatusBadRequest)
@@ -335,19 +338,8 @@ func NewCreateBookInput(r *http.Request) (*models.CreateBookInput, error) {
 }
 
 func (h handler) HealthCheckHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	input, err := NewHealthCheckInput(r)
-	if err != nil {
-		http.Error(w, jsonMarshalNoError(models.DefaultBadRequest{Msg: err.Error()}), http.StatusBadRequest)
-		return
-	}
 
-	err = input.Validate()
-	if err != nil {
-		http.Error(w, jsonMarshalNoError(models.DefaultBadRequest{Msg: err.Error()}), http.StatusBadRequest)
-		return
-	}
-
-	err = h.HealthCheck(ctx, input)
+	err := h.HealthCheck(ctx)
 
 	if err != nil {
 		if respErr, ok := err.(models.HealthCheckError); ok {

--- a/generated/server/interface.go
+++ b/generated/server/interface.go
@@ -11,5 +11,5 @@ type Controller interface {
 	GetBooks(ctx context.Context, i *models.GetBooksInput) ([]models.Book, error)
 	GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (models.GetBookByIDOutput, error)
 	CreateBook(ctx context.Context, i *models.CreateBookInput) (*models.Book, error)
-	HealthCheck(ctx context.Context, i *models.HealthCheckInput) error
+	HealthCheck(ctx context.Context) error
 }

--- a/generated/server/mock_controller.go
+++ b/generated/server/mock_controller.go
@@ -63,12 +63,12 @@ func (_mr *_MockControllerRecorder) CreateBook(arg0, arg1 interface{}) *gomock.C
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateBook", arg0, arg1)
 }
 
-func (_m *MockController) HealthCheck(ctx context.Context, i *models.HealthCheckInput) error {
-	ret := _m.ctrl.Call(_m, "HealthCheck", ctx, i)
+func (_m *MockController) HealthCheck(ctx context.Context) error {
+	ret := _m.ctrl.Call(_m, "HealthCheck", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockControllerRecorder) HealthCheck(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "HealthCheck", arg0, arg1)
+func (_mr *_MockControllerRecorder) HealthCheck(arg0 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "HealthCheck", arg0)
 }

--- a/swagger/operation.go
+++ b/swagger/operation.go
@@ -10,8 +10,15 @@ import (
 // Interface returns the interface for an operation
 func Interface(op *spec.Operation) string {
 	capOpID := Capitalize(op.ID)
+
+	// Don't add the input parameter argument unless there are some arguments
+	input := ""
+	if len(op.Parameters) != 0 {
+		input = fmt.Sprintf("i *models.%sInput", capOpID)
+	}
+
 	if NoSuccessType(op) {
-		return fmt.Sprintf("%s(ctx context.Context, i *models.%sInput) error", capOpID, capOpID)
+		return fmt.Sprintf("%s(ctx context.Context, %s) error", capOpID, input)
 	}
 
 	successCodes := SuccessStatusCodes(op)
@@ -32,8 +39,8 @@ func Interface(op *spec.Operation) string {
 		successType = fmt.Sprintf("models.%sOutput", capOpID)
 	}
 
-	return fmt.Sprintf("%s(ctx context.Context, i *models.%sInput) (%s, error)",
-		capOpID, capOpID, successType)
+	return fmt.Sprintf("%s(ctx context.Context, %s) (%s, error)",
+		capOpID, input, successType)
 }
 
 // OutputType returns the output type for a given status code of an operation

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -35,7 +35,7 @@ func (c *ClientContextTest) CreateBook(ctx context.Context, input *models.Create
 	return &models.Book{}, nil
 }
 
-func (c *ClientContextTest) HealthCheck(ctx context.Context, input *models.HealthCheckInput) error {
+func (c *ClientContextTest) HealthCheck(ctx context.Context) error {
 	return nil
 }
 

--- a/test/sample_server.go
+++ b/test/sample_server.go
@@ -35,7 +35,7 @@ func (c *ControllerImpl) CreateBook(ctx context.Context, input *models.CreateBoo
 	c.books[input.NewBook.ID] = input.NewBook
 	return input.NewBook, nil
 }
-func (c *ControllerImpl) HealthCheck(ctx context.Context, input *models.HealthCheckInput) error {
+func (c *ControllerImpl) HealthCheck(ctx context.Context) error {
 	return nil
 }
 

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -110,7 +110,7 @@ func (d *LastCallServer) GetBookByID(ctx context.Context, input *models.GetBookB
 func (d *LastCallServer) CreateBook(ctx context.Context, input *models.CreateBookInput) (*models.Book, error) {
 	return nil, nil
 }
-func (c *LastCallServer) HealthCheck(ctx context.Context, input *models.HealthCheckInput) error {
+func (c *LastCallServer) HealthCheck(ctx context.Context) error {
 	return nil
 }
 
@@ -156,7 +156,7 @@ func (m *MiddlewareContextTest) GetBookByID(ctx context.Context, input *models.G
 func (m *MiddlewareContextTest) CreateBook(ctx context.Context, input *models.CreateBookInput) (*models.Book, error) {
 	return nil, nil
 }
-func (m *MiddlewareContextTest) HealthCheck(ctx context.Context, input *models.HealthCheckInput) error {
+func (m *MiddlewareContextTest) HealthCheck(ctx context.Context) error {
 	return nil
 }
 


### PR DESCRIPTION
If we don't need the input parameter argument don't add it to the
interface. It makes both the client and server implementations of these
methods a bit simpler, though methods with no arguments are fairly
unlikely from a client perspective as they usually come up in health
checks. It makes the codegen logic a bit trickier.

Not sure if it's worth it.