### PR TITLE
Custom string formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ app.use((req, res, next) => {
 ```
 
 ### Custom String Validation
-We've added custom string validation for mongo-ids so users don't have to add `pattern: "^[0-9a-f]{24}$"` throughout your swagger.yml. To use it you have must:
+We've added custom string validation for mongo-ids to avoid repeating: "^[0-9a-f]{24}$"` throughout the swagger.yml. To use it you have must:
 
 - Change you swagger.yml file to have the `mongo-id` format. For example:
 ```
@@ -190,7 +190,7 @@ authorID:
 
 - Import `github.com/Clever/wag/swagger` and call `swagger.InitCustomFormats()` in your server code.
 
-Note that custom string validation only applies to input parameters and does not have any impact on objects defined in '#/definitions'
+Note that custom string validation only applies to input parameters and does not have any impact on objects defined in '#/definitions'.
 
 Right now we do not allow user-defined custom strings, but this is something we may add if there's sufficient demand.
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,22 @@ app.use((req, res, next) => {
 });
 ```
 
+### Custom String Validation
+We've added custom string validation for mongo-ids so users don't have to add `pattern: "^[0-9a-f]{24}$"` throughout your swagger.yml. To use it you have must:
+
+- Change you swagger.yml file to have the `mongo-id` format. For example:
+```
+authorID:
+        type: string
+        format: mongo-id
+```
+
+- Import `github.com/Clever/wag/swagger` and call `swagger.InitCustomFormats()` in your server code.
+
+Note that custom string validation only applies to input parameters and does not have any impact on objects defined in '#/definitions'
+
+Right now we do not allow user-defined custom strings, but this is something we may add if there's sufficient demand.
+
 ## Tests
 ```
 make test

--- a/gen-go/client/client.go
+++ b/gen-go/client/client.go
@@ -152,6 +152,9 @@ func (c Client) GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (mo
 	var body []byte
 
 	path = strings.Replace(path, "{book_id}", strconv.FormatInt(i.BookID, 10), -1)
+	if i.AuthorID != nil {
+		urlVals.Add("authorID", *i.AuthorID)
+	}
 	if i.RandomBytes != nil {
 		urlVals.Add("randomBytes", string(*i.RandomBytes))
 	}

--- a/gen-go/models/book.go
+++ b/gen-go/models/book.go
@@ -15,6 +15,10 @@ swagger:model Book
 */
 type Book struct {
 
+	/* author
+	 */
+	Author string `json:"author,omitempty"`
+
 	/* id
 	 */
 	ID int64 `json:"id,omitempty"`

--- a/gen-go/models/inputs.go
+++ b/gen-go/models/inputs.go
@@ -86,6 +86,7 @@ func (i GetBooksInput) Validate() error {
 // GetBookByIDInput holds the input parameters for a getBookByID operation.
 type GetBookByIDInput struct {
 	BookID        int64
+	AuthorID      *string
 	Authorization *string
 	RandomBytes   *strfmt.Base64
 }
@@ -101,6 +102,11 @@ func (i GetBookByIDInput) Validate() error {
 	}
 	if err := validate.MultipleOf("book_id", "path", float64(i.BookID), 2.000000); err != nil {
 		return err
+	}
+	if i.AuthorID != nil {
+		if err := validate.FormatOf("authorID", "query", "mongo-id", *i.AuthorID, strfmt.Default); err != nil {
+			return err
+		}
 	}
 	if i.Authorization != nil {
 		if err := validate.MaxLength("authorization", "header", string(*i.Authorization), 24); err != nil {

--- a/gen-go/server/handlers.go
+++ b/gen-go/server/handlers.go
@@ -284,6 +284,16 @@ func newGetBookByIDInput(r *http.Request) (*models.GetBookByIDInput, error) {
 		input.BookID = bookIDTmp
 
 	}
+	authorIDStr := r.URL.Query().Get("authorID")
+	if len(authorIDStr) != 0 {
+		var authorIDTmp string
+		authorIDTmp, err = authorIDStr, error(nil)
+		if err != nil {
+			return nil, err
+		}
+		input.AuthorID = &authorIDTmp
+
+	}
 	authorizationStr := r.Header.Get("authorization")
 	if len(authorizationStr) != 0 {
 		var authorizationTmp string

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,9 @@
-hash: 681dcd3704e3193fc308bf20c9169b4f5d8e8173e30aac669ae5369d653751a5
-updated: 2016-08-31T20:14:27.623991306-07:00
+hash: b13470dd80e514b22a2c8bf0869cfc12158746b27d4e3a3ab7b53a1fd1a34e24
+updated: 2016-09-02T12:12:50.332430762-07:00
 imports:
 - name: bitbucket.org/pkg/inflect
   version: 8961c3750a47
+  repo: https://bitbucket.org/pkg/inflect
 - name: github.com/asaskevich/govalidator
   version: 593d64559f7600f29581a3ee42177f5dbded27a9
 - name: github.com/davecgh/go-spew
@@ -12,7 +13,7 @@ imports:
 - name: github.com/go-openapi/analysis
   version: b44dc874b601d9e4e2f6e19140e794ba24bead3b
 - name: github.com/go-openapi/errors
-  version: d24ebc2075bad502fac3a8ae27aa6dd58e1952dc
+  version: 4178436c9f2430cdd945c50301cfb61563b56573
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -22,7 +23,7 @@ imports:
   subpackages:
   - fmts
 - name: github.com/go-openapi/runtime
-  version: 11e322eeecc1032d5a0a96c566ed53f2b5c26e22
+  version: 18efe8c11921c0ddabc8e91554971d6db1f91c7c
 - name: github.com/go-openapi/spec
   version: 6aced65f8501fe1217321abf0749d354824ba2ff
 - name: github.com/go-openapi/strfmt
@@ -32,11 +33,12 @@ imports:
 - name: github.com/go-openapi/validate
   version: deaf2c9013bc1a7f4c774662259a506ba874d80f
 - name: github.com/go-swagger/go-swagger
-  version: fa33185e4cd5c4c787db1047c7bd1fca7f857bca
+  version: 34f62b5e5aaae44788565706f7c676d5be781800
   subpackages:
   - /generator
 - name: github.com/go-swagger/scan-repo-boundary
   version: 196ec52cfa1c96b45dd793dfa0fa3f8877b299da
+  repo: https://github.com/go-swagger/scan-repo-boundary
 - name: github.com/golang/mock
   version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
   subpackages:
@@ -44,11 +46,18 @@ imports:
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
-  version: 0b13a922203ebdbfd236c818efcd5ed46097d690
+  version: 0a192a193177452756c362c20087ddafcf6829c4
 - name: github.com/jessevdk/go-flags
-  version: f2785f5820ec967043de79c8be97edfc464ca745
+  version: a8cab0163d48558ffd77076c9c99388529766f63
+  repo: https://github.com/jessevdk/go-flags
 - name: github.com/mailru/easyjson
-  version: 3d7eb5818bd515e07588ded25d0d501516a0309d
+  version: 34560e358dc05e2c28f6fda2f5c9e7494a4b9b19
+- name: github.com/naoina/denco
+  version: 9af2ba0e24214bac003821f4a501b131b2e04c75
+  repo: https://github.com/naoina/denco
+- name: github.com/opennota/urlesc
+  version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+  repo: https://github.com/opennota/urlesc
 - name: github.com/opentracing/opentracing-go
   version: 77a31d686003349e89c89e58408aafcd20003f41
 - name: github.com/pmezard/go-difflib
@@ -64,26 +73,43 @@ imports:
 - name: github.com/stretchr/testify
   version: d77da356e56a7428ad25149ca77381849a6a5232
 - name: github.com/tylerb/graceful
-  version: 842f31108f8d3512ce3176d00bf1a32db1d5e3af
+  version: 50a48b6e73fcc75b45e22c05b79629a67c79e938
+  repo: https://github.com/tylerb/graceful
 - name: github.com/urfave/negroni
   version: 5d815f907a182b6131cc88af3f17f898b93142a5
+  repo: https://github.com/urfave/negroni
 - name: github.com/vburenin/nsync
   version: 9a75d1c80410815ac45d65fc01ccabac9c98dd4a
+- name: github.com/willf/bitset
+  version: 1730870b454dde6756091d8c6a3d780ef123674c
+  repo: https://github.com/willf/bitset
 - name: golang.org/x/crypto
-  version: f160b6bf95857cd862817875dd958be022e587c4
+  version: 9e590154d2353f3f5e1b24da7275686040dcf491
 - name: golang.org/x/net
-  version: 7394c112eae4dba7e96bfcfe738e6373d61772b4
+  version: 9bc2a3340c92c17a20edcd0080e93851ed58f5d5
   subpackages:
   - /context/ctxhttp
 - name: golang.org/x/text
-  version: d69c40b4be55797923cec7457fac7a244d91a9b6
+  version: 09c7ea1fcb3345da09be5a32c9c52303acd1dc2c
 - name: golang.org/x/tools
-  version: 8ea9d4606980305f7f46cabde046adbb530e71c8
+  version: 9deed8c6c1c89e0b6d68d727f215de8e851d1064
+  repo: https://go.googlesource.com/tools
+  subpackages:
+  - go/ast/astutil
+  - go/buildutil
+  - go/loader
+  - imports
 - name: gopkg.in/Clever/kayvee-go.v4
   version: ^4.1.0
   subpackages:
   - /logger
   - middleware
+- name: gopkg.in/mgo.v2
+  version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
+  subpackages:
+  - /bson
+- name: gopkg.in/tomb.v2
+  version: 14b3d72120e8d10ea6e6b7f87f7175734b1faab8
 - name: gopkg.in/tylerb/graceful.v1
   version: 50a48b6e73fcc75b45e22c05b79629a67c79e938
 - name: gopkg.in/yaml.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -25,3 +25,6 @@ import:
   - middleware
 - package: gopkg.in/tylerb/graceful.v1
 - package: github.com/vburenin/nsync
+- package: gopkg.in/mgo.v2
+  subpackages:
+  - /bson

--- a/main.go
+++ b/main.go
@@ -32,7 +32,6 @@ func main() {
 		log.Fatal("package is required")
 	}
 
-	swagger.InitCustomFormats()
 	loads.AddLoader(fmts.YAMLMatcher, fmts.YAMLDoc)
 	doc, err := loads.Spec(*swaggerFile)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func main() {
 		log.Fatal("package is required")
 	}
 
+	swagger.InitCustomFormats()
 	loads.AddLoader(fmts.YAMLMatcher, fmts.YAMLDoc)
 	doc, err := loads.Spec(*swaggerFile)
 	if err != nil {

--- a/models/genmodels.go
+++ b/models/genmodels.go
@@ -25,13 +25,16 @@ func Generate(packageName, swaggerFile string, swagger spec.Swagger) error {
 		IncludeHandler: false,
 		IncludeSupport: false,
 	}); err != nil {
-		return err
+		return fmt.Errorf("error generating go-swagger models: %s", err)
 	}
 
 	if err := generateOutputs(packageName, swagger.Paths); err != nil {
-		return err
+		return fmt.Errorf("error generating outputs: %s", err)
 	}
-	return generateInputs(packageName, swagger.Paths)
+	if err := generateInputs(packageName, swagger.Paths); err != nil {
+		return fmt.Errorf("error generating inputs: %s", err)
+	}
+	return nil
 }
 
 func generateInputs(packageName string, paths *spec.Paths) error {

--- a/models/genmodels.go
+++ b/models/genmodels.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/go-openapi/loads"
+	"github.com/go-openapi/loads/fmts"
 	"github.com/go-openapi/spec"
 
 	"github.com/Clever/wag/swagger"
@@ -17,6 +19,7 @@ import (
 // Generate writes the files to the client directories
 func Generate(packageName, swaggerFile string, swagger spec.Swagger) error {
 	// generate models with go-swagger
+	loads.AddLoader(fmts.YAMLMatcher, fmts.YAMLDoc)
 	if err := generator.GenerateServer("", []string{}, []string{}, generator.GenOpts{
 		Spec:           swaggerFile,
 		ModelPackage:   "models",

--- a/swagger.yml
+++ b/swagger.yml
@@ -33,6 +33,10 @@ paths:
           minimum: 2
           # This is a silly requirement, but let's add it to show how it would work
           multipleOf: 2
+        - name: authorID
+          in: query
+          type: string
+          format: "mongo-id"
         - name: authorization
           in: header
           type: string
@@ -168,6 +172,9 @@ definitions:
         type: integer
       name:
         type: string
+      author:
+        type: string
+        format: mongo-id
   Error:
     type: object
     properties:

--- a/swagger.yml
+++ b/swagger.yml
@@ -36,7 +36,7 @@ paths:
         - name: authorID
           in: query
           type: string
-          format: "mongo-id"
+          format: mongo-id
         - name: authorization
           in: header
           type: string

--- a/swagger/formats.go
+++ b/swagger/formats.go
@@ -1,0 +1,35 @@
+package swagger
+
+import (
+	"regexp"
+
+	"github.com/go-openapi/strfmt"
+)
+
+func InitCustomFormats() {
+	m := mongoID("")
+	strfmt.Default.Add("mongoID", &m, isMongoID)
+}
+
+var mongoRegExp = regexp.MustCompile("^[0-9a-f]{24}$")
+
+func isMongoID(str string) bool {
+	return mongoRegExp.MatchString(str)
+}
+
+type mongoID string
+
+// MarshalText turns this instance into text
+func (e mongoID) MarshalText() ([]byte, error) {
+	return []byte(string(e)), nil
+}
+
+// UnmarshalText hydrates this instance from text
+func (e *mongoID) UnmarshalText(data []byte) error { // validation is performed later on
+	*e = mongoID(string(data))
+	return nil
+}
+
+func (e mongoID) String() string {
+	return string(e)
+}

--- a/swagger/formats.go
+++ b/swagger/formats.go
@@ -8,7 +8,7 @@ import (
 
 func InitCustomFormats() {
 	m := mongoID("")
-	strfmt.Default.Add("mongoID", &m, isMongoID)
+	strfmt.Default.Add("mongo-id", &m, isMongoID)
 }
 
 var mongoRegExp = regexp.MustCompile("^[0-9a-f]{24}$")

--- a/swagger/formats.go
+++ b/swagger/formats.go
@@ -1,9 +1,9 @@
 package swagger
 
 import (
-	"regexp"
-
 	"github.com/go-openapi/strfmt"
+
+	"gopkg.in/mgo.v2/bson"
 )
 
 func InitCustomFormats() {
@@ -11,10 +11,8 @@ func InitCustomFormats() {
 	strfmt.Default.Add("mongo-id", &m, isMongoID)
 }
 
-var mongoRegExp = regexp.MustCompile("^[0-9a-f]{24}$")
-
 func isMongoID(str string) bool {
-	return mongoRegExp.MatchString(str)
+	return bson.IsObjectIdHex(str)
 }
 
 type mongoID string

--- a/swagger/parameter.go
+++ b/swagger/parameter.go
@@ -64,6 +64,8 @@ func ParamToStringCode(param spec.Parameter) string {
 			return fmt.Sprintf("(%s).String()", valToSet)
 		case "date-time":
 			return fmt.Sprintf("(%s).String()", valToSet)
+		case "mongo-id":
+			return fmt.Sprintf("%s", valToSet)
 		case "":
 			return fmt.Sprintf("%s", valToSet)
 		default:
@@ -105,6 +107,8 @@ func ParamToType(param spec.Parameter, withPointer bool) (string, error) {
 			typeName = "strfmt.Date"
 		case "date-time":
 			typeName = "strfmt.DateTime"
+		case "mongo-id":
+			typeName = "string"
 		case "":
 			typeName = "string"
 		default:
@@ -203,6 +207,8 @@ func StringToTypeCode(strField string, param spec.Parameter) (string, error) {
 		switch param.Format {
 		case "byte":
 			return fmt.Sprintf("convertBase64(%s)", strField), nil
+		case "mongo-id":
+			return fmt.Sprintf("%s, error(nil)", strField), nil
 		case "":
 			return fmt.Sprintf("%s, error(nil)", strField), nil
 		case "date":

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -116,7 +116,7 @@ func TestCustomStringValidation(t *testing.T) {
 
 	bookID := int64(124)
 	_, err := c.CreateBook(context.Background(),
-		&models.CreateBookInput{NewBook: &models.Book{ID: bookID, Name: "test"}})
+		&models.Book{ID: bookID, Name: "test"})
 	assert.NoError(t, err)
 
 	badFormat := "nonMongoFormat"

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -11,10 +11,15 @@ import (
 	"github.com/Clever/wag/gen-go/client"
 	"github.com/Clever/wag/gen-go/models"
 	"github.com/Clever/wag/gen-go/server"
+	"github.com/Clever/wag/swagger"
 
 	"net/http"
 	"net/http/httptest"
 )
+
+func init() {
+	swagger.InitCustomFormats()
+}
 
 func TestBasicEndToEnd(t *testing.T) {
 	s := setupServer()
@@ -103,6 +108,27 @@ func TestHeaders(t *testing.T) {
 	assert.NoError(t, err)
 	defer resp.Body.Close()
 	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+}
+
+func TestCustomStringValidation(t *testing.T) {
+	s := setupServer()
+	c := client.New(s.URL)
+
+	bookID := int64(124)
+	_, err := c.CreateBook(context.Background(),
+		&models.CreateBookInput{NewBook: &models.Book{ID: bookID, Name: "test"}})
+	assert.NoError(t, err)
+
+	badFormat := "nonMongoFormat"
+	_, err = c.GetBookByID(context.Background(),
+		&models.GetBookByIDInput{BookID: bookID, AuthorID: &badFormat})
+	_, ok := err.(models.DefaultBadRequest)
+	assert.True(t, ok)
+
+	validFormat := "012345678901234567890123"
+	_, err = c.GetBookByID(context.Background(),
+		&models.GetBookByIDInput{BookID: bookID, AuthorID: &validFormat})
+	assert.NoError(t, err)
 }
 
 type LastCallServer struct {


### PR DESCRIPTION
This adds support for a `mongo-id` string format. It can be defined with a swagger.yml like:
```
authorID:
  type: string
  format: mongo-id
```

Right now it only applies to input parameters because as far as I can tell go-swagger doesn't add that type of validation to the objects defined in '#/definitions`. I think that's fine for now, as we can see how people use this and then adjust.