### PR TITLE
simplify interface for single-input operations

### DIFF
--- a/gen-go/client/client.go
+++ b/gen-go/client/client.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/Clever/wag/gen-go/models"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
+
+	"github.com/Clever/wag/gen-go/models"
 )
 
 var _ = json.Marshal
@@ -213,17 +214,17 @@ func (c Client) GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (mo
 
 // CreateBook makes a POST request to /books/{book_id}.
 // Creates a book
-func (c Client) CreateBook(ctx context.Context, i *models.CreateBookInput) (*models.Book, error) {
+func (c Client) CreateBook(ctx context.Context, i *models.Book) (*models.Book, error) {
 	path := c.basePath + "/v1/books/{book_id}"
 	urlVals := url.Values{}
 	var body []byte
 
 	path = path + "?" + urlVals.Encode()
 
-	if i.NewBook != nil {
+	if i != nil {
 
 		var err error
-		body, err = json.Marshal(i.NewBook)
+		body, err = json.Marshal(i)
 
 		if err != nil {
 			return nil, err

--- a/gen-go/models/inputs.go
+++ b/gen-go/models/inputs.go
@@ -2,9 +2,10 @@ package models
 
 import (
 	"encoding/json"
+	"strconv"
+
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/validate"
-	"strconv"
 )
 
 // These imports may not be used depending on the input parameters
@@ -121,21 +122,6 @@ func (i GetBookByIDInput) Validate() error {
 			return err
 		}
 	}
-	return nil
-}
-
-// CreateBookInput holds the input parameters for a createBook operation.
-type CreateBookInput struct {
-	NewBook *Book
-}
-
-// Validate returns an error if any of the CreateBookInput parameters don't satisfy the
-// requirements from the swagger yml file.
-func (i CreateBookInput) Validate() error {
-	if err := i.NewBook.Validate(nil); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/gen-go/server/handlers.go
+++ b/gen-go/server/handlers.go
@@ -5,13 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+
 	"github.com/Clever/wag/gen-go/models"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/gorilla/mux"
-	"io/ioutil"
-	"net/http"
-	"strconv"
 )
 
 var _ = strconv.ParseInt
@@ -306,7 +307,7 @@ func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r
 		return
 	}
 
-	err = input.Validate()
+	err = input.Validate(nil)
 	if err != nil {
 		http.Error(w, jsonMarshalNoError(models.DefaultBadRequest{Msg: err.Error()}), http.StatusBadRequest)
 		return
@@ -336,16 +337,15 @@ func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r
 }
 
 // newCreateBookInput takes in an http.Request an returns the input struct.
-func newCreateBookInput(r *http.Request) (*models.CreateBookInput, error) {
-	var input models.CreateBookInput
+func newCreateBookInput(r *http.Request) (*models.Book, error) {
+	var input models.Book
 
 	var err error
 	_ = err
 
 	data, err := ioutil.ReadAll(r.Body)
 	if len(data) > 0 {
-		input.NewBook = &models.Book{}
-		if err := json.NewDecoder(bytes.NewReader(data)).Decode(input.NewBook); err != nil {
+		if err := json.NewDecoder(bytes.NewReader(data)).Decode(&input); err != nil {
 			return nil, err
 		}
 	}

--- a/gen-go/server/interface.go
+++ b/gen-go/server/interface.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+
 	"github.com/Clever/wag/gen-go/models"
 )
 
@@ -19,7 +20,7 @@ type Controller interface {
 
 	// CreateBook makes a POST request to /books/{book_id}.
 	// Creates a book
-	CreateBook(ctx context.Context, i *models.CreateBookInput) (*models.Book, error)
+	CreateBook(ctx context.Context, i *models.Book) (*models.Book, error)
 
 	// HealthCheck makes a GET request to /health/check.
 	// Checks if the service is healthy

--- a/gen-go/server/mock_controller.go
+++ b/gen-go/server/mock_controller.go
@@ -52,7 +52,7 @@ func (_mr *_MockControllerRecorder) GetBookByID(arg0, arg1 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetBookByID", arg0, arg1)
 }
 
-func (_m *MockController) CreateBook(ctx context.Context, i *models.CreateBookInput) (*models.Book, error) {
+func (_m *MockController) CreateBook(ctx context.Context, i *models.Book) (*models.Book, error) {
 	ret := _m.ctrl.Call(_m, "CreateBook", ctx, i)
 	ret0, _ := ret[0].(*models.Book)
 	ret1, _ := ret[1].(error)

--- a/models/genmodels.go
+++ b/models/genmodels.go
@@ -44,6 +44,7 @@ package models
 import(
 		"encoding/json"
 		"strconv"
+
 		"github.com/go-openapi/validate"
 		"github.com/go-openapi/strfmt"
 )
@@ -60,6 +61,13 @@ var _ = strfmt.NewFormats
 		pathItemOps := swagger.PathItemOperations(path)
 		for _, opKey := range swagger.SortedOperationsKeys(pathItemOps) {
 			op := pathItemOps[opKey]
+			// Do not generate an input struct + validation for an
+			// operation that has a single, schema'd input.
+			// The input to these will be the model generated for
+			// the schema.
+			if ssbp, _ := swagger.SingleSchemaedBodyParameter(op); ssbp {
+				continue
+			}
 			if err := printInputStruct(&g, op); err != nil {
 				return err
 			}

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -44,8 +44,19 @@ func ImportStatements(imports []string) string {
 	if len(imports) == 0 {
 		return ""
 	}
+	remoteImports := []string{}
 	output := "import (\n"
 	for _, importStr := range imports {
+		if strings.Contains(importStr, ".") {
+			remoteImports = append(remoteImports, importStr)
+		} else {
+			output += fmt.Sprintf("\t\"%s\"\n", importStr)
+		}
+	}
+	if len(remoteImports) > 0 {
+		output += "\n"
+	}
+	for _, importStr := range remoteImports {
 		output += fmt.Sprintf("\t\"%s\"\n", importStr)
 	}
 	output += ")\n\n"

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -27,7 +27,7 @@ func (c *ClientContextTest) GetBooks(ctx context.Context, input *models.GetBooks
 func (c *ClientContextTest) GetBookByID(ctx context.Context, input *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
 	return nil, nil
 }
-func (c *ClientContextTest) CreateBook(ctx context.Context, input *models.CreateBookInput) (*models.Book, error) {
+func (c *ClientContextTest) CreateBook(ctx context.Context, input *models.Book) (*models.Book, error) {
 	c.postCount++
 	if c.postCount == 1 {
 		return nil, fmt.Errorf("Error count: %d", c.postCount)
@@ -78,7 +78,7 @@ func TestNonGetRetries(t *testing.T) {
 	s := server.New(&controller, ":8080")
 	testServer := httptest.NewServer(s.Handler)
 	c := client.New(testServer.URL)
-	_, err := c.CreateBook(context.Background(), &models.CreateBookInput{})
+	_, err := c.CreateBook(context.Background(), &models.Book{})
 	assert.Error(t, err)
 	assert.Equal(t, 1, controller.postCount)
 }

--- a/test/sample_server.go
+++ b/test/sample_server.go
@@ -31,9 +31,9 @@ func (c *ControllerImpl) GetBookByID(ctx context.Context, input *models.GetBookB
 	}
 
 }
-func (c *ControllerImpl) CreateBook(ctx context.Context, input *models.CreateBookInput) (*models.Book, error) {
-	c.books[input.NewBook.ID] = input.NewBook
-	return input.NewBook, nil
+func (c *ControllerImpl) CreateBook(ctx context.Context, input *models.Book) (*models.Book, error) {
+	c.books[input.ID] = input
+	return input, nil
 }
 func (c *ControllerImpl) HealthCheck(ctx context.Context) error {
 	return nil

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -25,7 +25,7 @@ func TestBasicEndToEnd(t *testing.T) {
 	bookName := "Test"
 
 	createdBook, err := c.CreateBook(
-		context.Background(), &models.CreateBookInput{NewBook: &models.Book{ID: bookID, Name: bookName}})
+		context.Background(), &models.Book{ID: bookID, Name: bookName})
 	assert.NoError(t, err)
 	assert.Equal(t, bookID, createdBook.ID)
 	assert.Equal(t, bookName, createdBook.Name)
@@ -46,7 +46,7 @@ func TestBasicEndToEnd(t *testing.T) {
 	otherBookID := int64(126)
 
 	createdBook, err = c.CreateBook(
-		context.Background(), &models.CreateBookInput{NewBook: &models.Book{ID: otherBookID, Name: bookName}})
+		context.Background(), &models.Book{ID: otherBookID, Name: bookName})
 	assert.NoError(t, err)
 	assert.Equal(t, otherBookID, createdBook.ID)
 	assert.Equal(t, bookName, createdBook.Name)
@@ -95,7 +95,7 @@ func TestHeaders(t *testing.T) {
 	bookID := int64(124)
 	c := client.New(s.URL)
 	_, err := c.CreateBook(context.Background(),
-		&models.CreateBookInput{NewBook: &models.Book{ID: bookID, Name: "test"}})
+		&models.Book{ID: bookID, Name: "test"})
 	assert.NoError(t, err)
 
 	// Make a raw HTTP request (i.e. don't use the client) so we can check the headers
@@ -124,7 +124,7 @@ func (d *LastCallServer) GetBooks(ctx context.Context, input *models.GetBooksInp
 func (d *LastCallServer) GetBookByID(ctx context.Context, input *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
 	return nil, nil
 }
-func (d *LastCallServer) CreateBook(ctx context.Context, input *models.CreateBookInput) (*models.Book, error) {
+func (d *LastCallServer) CreateBook(ctx context.Context, input *models.Book) (*models.Book, error) {
 	return nil, nil
 }
 func (c *LastCallServer) HealthCheck(ctx context.Context) error {
@@ -170,7 +170,7 @@ func (m *MiddlewareContextTest) GetBooks(ctx context.Context, input *models.GetB
 func (m *MiddlewareContextTest) GetBookByID(ctx context.Context, input *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
 	return nil, nil
 }
-func (m *MiddlewareContextTest) CreateBook(ctx context.Context, input *models.CreateBookInput) (*models.Book, error) {
+func (m *MiddlewareContextTest) CreateBook(ctx context.Context, input *models.Book) (*models.Book, error) {
 	return nil, nil
 }
 func (m *MiddlewareContextTest) HealthCheck(ctx context.Context) error {


### PR DESCRIPTION
This is a breaking change to the server / client interface. It changes the interface definition for an operation like this

```yaml
    post:
      operationId: createBook
      description: Creates a book
      parameters:
        - name: newBook
          in: body
          schema:
            $ref: "#/definitions/Book"
      responses:
        200:
          description: "Success"
          schema:
            $ref: "#/definitions/Book"
```

from 

```go
CreateBook(ctx context.Context, i *models.CreateBookInput) (*models.Book, error)
...
type CreateBookInput struct {
	NewBook *Book
}
```

to

```go
CreateBook(ctx context.Context, i *models.Book) (*models.Book, error)
```


Generally speaking it will remove the wrapper input struct for any operation that has a single input in the body of the request.

cc @carolinemodic who brought this up in reviewing matchmaker-service.