### PR TITLE
Add go 1.7 req in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 sWAGger - Web API Generator
 
 ## Usage
+Note that WAG requires Go 1.7.
 ### Generating Code
 Create a swagger.yml file with your [service definition](http://editor.swagger.io/#/). Note that WAG supports a [subset](https://github.com/Clever/wag#swagger-spec) of the Swagger spec.
 Copy the latest `swagger.mk` from the [dev-handbook](https://github.com/Clever/dev-handbook/blob/master/make/swagger.mk).


### PR DESCRIPTION
Realized we didn't have it in the README and thought we should mention.