### PR TITLE
Call WriteHeader after changing headers

### DIFF
--- a/generated/server/handlers.go
+++ b/generated/server/handlers.go
@@ -83,8 +83,6 @@ func (h handler) GetBooksHandler(ctx context.Context, w http.ResponseWriter, r *
 		}
 	}
 
-	w.WriteHeader(200)
-
 	respBytes, err := json.Marshal(resp)
 	if err != nil {
 		http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
@@ -92,6 +90,7 @@ func (h handler) GetBooksHandler(ctx context.Context, w http.ResponseWriter, r *
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
 	w.Write(respBytes)
 
 }
@@ -237,8 +236,6 @@ func (h handler) GetBookByIDHandler(ctx context.Context, w http.ResponseWriter, 
 		}
 	}
 
-	w.WriteHeader(resp.GetBookByIDStatus())
-
 	respBytes, err := json.Marshal(resp)
 	if err != nil {
 		http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
@@ -246,6 +243,7 @@ func (h handler) GetBookByIDHandler(ctx context.Context, w http.ResponseWriter, 
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.GetBookByIDStatus())
 	w.Write(respBytes)
 
 }
@@ -318,8 +316,6 @@ func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r
 		}
 	}
 
-	w.WriteHeader(200)
-
 	respBytes, err := json.Marshal(resp)
 	if err != nil {
 		http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
@@ -327,6 +323,7 @@ func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
 	w.Write(respBytes)
 
 }
@@ -362,7 +359,6 @@ func (h handler) HealthCheckHandler(ctx context.Context, w http.ResponseWriter, 
 	}
 
 	w.WriteHeader(200)
-
 	w.Write([]byte(""))
 
 }

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -336,7 +336,6 @@ var handlerTemplate = `func (h handler) {{.Op}}Handler(ctx context.Context, w ht
 		}
 	}
 
-	w.WriteHeader({{.StatusCode}})
 {{if .SuccessReturnType}}
 	respBytes, err := json.Marshal(resp)
 	if err != nil {
@@ -345,8 +344,10 @@ var handlerTemplate = `func (h handler) {{.Op}}Handler(ctx context.Context, w ht
 	}
 
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader({{.StatusCode}})
 	w.Write(respBytes)
 {{else}}
+	w.WriteHeader({{.StatusCode}})
 	w.Write([]byte(""))
 {{end}}
 }


### PR DESCRIPTION
According to the docs: "Changing the header after a call to
WriteHeader (or Write) has no effect unless the modified headers
were declared as trailers"

So let's do it in the other order.

Will add some tests tomorrow