### PR TITLE
Write invalid code to file to debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ impl/impl
 bin/
 
 vendor/
+badcode.txt
+

--- a/swagger/swagger.go
+++ b/swagger/swagger.go
@@ -31,10 +31,16 @@ func (g *Generator) WriteFile(path string) error {
 	}
 	fileBytes, err := format.Source(g.buf.Bytes())
 	if err != nil {
-		// This will error if the code isn't valid so let's print it to make it
-		// easier to debug
-		fmt.Printf("BAD CODE\n%s\n", string(g.buf.Bytes()))
-		return err
+		// This will error if the code isn't valid so let's write it out so we can debug
+		f, createErr := os.Create("badcode.txt")
+		if createErr != nil {
+			return createErr
+		}
+		if _, writeErr := f.Write(g.buf.Bytes()); writeErr != nil {
+			return writeErr
+		}
+
+		return fmt.Errorf("INTERNAL ERROR: %s. The invalid code was written to badcode.txt", err)
 	}
 	return ioutil.WriteFile(os.Getenv("GOPATH")+"/src/"+g.PackageName+"/"+path, fileBytes, 0644)
 }


### PR DESCRIPTION
We used to write this to stdout, but I think it will be easier to debug
issues if we write it to a file because the Go error from Source has the
line number in the error. If we write the exact code to a file then the
line number will be easier to match.