### PR TITLE
Clients from discovery

### DIFF
--- a/client/genclients.go
+++ b/client/genclients.go
@@ -29,6 +29,8 @@ import (
 		"time"
 
 		"%s/models"
+
+		discovery "github.com/Clever/discovery-go"
 )
 
 var _ = json.Marshal
@@ -57,6 +59,16 @@ func New(basePath string) *Client {
 		transport: &http.Transport{}, basePath: basePath}
 }
 
+// NewFromDiscovery creates a client from the discovery environment variables. This method requires
+// the three env vars: SERVICE_%s_HTTP_(HOST/PORT/PROTO) to be set. Otherwise it returns an error.
+func NewFromDiscovery() (*Client, error) {
+	url, err := discovery.URL("%s", "http")
+	if err != nil {
+		return nil, err
+	}
+	return New(url), nil
+}
+
 // WithRetries returns a new client that retries all GET operations until they either succeed or fail the
 // number of times specified.
 func (c *Client) WithRetries(retries int) *Client {
@@ -71,7 +83,10 @@ func (c *Client) WithTimeout(timeout time.Duration) *Client {
 	return c
 }
 
-`, packageName, s.Info.InfoProps.Title)
+`, packageName,
+		s.Info.InfoProps.Title,
+		strings.ToUpper(strings.Replace(s.Info.InfoProps.Title, "-", "_", -1)),
+		s.Info.InfoProps.Title)
 
 	g.Printf(swagger.BaseParamToStringCode())
 

--- a/gen-go/client/client.go
+++ b/gen-go/client/client.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/Clever/wag/gen-go/models"
+
+	discovery "github.com/Clever/discovery-go"
 )
 
 var _ = json.Marshal
@@ -18,7 +20,7 @@ var _ = strings.Replace
 var _ = strconv.FormatInt
 var _ = bytes.Compare
 
-// Client is used to make requests to the Swagger Test service.
+// Client is used to make requests to the swagger-test service.
 type Client struct {
 	basePath    string
 	requestDoer doer
@@ -37,6 +39,16 @@ func New(basePath string) *Client {
 
 	return &Client{requestDoer: &retry, retryDoer: &retry, defaultTimeout: 10 * time.Second,
 		transport: &http.Transport{}, basePath: basePath}
+}
+
+// NewFromDiscovery creates a client from the discovery environment variables. There must be three
+// env vars with the format: SERVICE_SWAGGER_TEST_HTTP_(HOST/PORT/PROTO)
+func NewFromDiscovery() (*Client, error) {
+	url, err := discovery.URL("swagger-test", "http")
+	if err != nil {
+		return nil, err
+	}
+	return New(url), nil
 }
 
 // WithRetries returns a new client that retries all GET operations until they either succeed or fail the

--- a/gen-go/server/interface.go
+++ b/gen-go/server/interface.go
@@ -8,7 +8,7 @@ import (
 
 //go:generate $GOPATH/bin/mockgen -source=$GOFILE -destination=mock_controller.go -package=server
 
-// Controller defines the interface for the Swagger Test service.
+// Controller defines the interface for the swagger-test service.
 type Controller interface {
 	// GetBooks makes a GET request to /books.
 	// Returns a list of books

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 58cf61feb04a0ed2650f55a270be4a177fe62649c75fca0733a5c61f143c1eec
-updated: 2016-09-09T15:41:51.439947962-07:00
+hash: 254b127b78f5df13010c171cbc6ff7286b1fef62d77d8b74bc52d385aabbe2a3
+updated: 2016-09-20T19:38:52.367180149-07:00
 imports:
 - name: bitbucket.org/pkg/inflect
   version: 8961c3750a47
@@ -9,6 +9,8 @@ imports:
   repo: https://github.com/armon/consul-api
 - name: github.com/asaskevich/govalidator
   version: 593d64559f7600f29581a3ee42177f5dbded27a9
+- name: github.com/Clever/discovery-go
+  version: e432f2a0d4331b80a20674df4c1d0baa753e0bc5
 - name: github.com/Clever/go-process-metrics
   version: b7f30fc286d312e80ccc1d88086a283a0bce48c1
   subpackages:
@@ -48,7 +50,7 @@ imports:
 - name: github.com/go-openapi/validate
   version: deaf2c9013bc1a7f4c774662259a506ba874d80f
 - name: github.com/go-swagger/go-swagger
-  version: df1f8c22c1ba419eb988b48aea446ee7143a4780
+  version: dd82f733d6adc9a78c350e8c2581f0e4612d755e
   subpackages:
   - /generator
 - name: github.com/go-swagger/scan-repo-boundary
@@ -61,7 +63,7 @@ imports:
 - name: github.com/gorilla/context
   version: 08b5f424b9271eedf6f9f0ce86cb9396ed337a42
 - name: github.com/gorilla/mux
-  version: 0a192a193177452756c362c20087ddafcf6829c4
+  version: 757bef944d0f21880861c2dd9c871ca543023cba
 - name: github.com/hashicorp/hcl
   version: 99df0eb941dd8ddbc83d3f3605a34f6a686ac85e
   repo: https://github.com/hashicorp/hcl
@@ -180,7 +182,7 @@ imports:
 - name: gopkg.in/Clever/kayvee-go.v3
   version: 056c92dcc68b40c5d6045f755197b3776f914154
 - name: gopkg.in/Clever/kayvee-go.v4
-  version: c78a599f8d30cb7c2bb3746690500c4029545784
+  version: 94772833b9df4d5af35c5150af34466d656faeee
   subpackages:
   - /logger
   - middleware

--- a/glide.yaml
+++ b/glide.yaml
@@ -31,3 +31,4 @@ import:
 - package: github.com/Clever/go-process-metrics
   subpackages:
   - /metrics
+- package: github.com/Clever/discovery-go

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  title: Swagger Test
+  title: swagger-test
   description: Testing Swagger Codegen
   version: 0.1.0
 basePath: /v1

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -90,7 +90,7 @@ func TestNonGetRetries(t *testing.T) {
 
 func TestNewWithDiscovery(t *testing.T) {
 	controller := ClientContextTest{}
-	s := server.New(&controller, "books", "")
+	s := server.New(&controller, "")
 	testServer := httptest.NewServer(s.Handler)
 
 	// Should be an err if env vars aren't set


### PR DESCRIPTION
This change adds support for creating clients from discovery environment variables. This change has two nice benefits:
1. Consumers don't have to know anything about discovery env vars
2. If we change the way discovery works we can hide it behind this interface.