### PR TITLE
Clean up interface comments

### DIFF
--- a/gen-go/client/client.go
+++ b/gen-go/client/client.go
@@ -398,7 +398,6 @@ func (c *Client) GetBookByID2(ctx context.Context, i *models.GetBookByID2Input) 
 }
 
 // HealthCheck makes a GET request to /health/check.
-// Checks if the service is healthy
 func (c *Client) HealthCheck(ctx context.Context) error {
 	path := c.basePath + "/v1/health/check"
 	urlVals := url.Values{}

--- a/gen-go/server/interface.go
+++ b/gen-go/server/interface.go
@@ -10,6 +10,7 @@ import (
 
 // Controller defines the interface for the swagger-test service.
 type Controller interface {
+
 	// GetBooks makes a GET request to /books.
 	// Returns a list of books
 	GetBooks(ctx context.Context, i *models.GetBooksInput) ([]models.Book, error)
@@ -27,6 +28,5 @@ type Controller interface {
 	GetBookByID2(ctx context.Context, i *models.GetBookByID2Input) (*models.Book, error)
 
 	// HealthCheck makes a GET request to /health/check.
-	// Checks if the service is healthy
 	HealthCheck(ctx context.Context) error
 }

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -139,7 +139,7 @@ func generateInterface(packageName string, serviceName string, paths *spec.Paths
 	g.Printf(swagger.ImportStatements([]string{"context", packageName + "/models"}))
 	g.Printf("//go:generate $GOPATH/bin/mockgen -source=$GOFILE -destination=mock_controller.go -package=server\n\n")
 	g.Printf("// Controller defines the interface for the %s service.\n", serviceName)
-	g.Printf("type Controller interface {\n")
+	g.Printf("type Controller interface {\n\n")
 
 	for _, pathKey := range swagger.SortedPathItemKeys(paths.Paths) {
 		path := paths.Paths[pathKey]

--- a/swagger.yml
+++ b/swagger.yml
@@ -14,7 +14,6 @@ paths:
   /health/check:
     get:
       operationId: healthCheck
-      description: Checks if the service is healthy
       tags:
         - Infra
       responses:

--- a/swagger/operation.go
+++ b/swagger/operation.go
@@ -67,9 +67,9 @@ func Interface(op *spec.Operation) string {
 func InterfaceComment(method, path string, op *spec.Operation) string {
 
 	capOpID := Capitalize(op.ID)
-	comment := fmt.Sprintf("// %s makes a %s request to %s.\n", capOpID, method, path)
+	comment := fmt.Sprintf("// %s makes a %s request to %s.", capOpID, method, path)
 	if op.Description != "" {
-		comment += "// " + op.Description
+		comment += "\n// " + op.Description
 	}
 	return comment
 }


### PR DESCRIPTION
This removes an extra line that existed if the description was empty. It
also adds a line under the `type interface` line.