### PR TITLE
Remove error interface

### DIFF
--- a/client/genclients.go
+++ b/client/genclients.go
@@ -291,46 +291,50 @@ func errorMessage(err string, op *spec.Operation) string {
 `, err)
 }
 
-// TODO: Add a nice comment and ultimately move this to the (maybe an interface object with all
-// this...)
-// Response:
-//   success
-//   failure
-//   decode
-//   makePointer
-// TODO: make this into a struct
-// TODO: Change this to a list of return values??? (have 2 cases, nil and a type...)
-func pair(op *spec.Operation, statusCode int) (string, string, bool, bool) {
+type statusCodeReturn struct {
+	responseTypes []string
+	// unclear if we need this decode param
+	decode      bool
+	makePointer bool
+}
+
+// outputForCode returns the definition for the output for an operation for a particular
+// status code. The first response value is the list of types in the response in the order they
+// are returned (e.g. GetBookById200Output, nil). The second argument is whether the model object
+// returned should be decode. The final argument is whether the model object should be returned as
+// a pointer.
+func outputForCode(op *spec.Operation, statusCode int) ([]string, bool, bool) {
 
 	noSuccessType := swagger.NoSuccessType(op)
-	successReturn := "nil"
-	if noSuccessType {
-		successReturn = ""
+	successResponses := []string{}
+	if !noSuccessType {
+		successResponses = append(successResponses, "nil")
 	}
 	if statusCode == 400 {
-		return successReturn, "models.DefaultBadRequest", true, false
+		successResponses = append(successResponses, "models.DefaultBadRequest")
+		return successResponses, true, false
 	} else if statusCode == 500 {
-		return successReturn, "models.DefaultInternalError", true, false
+		successResponses = append(successResponses, "models.DefaultInternalError")
+		return successResponses, true, false
 	}
 
 	response := op.Responses.StatusCodeResponses[statusCode]
 	outputName, makePointer := swagger.OutputType(op, statusCode)
-	if noSuccessType && statusCode < 400 {
-		return "", "nil", false, false
+	if noSuccessType {
+		if statusCode < 400 {
+			return []string{"nil"}, false, false
+		}
+		return []string{outputName}, false, false
 	} else if response.Schema == nil {
 		if statusCode < 400 {
-			return outputName, "nil", false, false
+			return []string{outputName, "nil"}, false, false
 		}
-		// TODO: Understand this case...
-		if noSuccessType {
-			return outputName, "nil", false, false
-		}
-		return "nil", outputName, false, false
+		return []string{"nil", outputName}, false, false
 	}
 	if statusCode < 400 {
-		return outputName, "nil", true, makePointer
+		return []string{outputName, "nil"}, true, makePointer
 	}
-	return "nil", fmt.Sprintf("%s", outputName), false, false
+	return []string{"nil", fmt.Sprintf("%s", outputName)}, false, false
 }
 
 // parseResponseCode generates the code for handling the http response.
@@ -369,18 +373,28 @@ func parseResponseCode(op *spec.Operation, capOpID string) string {
 
 func writeStatusCodeDecoder(op *spec.Operation, statusCode int) string {
 	var buf bytes.Buffer
-	success, failure, decode, makePointer := pair(op, statusCode)
+	responses, decode, makePointer := outputForCode(op, statusCode)
 
 	buf.WriteString(fmt.Sprintf("\tcase %d:\n", statusCode))
 
-	if success != "" && success != "nil" {
-		buf.WriteString(fmt.Sprintf("var output %s\n", success))
-	} else if failure != "" && failure != "nil" {
-		buf.WriteString(fmt.Sprintf("var output %s\n", failure))
+	var newResponses []string
+	for _, response := range responses {
+		newResponse := "nil"
+		if response != "nil" {
+			// Turn any of the non-nil output types into variables
+			buf.WriteString(fmt.Sprintf("var output %s\n", response))
+			if makePointer {
+				newResponse = "&output"
+			} else {
+				newResponse = "output"
+			}
+		}
+		newResponses = append(newResponses, newResponse)
 	}
+
 	if decode {
 		nilString := ""
-		if success != "" {
+		if len(responses) > 1 {
 			nilString = "nil, "
 		}
 		buf.WriteString(fmt.Sprintf(`
@@ -392,18 +406,7 @@ func writeStatusCodeDecoder(op *spec.Operation, statusCode int) string {
 `, nilString))
 
 	}
-	if success != "" && success != "nil" {
-		if makePointer {
-			buf.WriteString("return &output, nil\n")
-		} else {
-			buf.WriteString("return output, nil\n")
-		}
-	} else {
-		if success == "" {
-			buf.WriteString("return output\n")
-		} else {
-			buf.WriteString("return nil, output\n")
-		}
-	}
+
+	buf.WriteString("return " + strings.Join(newResponses, ",") + "\n")
 	return buf.String()
 }

--- a/client/genclients.go
+++ b/client/genclients.go
@@ -264,8 +264,7 @@ func parseResponseCode(op *spec.Operation, capOpID string) string {
 	noSuccessType := swagger.NoSuccessType(op)
 	for _, statusCode := range swagger.SortedStatusCodeKeys(op.Responses.StatusCodeResponses) {
 		response := op.Responses.StatusCodeResponses[statusCode]
-		outputName := swagger.OutputType(op, statusCode)
-
+		outputName, _ := swagger.OutputType(op, statusCode)
 		buf.WriteString(fmt.Sprintf("\tcase %d:\n", statusCode))
 
 		if noSuccessType && statusCode < 400 {

--- a/gen-go/client/client.go
+++ b/gen-go/client/client.go
@@ -450,7 +450,7 @@ func (c *WagClient) HealthCheck(ctx context.Context) error {
 	defer resp.Body.Close()
 	switch resp.StatusCode {
 	case 200:
-		return output
+		return nil
 	case 400:
 		var output models.DefaultBadRequest
 

--- a/gen-go/client/client.go
+++ b/gen-go/client/client.go
@@ -4,13 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"github.com/Clever/wag/gen-go/models"
 	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/Clever/wag/gen-go/models"
 
 	discovery "github.com/Clever/discovery-go"
 )

--- a/gen-go/client/client.go
+++ b/gen-go/client/client.go
@@ -156,25 +156,28 @@ func (c *WagClient) GetBooks(ctx context.Context, i *models.GetBooksInput) ([]mo
 	defer resp.Body.Close()
 	switch resp.StatusCode {
 	case 200:
-
 		var output []models.Book
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
-		return output, nil
 
+		return output, nil
 	case 400:
 		var output models.DefaultBadRequest
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
-		return nil, output
 
+		return nil, output
 	case 500:
 		var output models.DefaultInternalError
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
+
 		return nil, output
 
 	default:
@@ -229,12 +232,13 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 	defer resp.Body.Close()
 	switch resp.StatusCode {
 	case 200:
-
 		var output models.GetBookByID200Output
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
-		return &output, nil
+
+		return output, nil
 	case 204:
 		var output models.GetBookByID204Output
 		return output, nil
@@ -242,20 +246,23 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 		var output models.GetBookByID401Output
 		return nil, output
 	case 404:
-		return nil, models.GetBookByID404Output{}
-
+		var output models.GetBookByID404Output
+		return nil, output
 	case 400:
 		var output models.DefaultBadRequest
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
-		return nil, output
 
+		return nil, output
 	case 500:
 		var output models.DefaultInternalError
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
+
 		return nil, output
 
 	default:
@@ -310,25 +317,28 @@ func (c *WagClient) CreateBook(ctx context.Context, i *models.Book) (*models.Boo
 	defer resp.Body.Close()
 	switch resp.StatusCode {
 	case 200:
-
 		var output models.Book
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
-		return &output, nil
 
+		return &output, nil
 	case 400:
 		var output models.DefaultBadRequest
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
-		return nil, output
 
+		return nil, output
 	case 500:
 		var output models.DefaultInternalError
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
+
 		return nil, output
 
 	default:
@@ -373,28 +383,31 @@ func (c *WagClient) GetBookByID2(ctx context.Context, i *models.GetBookByID2Inpu
 	defer resp.Body.Close()
 	switch resp.StatusCode {
 	case 200:
-
 		var output models.Book
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
+
 		return &output, nil
 	case 404:
 		var output models.GetBookByID2404Output
 		return nil, output
-
 	case 400:
 		var output models.DefaultBadRequest
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
-		return nil, output
 
+		return nil, output
 	case 500:
 		var output models.DefaultInternalError
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
+
 		return nil, output
 
 	default:
@@ -437,20 +450,22 @@ func (c *WagClient) HealthCheck(ctx context.Context) error {
 	defer resp.Body.Close()
 	switch resp.StatusCode {
 	case 200:
-		return nil
-
+		return output
 	case 400:
 		var output models.DefaultBadRequest
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return models.DefaultInternalError{Msg: err.Error()}
 		}
-		return output
 
+		return output
 	case 500:
 		var output models.DefaultInternalError
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return models.DefaultInternalError{Msg: err.Error()}
 		}
+
 		return output
 
 	default:

--- a/gen-go/client/client.go
+++ b/gen-go/client/client.go
@@ -238,7 +238,7 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
 
-		return output, nil
+		return &output, nil
 	case 204:
 		var output models.GetBookByID204Output
 		return output, nil

--- a/gen-go/models/outputs.go
+++ b/gen-go/models/outputs.go
@@ -21,12 +21,6 @@ func (d DefaultBadRequest) Error() string {
 	return d.Msg
 }
 
-// GetBooksError defines the error interface for GetBooks.
-type GetBooksError interface {
-	error // Extend the error interface
-	GetBooksStatusCode() int
-}
-
 // GetBookByIDOutput defines the success output interface for GetBookByID.
 type GetBookByIDOutput interface {
 	GetBookByIDStatusCode() int
@@ -48,19 +42,8 @@ func (o GetBookByID204Output) GetBookByIDStatusCode() int {
 	return 204
 }
 
-// GetBookByIDError defines the error interface for GetBookByID.
-type GetBookByIDError interface {
-	error // Extend the error interface
-	GetBookByIDStatusCode() int
-}
-
 // GetBookByID401Output defines the 401 status code response for GetBookByID.
 type GetBookByID401Output struct{}
-
-// GetBookByIDStatusCode returns the status code for the operation.
-func (o GetBookByID401Output) GetBookByIDStatusCode() int {
-	return 401
-}
 
 // Error returns "Status Code: X". We implemented in to satisfy the error
 // interface. For a more descriptive error message see the output type.
@@ -71,45 +54,17 @@ func (o GetBookByID401Output) Error() string {
 // GetBookByID404Output defines the 404 status code response for GetBookByID.
 type GetBookByID404Output Error
 
-// GetBookByIDStatusCode returns the status code for the operation.
-func (o GetBookByID404Output) GetBookByIDStatusCode() int {
-	return 404
-}
-
 // Error returns "Status Code: X". We implemented in to satisfy the error
 // interface. For a more descriptive error message see the output type.
 func (o GetBookByID404Output) Error() string {
 	return "Status Code: 404"
 }
 
-// CreateBookError defines the error interface for CreateBook.
-type CreateBookError interface {
-	error // Extend the error interface
-	CreateBookStatusCode() int
-}
-
-// GetBookByID2Error defines the error interface for GetBookByID2.
-type GetBookByID2Error interface {
-	error // Extend the error interface
-	GetBookByID2StatusCode() int
-}
-
 // GetBookByID2404Output defines the 404 status code response for GetBookByID2.
 type GetBookByID2404Output struct{}
-
-// GetBookByID2StatusCode returns the status code for the operation.
-func (o GetBookByID2404Output) GetBookByID2StatusCode() int {
-	return 404
-}
 
 // Error returns "Status Code: X". We implemented in to satisfy the error
 // interface. For a more descriptive error message see the output type.
 func (o GetBookByID2404Output) Error() string {
 	return "Status Code: 404"
-}
-
-// HealthCheckError defines the error interface for HealthCheck.
-type HealthCheckError interface {
-	error // Extend the error interface
-	HealthCheckStatusCode() int
 }

--- a/gen-go/server/handlers.go
+++ b/gen-go/server/handlers.go
@@ -65,11 +65,10 @@ func jsonMarshalNoError(i interface{}) string {
 	}
 	return string(bytes)
 }
-func statusCodeForGetBooks(obj interface{}) int {
 
-	if obj == nil {
-		return 200
-	}
+// statusCodeForGetBooks returns the status code corresponding to the returned
+// object. It returns -1 if the type doesn't correspond to anything.
+func statusCodeForGetBooks(obj interface{}) int {
 
 	switch obj.(type) {
 
@@ -243,11 +242,9 @@ func newGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 	return &input, nil
 }
 
+// statusCodeForGetBookByID returns the status code corresponding to the returned
+// object. It returns -1 if the type doesn't correspond to anything.
 func statusCodeForGetBookByID(obj interface{}) int {
-
-	if obj == nil {
-		return 200
-	}
 
 	switch obj.(type) {
 
@@ -367,11 +364,9 @@ func newGetBookByIDInput(r *http.Request) (*models.GetBookByIDInput, error) {
 	return &input, nil
 }
 
+// statusCodeForCreateBook returns the status code corresponding to the returned
+// object. It returns -1 if the type doesn't correspond to anything.
 func statusCodeForCreateBook(obj interface{}) int {
-
-	if obj == nil {
-		return 200
-	}
 
 	switch obj.(type) {
 
@@ -445,11 +440,9 @@ func newCreateBookInput(r *http.Request) (*models.Book, error) {
 	return &input, nil
 }
 
+// statusCodeForGetBookByID2 returns the status code corresponding to the returned
+// object. It returns -1 if the type doesn't correspond to anything.
 func statusCodeForGetBookByID2(obj interface{}) int {
-
-	if obj == nil {
-		return 200
-	}
 
 	switch obj.(type) {
 
@@ -533,11 +526,9 @@ func newGetBookByID2Input(r *http.Request) (*models.GetBookByID2Input, error) {
 	return &input, nil
 }
 
+// statusCodeForHealthCheck returns the status code corresponding to the returned
+// object. It returns -1 if the type doesn't correspond to anything.
 func statusCodeForHealthCheck(obj interface{}) int {
-
-	if obj == nil {
-		return 200
-	}
 
 	switch obj.(type) {
 
@@ -564,7 +555,7 @@ func (h handler) HealthCheckHandler(ctx context.Context, w http.ResponseWriter, 
 		return
 	}
 
-	w.WriteHeader(statusCodeForHealthCheck(nil))
+	w.WriteHeader(200)
 	w.Write([]byte(""))
 
 }

--- a/gen-go/server/handlers.go
+++ b/gen-go/server/handlers.go
@@ -83,6 +83,7 @@ func statusCodeForGetBooks(obj interface{}) int {
 		return -1
 	}
 }
+
 func (h handler) GetBooksHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	input, err := newGetBooksInput(r)
@@ -268,6 +269,7 @@ func statusCodeForGetBookByID(obj interface{}) int {
 		return -1
 	}
 }
+
 func (h handler) GetBookByIDHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	input, err := newGetBookByIDInput(r)
@@ -381,6 +383,7 @@ func statusCodeForCreateBook(obj interface{}) int {
 		return -1
 	}
 }
+
 func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	input, err := newCreateBookInput(r)
@@ -460,6 +463,7 @@ func statusCodeForGetBookByID2(obj interface{}) int {
 		return -1
 	}
 }
+
 func (h handler) GetBookByID2Handler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	input, err := newGetBookByID2Input(r)
@@ -540,6 +544,7 @@ func statusCodeForHealthCheck(obj interface{}) int {
 		return -1
 	}
 }
+
 func (h handler) HealthCheckHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	err := h.HealthCheck(ctx)

--- a/gen-go/server/handlers.go
+++ b/gen-go/server/handlers.go
@@ -249,6 +249,18 @@ func statusCodeForGetBookByID(obj interface{}) int {
 
 	switch obj.(type) {
 
+	case *models.GetBookByID200Output:
+		return 200
+
+	case *models.GetBookByID204Output:
+		return 204
+
+	case *models.GetBookByID401Output:
+		return 401
+
+	case *models.GetBookByID404Output:
+		return 404
+
 	case models.GetBookByID200Output:
 		return 200
 
@@ -375,6 +387,9 @@ func statusCodeForCreateBook(obj interface{}) int {
 	case *models.Book:
 		return 200
 
+	case models.Book:
+		return 200
+
 	case models.DefaultBadRequest:
 		return 400
 	case models.DefaultInternalError:
@@ -450,6 +465,12 @@ func statusCodeForGetBookByID2(obj interface{}) int {
 	switch obj.(type) {
 
 	case *models.Book:
+		return 200
+
+	case *models.GetBookByID2404Output:
+		return 404
+
+	case models.Book:
 		return 200
 
 	case models.GetBookByID2404Output:

--- a/gen-go/server/handlers.go
+++ b/gen-go/server/handlers.go
@@ -67,14 +67,18 @@ func jsonMarshalNoError(i interface{}) string {
 }
 func statusCodeForGetBooks(obj interface{}) int {
 
-	switch t := obj.(type) {
+	if obj == nil {
+		return 200
+	}
 
-	case models.GetBooks200Output:
+	switch obj.(type) {
+
+	case []models.Book:
 		return 200
 
-	case DefaultBadRequest:
+	case models.DefaultBadRequest:
 		return 400
-	case DefaultInternalError:
+	case models.DefaultInternalError:
 		return 500
 	default:
 		return -1
@@ -102,7 +106,7 @@ func (h handler) GetBooksHandler(ctx context.Context, w http.ResponseWriter, r *
 		logger.FromContext(ctx).AddContext("error", err.Error())
 		statusCode := statusCodeForGetBooks(err)
 		if statusCode != -1 {
-			http.Error(w, respErr, statusCode)
+			http.Error(w, err.Error(), statusCode)
 		} else {
 			http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
 		}
@@ -241,7 +245,11 @@ func newGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 
 func statusCodeForGetBookByID(obj interface{}) int {
 
-	switch t := obj.(type) {
+	if obj == nil {
+		return 200
+	}
+
+	switch obj.(type) {
 
 	case models.GetBookByID200Output:
 		return 200
@@ -255,9 +263,9 @@ func statusCodeForGetBookByID(obj interface{}) int {
 	case models.GetBookByID404Output:
 		return 404
 
-	case DefaultBadRequest:
+	case models.DefaultBadRequest:
 		return 400
-	case DefaultInternalError:
+	case models.DefaultInternalError:
 		return 500
 	default:
 		return -1
@@ -285,7 +293,7 @@ func (h handler) GetBookByIDHandler(ctx context.Context, w http.ResponseWriter, 
 		logger.FromContext(ctx).AddContext("error", err.Error())
 		statusCode := statusCodeForGetBookByID(err)
 		if statusCode != -1 {
-			http.Error(w, respErr, statusCode)
+			http.Error(w, err.Error(), statusCode)
 		} else {
 			http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
 		}
@@ -361,14 +369,18 @@ func newGetBookByIDInput(r *http.Request) (*models.GetBookByIDInput, error) {
 
 func statusCodeForCreateBook(obj interface{}) int {
 
-	switch t := obj.(type) {
+	if obj == nil {
+		return 200
+	}
 
-	case models.CreateBook200Output:
+	switch obj.(type) {
+
+	case *models.Book:
 		return 200
 
-	case DefaultBadRequest:
+	case models.DefaultBadRequest:
 		return 400
-	case DefaultInternalError:
+	case models.DefaultInternalError:
 		return 500
 	default:
 		return -1
@@ -396,7 +408,7 @@ func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r
 		logger.FromContext(ctx).AddContext("error", err.Error())
 		statusCode := statusCodeForCreateBook(err)
 		if statusCode != -1 {
-			http.Error(w, respErr, statusCode)
+			http.Error(w, err.Error(), statusCode)
 		} else {
 			http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
 		}
@@ -435,17 +447,21 @@ func newCreateBookInput(r *http.Request) (*models.Book, error) {
 
 func statusCodeForGetBookByID2(obj interface{}) int {
 
-	switch t := obj.(type) {
+	if obj == nil {
+		return 200
+	}
 
-	case models.GetBookByID2200Output:
+	switch obj.(type) {
+
+	case *models.Book:
 		return 200
 
 	case models.GetBookByID2404Output:
 		return 404
 
-	case DefaultBadRequest:
+	case models.DefaultBadRequest:
 		return 400
-	case DefaultInternalError:
+	case models.DefaultInternalError:
 		return 500
 	default:
 		return -1
@@ -473,7 +489,7 @@ func (h handler) GetBookByID2Handler(ctx context.Context, w http.ResponseWriter,
 		logger.FromContext(ctx).AddContext("error", err.Error())
 		statusCode := statusCodeForGetBookByID2(err)
 		if statusCode != -1 {
-			http.Error(w, respErr, statusCode)
+			http.Error(w, err.Error(), statusCode)
 		} else {
 			http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
 		}
@@ -519,14 +535,15 @@ func newGetBookByID2Input(r *http.Request) (*models.GetBookByID2Input, error) {
 
 func statusCodeForHealthCheck(obj interface{}) int {
 
-	switch t := obj.(type) {
-
-	case models.HealthCheck200Output:
+	if obj == nil {
 		return 200
+	}
 
-	case DefaultBadRequest:
+	switch obj.(type) {
+
+	case models.DefaultBadRequest:
 		return 400
-	case DefaultInternalError:
+	case models.DefaultInternalError:
 		return 500
 	default:
 		return -1
@@ -540,14 +557,14 @@ func (h handler) HealthCheckHandler(ctx context.Context, w http.ResponseWriter, 
 		logger.FromContext(ctx).AddContext("error", err.Error())
 		statusCode := statusCodeForHealthCheck(err)
 		if statusCode != -1 {
-			http.Error(w, respErr, statusCode)
+			http.Error(w, err.Error(), statusCode)
 		} else {
 			http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
 		}
 		return
 	}
 
-	w.WriteHeader(statusCodeForHealthCheck(resp))
+	w.WriteHeader(statusCodeForHealthCheck(nil))
 	w.Write([]byte(""))
 
 }

--- a/gen-go/server/handlers.go
+++ b/gen-go/server/handlers.go
@@ -65,6 +65,21 @@ func jsonMarshalNoError(i interface{}) string {
 	}
 	return string(bytes)
 }
+func statusCodeForGetBooks(obj interface{}) int {
+
+	switch t := obj.(type) {
+
+	case models.GetBooks200Output:
+		return 200
+
+	case DefaultBadRequest:
+		return 400
+	case DefaultInternalError:
+		return 500
+	default:
+		return -1
+	}
+}
 func (h handler) GetBooksHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	input, err := newGetBooksInput(r)
@@ -84,12 +99,13 @@ func (h handler) GetBooksHandler(ctx context.Context, w http.ResponseWriter, r *
 	resp, err := h.GetBooks(ctx, input)
 
 	if err != nil {
-		if respErr, ok := err.(models.GetBooksError); ok {
-			http.Error(w, respErr.Error(), respErr.GetBooksStatusCode())
-			return
-		}
 		logger.FromContext(ctx).AddContext("error", err.Error())
-		http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
+		statusCode := statusCodeForGetBooks(err)
+		if statusCode != -1 {
+			http.Error(w, respErr, statusCode)
+		} else {
+			http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
+		}
 		return
 	}
 
@@ -101,7 +117,7 @@ func (h handler) GetBooksHandler(ctx context.Context, w http.ResponseWriter, r *
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(statusCodeForGetBooks(resp))
 	w.Write(respBytes)
 
 }
@@ -223,6 +239,30 @@ func newGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 	return &input, nil
 }
 
+func statusCodeForGetBookByID(obj interface{}) int {
+
+	switch t := obj.(type) {
+
+	case models.GetBookByID200Output:
+		return 200
+
+	case models.GetBookByID204Output:
+		return 204
+
+	case models.GetBookByID401Output:
+		return 401
+
+	case models.GetBookByID404Output:
+		return 404
+
+	case DefaultBadRequest:
+		return 400
+	case DefaultInternalError:
+		return 500
+	default:
+		return -1
+	}
+}
 func (h handler) GetBookByIDHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	input, err := newGetBookByIDInput(r)
@@ -242,12 +282,13 @@ func (h handler) GetBookByIDHandler(ctx context.Context, w http.ResponseWriter, 
 	resp, err := h.GetBookByID(ctx, input)
 
 	if err != nil {
-		if respErr, ok := err.(models.GetBookByIDError); ok {
-			http.Error(w, respErr.Error(), respErr.GetBookByIDStatusCode())
-			return
-		}
 		logger.FromContext(ctx).AddContext("error", err.Error())
-		http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
+		statusCode := statusCodeForGetBookByID(err)
+		if statusCode != -1 {
+			http.Error(w, respErr, statusCode)
+		} else {
+			http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
+		}
 		return
 	}
 
@@ -259,7 +300,7 @@ func (h handler) GetBookByIDHandler(ctx context.Context, w http.ResponseWriter, 
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(resp.GetBookByIDStatusCode())
+	w.WriteHeader(statusCodeForGetBookByID(resp))
 	w.Write(respBytes)
 
 }
@@ -318,6 +359,21 @@ func newGetBookByIDInput(r *http.Request) (*models.GetBookByIDInput, error) {
 	return &input, nil
 }
 
+func statusCodeForCreateBook(obj interface{}) int {
+
+	switch t := obj.(type) {
+
+	case models.CreateBook200Output:
+		return 200
+
+	case DefaultBadRequest:
+		return 400
+	case DefaultInternalError:
+		return 500
+	default:
+		return -1
+	}
+}
 func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	input, err := newCreateBookInput(r)
@@ -337,12 +393,13 @@ func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r
 	resp, err := h.CreateBook(ctx, input)
 
 	if err != nil {
-		if respErr, ok := err.(models.CreateBookError); ok {
-			http.Error(w, respErr.Error(), respErr.CreateBookStatusCode())
-			return
-		}
 		logger.FromContext(ctx).AddContext("error", err.Error())
-		http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
+		statusCode := statusCodeForCreateBook(err)
+		if statusCode != -1 {
+			http.Error(w, respErr, statusCode)
+		} else {
+			http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
+		}
 		return
 	}
 
@@ -354,7 +411,7 @@ func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(statusCodeForCreateBook(resp))
 	w.Write(respBytes)
 
 }
@@ -376,6 +433,24 @@ func newCreateBookInput(r *http.Request) (*models.Book, error) {
 	return &input, nil
 }
 
+func statusCodeForGetBookByID2(obj interface{}) int {
+
+	switch t := obj.(type) {
+
+	case models.GetBookByID2200Output:
+		return 200
+
+	case models.GetBookByID2404Output:
+		return 404
+
+	case DefaultBadRequest:
+		return 400
+	case DefaultInternalError:
+		return 500
+	default:
+		return -1
+	}
+}
 func (h handler) GetBookByID2Handler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	input, err := newGetBookByID2Input(r)
@@ -395,12 +470,13 @@ func (h handler) GetBookByID2Handler(ctx context.Context, w http.ResponseWriter,
 	resp, err := h.GetBookByID2(ctx, input)
 
 	if err != nil {
-		if respErr, ok := err.(models.GetBookByID2Error); ok {
-			http.Error(w, respErr.Error(), respErr.GetBookByID2StatusCode())
-			return
-		}
 		logger.FromContext(ctx).AddContext("error", err.Error())
-		http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
+		statusCode := statusCodeForGetBookByID2(err)
+		if statusCode != -1 {
+			http.Error(w, respErr, statusCode)
+		} else {
+			http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
+		}
 		return
 	}
 
@@ -412,7 +488,7 @@ func (h handler) GetBookByID2Handler(ctx context.Context, w http.ResponseWriter,
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(200)
+	w.WriteHeader(statusCodeForGetBookByID2(resp))
 	w.Write(respBytes)
 
 }
@@ -441,21 +517,37 @@ func newGetBookByID2Input(r *http.Request) (*models.GetBookByID2Input, error) {
 	return &input, nil
 }
 
+func statusCodeForHealthCheck(obj interface{}) int {
+
+	switch t := obj.(type) {
+
+	case models.HealthCheck200Output:
+		return 200
+
+	case DefaultBadRequest:
+		return 400
+	case DefaultInternalError:
+		return 500
+	default:
+		return -1
+	}
+}
 func (h handler) HealthCheckHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	err := h.HealthCheck(ctx)
 
 	if err != nil {
-		if respErr, ok := err.(models.HealthCheckError); ok {
-			http.Error(w, respErr.Error(), respErr.HealthCheckStatusCode())
-			return
-		}
 		logger.FromContext(ctx).AddContext("error", err.Error())
-		http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
+		statusCode := statusCodeForHealthCheck(err)
+		if statusCode != -1 {
+			http.Error(w, respErr, statusCode)
+		} else {
+			http.Error(w, jsonMarshalNoError(models.DefaultInternalError{Msg: err.Error()}), http.StatusInternalServerError)
+		}
 		return
 	}
 
-	w.WriteHeader(200)
+	w.WriteHeader(statusCodeForHealthCheck(resp))
 	w.Write([]byte(""))
 
 }

--- a/gen-go/server/router.go
+++ b/gen-go/server/router.go
@@ -77,6 +77,7 @@ func New(c Controller, addr string) *Server {
 		logger.FromContext(r.Context()).AddContext("op", "healthCheck")
 		h.HealthCheckHandler(r.Context(), w, r)
 	})
+
 	handler := withMiddleware("swagger-test", r)
 	return &Server{Handler: handler, addr: addr, l: l}
 }

--- a/models/genmodels.go
+++ b/models/genmodels.go
@@ -266,7 +266,6 @@ func generateErrorTypes(capOpID string, responses map[int]spec.Response) (string
 }
 
 func generateType(capOpID string, statusCode int, response spec.Response) (string, error) {
-	// outputName := swagger.TypeFromStatusCode(op, statusCode)
 	outputName := fmt.Sprintf("%s%dOutput", capOpID, statusCode)
 	typeName, err := swagger.TypeFromSchema(response.Schema, false)
 	if err != nil {

--- a/models/genmodels.go
+++ b/models/genmodels.go
@@ -251,12 +251,6 @@ func generateSuccessTypes(capOpID string, responses map[int]spec.Response) (stri
 
 func generateErrorTypes(capOpID string, responses map[int]spec.Response) (string, error) {
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("// %sError defines the error interface for %s.\n",
-		capOpID, capOpID))
-	buf.WriteString(fmt.Sprintf("type %sError interface {\n", capOpID))
-	buf.WriteString(fmt.Sprintf("\terror // Extend the error interface\n"))
-	buf.WriteString(fmt.Sprintf("\t%sStatusCode() int\n", capOpID))
-	buf.WriteString(fmt.Sprintf("}\n\n"))
 
 	for _, statusCode := range swagger.SortedStatusCodeKeys(responses) {
 
@@ -272,6 +266,7 @@ func generateErrorTypes(capOpID string, responses map[int]spec.Response) (string
 }
 
 func generateType(capOpID string, statusCode int, response spec.Response) (string, error) {
+	// outputName := swagger.TypeFromStatusCode(op, statusCode)
 	outputName := fmt.Sprintf("%s%dOutput", capOpID, statusCode)
 	typeName, err := swagger.TypeFromSchema(response.Schema, false)
 	if err != nil {
@@ -305,17 +300,16 @@ var typeTemplate = `
 	// {{.Output}} defines the {{.StatusCode}} status code response for {{.OpName}}.
 	type {{.Output}} {{.Type}}
 
-
-	// {{.OpName}}StatusCode returns the status code for the operation.
-	func (o {{.Output}}) {{.OpName}}StatusCode() int {
-		return {{.StatusCode}}
-	}
-
 	{{if .ErrorType}}
 	// Error returns "Status Code: X". We implemented in to satisfy the error
 	// interface. For a more descriptive error message see the output type.
 	func (o {{.Output}}) Error() string {
 		return "Status Code: {{.StatusCode}}"
+	}
+	{{else}}
+	// {{.OpName}}StatusCode returns the status code for the operation.
+	func (o {{.Output}}) {{.OpName}}StatusCode() int {
+		return {{.StatusCode}}
 	}
 	{{end}}
 `

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -274,6 +274,11 @@ func generateOperationHandler(op *spec.Operation) (string, error) {
 	for code, typeStr := range swagger.CodeToTypeMap(op) {
 		if typeStr != "" {
 			typeToCode[typeStr] = code
+			// Support non-pointer types too so that the implementer can
+			// return either (this is a bit icky)
+			if len(typeStr) > 0 && typeStr[0] == '*' {
+				typeToCode[typeStr[1:]] = code
+			}
 		} else {
 			emptyResponseCode = code
 		}

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -8,8 +8,7 @@ import (
 	"github.com/go-openapi/spec"
 
 	"github.com/Clever/wag/swagger"
-
-	"text/template"
+	"github.com/Clever/wag/templates"
 )
 
 // Generate server package for a swagger spec.
@@ -126,7 +125,7 @@ func generateRouter(packageName string, s spec.Swagger, paths *spec.Paths) error
 		}
 	}
 
-	routerCode, err := writeTemplate(routerTemplateStr, template)
+	routerCode, err := templates.WriteTemplate(routerTemplateStr, template)
 	if err != nil {
 		return err
 	}
@@ -181,7 +180,7 @@ func generateInterface(packageName string, serviceName string, paths *spec.Paths
 		}
 	}
 
-	interfaceCode, err := writeTemplate(interfaceTemplateStr, tmpl)
+	interfaceCode, err := templates.WriteTemplate(interfaceTemplateStr, tmpl)
 	if err != nil {
 		return err
 	}
@@ -255,7 +254,7 @@ func generateHandlers(packageName string, paths *spec.Paths) error {
 		}
 	}
 
-	handlerCode, err := writeTemplate(handlerFileTemplateStr, tmpl)
+	handlerCode, err := templates.WriteTemplate(handlerFileTemplateStr, tmpl)
 	if err != nil {
 		return err
 	}
@@ -289,7 +288,7 @@ func generateOperationHandler(op *spec.Operation) (string, error) {
 		EmptyStatusCode:    emptyResponseCode,
 		TypesToStatusCodes: typeToCode,
 	}
-	handlerCode, err := writeTemplate(handlerTemplate, handlerOp)
+	handlerCode, err := templates.WriteTemplate(handlerTemplate, handlerOp)
 	if err != nil {
 		return "", err
 	}
@@ -304,23 +303,6 @@ func generateOperationHandler(op *spec.Operation) (string, error) {
 	buf.WriteString(newInputCode)
 
 	return buf.String(), nil
-}
-
-// writeTemplate takes in the template and the definition of its variables
-// and returns a filled-out template.
-func writeTemplate(templateStr string, templateStruct interface{}) (string, error) {
-
-	tmpl, err := template.New("test").Parse(templateStr)
-	if err != nil {
-		return "", err
-	}
-
-	var tmpBuf bytes.Buffer
-	err = tmpl.Execute(&tmpBuf, templateStruct)
-	if err != nil {
-		return "", err
-	}
-	return tmpBuf.String(), nil
 }
 
 // handlerOp contains the template variables for the handlerTemplate

--- a/swagger/operation.go
+++ b/swagger/operation.go
@@ -2,23 +2,9 @@ package swagger
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/go-openapi/spec"
 )
-
-// SingleSchemaedBodyParameter returns true if the operation has a single,
-// schema'd body input. It also returns the name of the model (without "models.").
-func SingleSchemaedBodyParameter(op *spec.Operation) (bool, string) {
-	if len(op.Parameters) == 1 && op.Parameters[0].ParamProps.Schema != nil {
-		typ, err := TypeFromSchema(op.Parameters[0].ParamProps.Schema, false)
-		if err != nil {
-			panic(err)
-		}
-		return true, typ
-	}
-	return false, ""
-}
 
 // Interface returns the interface for an operation
 func Interface(op *spec.Operation) string {
@@ -60,13 +46,13 @@ func InterfaceComment(method, path string, op *spec.Operation) string {
 	return comment
 }
 
-// OutputType returns the output type for a given status code of an operation
-// TODO: Add explanation of second return argument
+// OutputType returns the output type for a given status code of an operation and whether it
+// is a pointer in the interface.
 func OutputType(op *spec.Operation, statusCode int) (string, bool) {
 	if NoSuccessType(op) {
 		return "", false
 	}
-	successCodes := SuccessStatusCodes(op)
+	successCodes := successStatusCodes(op)
 	if len(successCodes) == 1 && statusCode < 400 {
 		singleSchema := op.Responses.StatusCodeResponses[successCodes[0]].Schema
 		var err error
@@ -76,28 +62,17 @@ func OutputType(op *spec.Operation, statusCode int) (string, bool) {
 		}
 		return successType, singleSchema != nil && singleSchema.Ref.String() != ""
 	}
-	// Not sure I like the -1 magic number...
+	// This magic number is only used internally in this file. I will clean it up soon.
 	if statusCode == -1 {
 		return fmt.Sprintf("models.%sOutput", Capitalize(op.ID)), false
 	}
 	return fmt.Sprintf("models.%s%dOutput", Capitalize(op.ID), statusCode), false
 }
 
-// SuccessStatusCodes returns a slice of all the success status codes for an operation
-func SuccessStatusCodes(op *spec.Operation) []int {
-	var successCodes []int
-	for statusCode := range op.Responses.StatusCodeResponses {
-		if statusCode < 400 {
-			successCodes = append(successCodes, statusCode)
-		}
-	}
-	return successCodes
-}
-
 // NoSuccessType returns true if the operation has no-success response type. This includes
 // either no 200-399 response code or a 200-399 response code without a schema.
 func NoSuccessType(op *spec.Operation) bool {
-	successCodes := SuccessStatusCodes(op)
+	successCodes := successStatusCodes(op)
 	if len(successCodes) > 1 {
 		return false
 	}
@@ -120,43 +95,26 @@ func CodeToTypeMap(op *spec.Operation) map[int]string {
 	return resp
 }
 
-// TypeFromSchema returns the type of a Swagger schema as a string. If includeModels is true
-// then it returns models.TYPE
-func TypeFromSchema(schema *spec.Schema, includeModels bool) (string, error) {
-	// We support three types of schemas
-	// 1. An empty schema, which we represent by the empty struct
-	// 2. A schema with one element, the $ref key
-	// 3. A schema with two elements. One a type with value 'array' and another items field
-	// referencing the $ref
-	if schema == nil {
-		return "struct{}", nil
-	} else if schema.Ref.String() != "" {
-		ref := schema.Ref.String()
-		if !strings.HasPrefix(ref, "#/definitions/") {
-			return "", fmt.Errorf("schema.$ref has undefined reference type. Must start with #/definitions")
+// successStatusCodes returns a slice of all the success status codes for an operation
+func successStatusCodes(op *spec.Operation) []int {
+	var successCodes []int
+	for statusCode := range op.Responses.StatusCodeResponses {
+		if statusCode < 400 {
+			successCodes = append(successCodes, statusCode)
 		}
-		def := ref[len("#/definitions/"):]
-		if includeModels {
-			def = "models." + def
-		}
-		return def, nil
-	} else {
-		schemaType := schema.Type
-		if len(schemaType) != 1 || schemaType[0] != "array" {
-			return "", fmt.Errorf("Two element schemas must have a 'type' field with the value 'array'")
-		}
-		items := schema.Items
-		if items == nil || items.Schema == nil {
-			return "", fmt.Errorf("Two element schemas must have a '$ref' field in the 'items' descriptions")
-		}
-		ref := items.Schema.Ref.String()
-		if !strings.HasPrefix(ref, "#/definitions/") {
-			return "", fmt.Errorf("schema.$ref has undefined reference type. Must start with #/definitions")
-		}
-		def := ref[len("#/definitions/"):]
-		if includeModels {
-			def = "models." + def
-		}
-		return "[]" + def, nil
 	}
+	return successCodes
+}
+
+// SingleSchemaedBodyParameter returns true if the operation has a single,
+// schema'd body input. It also returns the name of the model (without "models.").
+func SingleSchemaedBodyParameter(op *spec.Operation) (bool, string) {
+	if len(op.Parameters) == 1 && op.Parameters[0].ParamProps.Schema != nil {
+		typ, err := TypeFromSchema(op.Parameters[0].ParamProps.Schema, false)
+		if err != nil {
+			panic(err)
+		}
+		return true, typ
+	}
+	return false, ""
 }

--- a/swagger/operation.go
+++ b/swagger/operation.go
@@ -111,6 +111,22 @@ func NoSuccessType(op *spec.Operation) bool {
 	return op.Responses.StatusCodeResponses[successCodes[0]].Schema == nil
 }
 
+// TypeToStatusCodeMap returns a map from type name to status code for an operation
+func TypeToStatusCodeMap(op *spec.Operation) map[string]int {
+
+	resp := make(map[string]int)
+	for _, statusCode := range SortedStatusCodeKeys(op.Responses.StatusCodeResponses) {
+		resp[TypeFromStatusCode(op, statusCode)] = statusCode
+	}
+	return resp
+}
+
+// TypeFromStatusCode returns the type string from the status code for an operation
+func TypeFromStatusCode(op *spec.Operation, statusCode int) string {
+	// TODO: Think about this models thing...
+	return fmt.Sprintf("models.%s%dOutput", Capitalize(op.ID), statusCode)
+}
+
 // TypeFromSchema returns the type of a Swagger schema as a string. If includeModels is true
 // then it returns models.TYPE
 func TypeFromSchema(schema *spec.Schema, includeModels bool) (string, error) {

--- a/swagger/operation.go
+++ b/swagger/operation.go
@@ -66,7 +66,7 @@ func OutputType(op *spec.Operation, statusCode int) (string, bool) {
 	if statusCode == -1 {
 		return fmt.Sprintf("models.%sOutput", Capitalize(op.ID)), false
 	}
-	return fmt.Sprintf("models.%s%dOutput", Capitalize(op.ID), statusCode), false
+	return fmt.Sprintf("models.%s%dOutput", Capitalize(op.ID), statusCode), true
 }
 
 // NoSuccessType returns true if the operation has no-success response type. This includes

--- a/swagger/types.go
+++ b/swagger/types.go
@@ -1,0 +1,49 @@
+package swagger
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-openapi/spec"
+)
+
+// TypeFromSchema returns the type of a Swagger schema as a string. If includeModels is true
+// then it returns models.TYPE
+func TypeFromSchema(schema *spec.Schema, includeModels bool) (string, error) {
+	// We support three types of schemas
+	// 1. An empty schema, which we represent by the empty struct
+	// 2. A schema with one element, the $ref key
+	// 3. A schema with two elements. One a type with value 'array' and another items field
+	// referencing the $ref
+	if schema == nil {
+		return "struct{}", nil
+	} else if schema.Ref.String() != "" {
+		ref := schema.Ref.String()
+		if !strings.HasPrefix(ref, "#/definitions/") {
+			return "", fmt.Errorf("schema.$ref has undefined reference type. Must start with #/definitions")
+		}
+		def := ref[len("#/definitions/"):]
+		if includeModels {
+			def = "models." + def
+		}
+		return def, nil
+	} else {
+		schemaType := schema.Type
+		if len(schemaType) != 1 || schemaType[0] != "array" {
+			return "", fmt.Errorf("Two element schemas must have a 'type' field with the value 'array'")
+		}
+		items := schema.Items
+		if items == nil || items.Schema == nil {
+			return "", fmt.Errorf("Two element schemas must have a '$ref' field in the 'items' descriptions")
+		}
+		ref := items.Schema.Ref.String()
+		if !strings.HasPrefix(ref, "#/definitions/") {
+			return "", fmt.Errorf("schema.$ref has undefined reference type. Must start with #/definitions")
+		}
+		def := ref[len("#/definitions/"):]
+		if includeModels {
+			def = "models." + def
+		}
+		return "[]" + def, nil
+	}
+}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -1,0 +1,23 @@
+package templates
+
+import (
+	"bytes"
+	"text/template"
+)
+
+// WriteTemplate takes in the template and the definition of its variables
+// and returns a filled-out template.
+func WriteTemplate(templateStr string, templateStruct interface{}) (string, error) {
+
+	tmpl, err := template.New("test").Parse(templateStr)
+	if err != nil {
+		return "", err
+	}
+
+	var tmpBuf bytes.Buffer
+	err = tmpl.Execute(&tmpBuf, templateStruct)
+	if err != nil {
+		return "", err
+	}
+	return tmpBuf.String(), nil
+}

--- a/test/sample_server.go
+++ b/test/sample_server.go
@@ -25,6 +25,11 @@ func (c *ControllerImpl) GetBooks(ctx context.Context, input *models.GetBooksInp
 
 // GetBookByID returns a book by ID.
 func (c *ControllerImpl) GetBookByID(ctx context.Context, input *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
+	if input.BookID == 400 {
+		// TODO: Don't force this...
+		return nil, models.DefaultBadRequest{Msg: "{\"msg\" : \"400 means failure\"}"}
+	}
+
 	book, ok := c.books[input.BookID]
 	if !ok {
 		return nil, models.GetBookByID404Output{}

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -75,6 +75,18 @@ func TestUserDefinedErrorResponse(t *testing.T) {
 	assert.True(t, ok)
 }
 
+func TestDefaultErroResponse(t *testing.T) {
+	s := setupServer()
+
+	c := client.New(s.URL)
+
+	_, err := c.GetBookByID(context.Background(), &models.GetBookByIDInput{BookID: 400})
+	assert.Error(t, err)
+	fmt.Printf("ERROR: %T\n", err)
+	_, ok := err.(models.DefaultBadRequest)
+	assert.True(t, ok)
+}
+
 func TestValidationErrorResponse(t *testing.T) {
 	s := setupServer()
 	c := client.New(s.URL)


### PR DESCRIPTION
https://clever.atlassian.net/browse/CREW-41 for context.

This change does a couple things:
- It removes the error interface
- It changes the way we get status codes in the handler code
- It consolidates a bit of the

In the process of doing this change, I decided that we should clean up the way we access operation data. Right now we have a fair number of special cases strewn throughout the code. I didn't want to do that in this change to make it manageable, but will add a follow-up change.