### PR TITLE
Log process metrics

### DIFF
--- a/gen-go/server/router.go
+++ b/gen-go/server/router.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/Clever/go-process-metrics/metrics"
 	"github.com/gorilla/mux"
 	"gopkg.in/Clever/kayvee-go.v4/logger"
 	"gopkg.in/tylerb/graceful.v1"
@@ -22,6 +23,11 @@ type Server struct {
 
 // Serve starts the server. It will return if an error occurs.
 func (s Server) Serve() error {
+
+	go func() {
+		metrics.Log("Swagger Test", 1*time.Minute)
+	}()
+
 	// Give the sever 30 seconds to shut down
 	return graceful.RunWithErr(s.addr, 30*time.Second, s.Handler)
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,15 +1,30 @@
-hash: b13470dd80e514b22a2c8bf0869cfc12158746b27d4e3a3ab7b53a1fd1a34e24
-updated: 2016-09-02T12:12:50.332430762-07:00
+hash: 58cf61feb04a0ed2650f55a270be4a177fe62649c75fca0733a5c61f143c1eec
+updated: 2016-09-09T15:41:51.439947962-07:00
 imports:
 - name: bitbucket.org/pkg/inflect
   version: 8961c3750a47
   repo: https://bitbucket.org/pkg/inflect
+- name: github.com/armon/consul-api
+  version: dcfedd50ed5334f96adee43fc88518a4f095e15c
+  repo: https://github.com/armon/consul-api
 - name: github.com/asaskevich/govalidator
   version: 593d64559f7600f29581a3ee42177f5dbded27a9
+- name: github.com/Clever/go-process-metrics
+  version: b7f30fc286d312e80ccc1d88086a283a0bce48c1
+  subpackages:
+  - /metrics
+- name: github.com/coreos/go-etcd
+  version: 003851be7bb0694fe3cc457a49529a19388ee7cf
+  repo: https://github.com/coreos/go-etcd
+  subpackages:
+  - etcd
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
+- name: github.com/fsnotify/fsnotify
+  version: f12c6236fe7b5cf6bcf30e5935d08cb079d78334
+  repo: https://github.com/fsnotify/fsnotify
 - name: github.com/go-openapi/analysis
   version: b44dc874b601d9e4e2f6e19140e794ba24bead3b
 - name: github.com/go-openapi/errors
@@ -33,7 +48,7 @@ imports:
 - name: github.com/go-openapi/validate
   version: deaf2c9013bc1a7f4c774662259a506ba874d80f
 - name: github.com/go-swagger/go-swagger
-  version: 34f62b5e5aaae44788565706f7c676d5be781800
+  version: df1f8c22c1ba419eb988b48aea446ee7143a4780
   subpackages:
   - /generator
 - name: github.com/go-swagger/scan-repo-boundary
@@ -47,11 +62,23 @@ imports:
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
   version: 0a192a193177452756c362c20087ddafcf6829c4
+- name: github.com/hashicorp/hcl
+  version: 99df0eb941dd8ddbc83d3f3605a34f6a686ac85e
+  repo: https://github.com/hashicorp/hcl
 - name: github.com/jessevdk/go-flags
   version: a8cab0163d48558ffd77076c9c99388529766f63
   repo: https://github.com/jessevdk/go-flags
+- name: github.com/kr/fs
+  version: 2788f0dbd16903de03cb8186e5c7d97b69ad387b
+  repo: https://github.com/kr/fs
+- name: github.com/magiconair/properties
+  version: 61b492c03cf472e0c6419be5899b8e0dc28b1b88
+  repo: https://github.com/magiconair/properties
 - name: github.com/mailru/easyjson
   version: 34560e358dc05e2c28f6fda2f5c9e7494a4b9b19
+- name: github.com/mitchellh/mapstructure
+  version: ca63d7c062ee3c9f34db231e352b60012b4fd0c1
+  repo: https://github.com/mitchellh/mapstructure
 - name: github.com/naoina/denco
   version: 9af2ba0e24214bac003821f4a501b131b2e04c75
   repo: https://github.com/naoina/denco
@@ -59,7 +86,19 @@ imports:
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
   repo: https://github.com/opennota/urlesc
 - name: github.com/opentracing/opentracing-go
-  version: 77a31d686003349e89c89e58408aafcd20003f41
+  version: ca4c9c0010bd9155b6d067b33865d849fe533628
+- name: github.com/pelletier/go-buffruneio
+  version: df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d
+  repo: https://github.com/pelletier/go-buffruneio
+- name: github.com/pelletier/go-toml
+  version: 5a62685873ef617233ab5f1b825a6e4a758e16cf
+  repo: https://github.com/pelletier/go-toml
+- name: github.com/pkg/errors
+  version: 17b591df37844cde689f4d5813e5cea0927d8dd2
+  repo: https://github.com/pkg/errors
+- name: github.com/pkg/sftp
+  version: a71e8f580e3b622ebff585309160b1cc549ef4d2
+  repo: https://github.com/pkg/sftp
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -68,6 +107,21 @@ imports:
   version: 8a290539e2e8629dbc4e6bad948158f790ec31f4
 - name: github.com/PuerkitoBio/urlesc
   version: 5bd2802263f21d8788851d5305584c82a5c75d7e
+- name: github.com/spf13/afero
+  version: 20500e2abd0d1f4564a499e83d11d6c73cd58c27
+  repo: https://github.com/spf13/afero
+- name: github.com/spf13/cast
+  version: e31f36ffc91a2ba9ddb72a4b6a607ff9b3d3cb63
+  repo: https://github.com/spf13/cast
+- name: github.com/spf13/jwalterweatherman
+  version: 33c24e77fb80341fe7130ee7c594256ff08ccc46
+  repo: https://github.com/spf13/jwalterweatherman
+- name: github.com/spf13/pflag
+  version: 103ce5cd2042f2fe629c1957abb64ab3e7f50235
+  repo: https://github.com/spf13/pflag
+- name: github.com/spf13/viper
+  version: 16990631d4aa7e38f73dbbbf37fa13e67c648531
+  repo: https://github.com/spf13/viper
 - name: github.com/stretchr/objx
   version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
@@ -75,20 +129,44 @@ imports:
 - name: github.com/tylerb/graceful
   version: 50a48b6e73fcc75b45e22c05b79629a67c79e938
   repo: https://github.com/tylerb/graceful
+- name: github.com/ugorji/go
+  version: 5cd0f2b3b6cca8e3a0a4101821e41a73cb59bed6
+  repo: https://github.com/ugorji/go
+  subpackages:
+  - codec
 - name: github.com/urfave/negroni
-  version: 5d815f907a182b6131cc88af3f17f898b93142a5
+  version: 3f7ce7b928e14ff890b067e5bbbc80af73690a9c
   repo: https://github.com/urfave/negroni
 - name: github.com/vburenin/nsync
   version: 9a75d1c80410815ac45d65fc01ccabac9c98dd4a
 - name: github.com/willf/bitset
   version: 1730870b454dde6756091d8c6a3d780ef123674c
   repo: https://github.com/willf/bitset
+- name: github.com/xordataexchange/crypt
+  version: 749e360c8f236773f28fc6d3ddfce4a470795227
+  repo: https://github.com/xordataexchange/crypt
+  subpackages:
+  - backend
+  - config
+  - encoding/secconf
 - name: golang.org/x/crypto
   version: 9e590154d2353f3f5e1b24da7275686040dcf491
+  repo: https://go.googlesource.com/crypto
+  subpackages:
+  - cast5
+  - curve25519
+  - ed25519
+  - openpgp
+  - ssh
 - name: golang.org/x/net
   version: 9bc2a3340c92c17a20edcd0080e93851ed58f5d5
   subpackages:
   - /context/ctxhttp
+- name: golang.org/x/sys
+  version: a646d33e2ee3172a661fc09bca23bb4889a41bc8
+  repo: https://go.googlesource.com/sys
+  subpackages:
+  - unix
 - name: golang.org/x/text
   version: 09c7ea1fcb3345da09be5a32c9c52303acd1dc2c
 - name: golang.org/x/tools
@@ -99,8 +177,10 @@ imports:
   - go/buildutil
   - go/loader
   - imports
+- name: gopkg.in/Clever/kayvee-go.v3
+  version: 056c92dcc68b40c5d6045f755197b3776f914154
 - name: gopkg.in/Clever/kayvee-go.v4
-  version: ^4.1.0
+  version: c78a599f8d30cb7c2bb3746690500c4029545784
   subpackages:
   - /logger
   - middleware

--- a/glide.yaml
+++ b/glide.yaml
@@ -28,3 +28,6 @@ import:
 - package: gopkg.in/mgo.v2
   subpackages:
   - /bson
+- package: github.com/Clever/go-process-metrics
+  subpackages:
+  - /metrics

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gorilla/mux"
 	"gopkg.in/Clever/kayvee-go.v4/logger"
 	"gopkg.in/tylerb/graceful.v1"
+	"github.com/Clever/go-process-metrics/metrics"
 )
 
 type contextKey struct{}
@@ -54,6 +55,11 @@ type Server struct {
 
 // Serve starts the server. It will return if an error occurs.
 func (s Server) Serve() error {
+
+	go func() {
+		metrics.Log("%s", 1*time.Minute)
+	}()
+
 	// Give the sever 30 seconds to shut down
 	return graceful.RunWithErr(s.addr,30*time.Second,s.Handler)
 }
@@ -66,7 +72,7 @@ type handler struct {
 func New(c Controller, addr string) Server {
 	r := mux.NewRouter()
 	h := handler{Controller: c}
-`)
+`, s.Info.InfoProps.Title)
 
 	for _, path := range swagger.SortedPathItemKeys(paths.Paths) {
 		pathItem := paths.Paths[path]


### PR DESCRIPTION
Let's log process metrics by default so we get things like GC / heap
usage information. At some point we might consider more configurability,
including possibly https://golang.org/pkg/expvar/, but this seems like
an easy, low-impact way to start.