### PR TITLE
Encapsulate logic out of actual code generation (part 1)

### DIFF
--- a/client/genclients.go
+++ b/client/genclients.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-openapi/spec"
 
 	"github.com/Clever/wag/swagger"
+	"github.com/Clever/wag/templates"
 )
 
 // Generate generates a client
@@ -21,10 +22,16 @@ func Generate(packageName string, s spec.Swagger) error {
 	return nil
 }
 
-func generateClient(packageName string, s spec.Swagger) error {
-	g := swagger.Generator{PackageName: packageName}
+type clientCodeTemplate struct {
+	PackageName           string
+	ServiceName           string
+	FormattedServiceName  string
+	BaseParamToStringCode string
+	Methods               []string
+}
 
-	g.Printf(`package client
+var clientCodeTemplateStr = `
+package client
 
 import (
 		"context"
@@ -37,7 +44,7 @@ import (
 		"strconv"
 		"time"
 
-		"%s/models"
+		"{{.PackageName}}/models"
 
 		discovery "github.com/Clever/discovery-go"
 )
@@ -47,7 +54,7 @@ var _ = strings.Replace
 var _ = strconv.FormatInt
 var _ = bytes.Compare
 
-// WagClient is used to make requests to the %s service.
+// WagClient is used to make requests to the {{.ServiceName}} service.
 type WagClient struct {
 	basePath    string
 	requestDoer doer
@@ -71,9 +78,9 @@ func New(basePath string) *WagClient {
 }
 
 // NewFromDiscovery creates a client from the discovery environment variables. This method requires
-// the three env vars: SERVICE_%s_HTTP_(HOST/PORT/PROTO) to be set. Otherwise it returns an error.
+// the three env vars: SERVICE_{{.FormattedServiceName}}_HTTP_(HOST/PORT/PROTO) to be set. Otherwise it returns an error.
 func NewFromDiscovery() (*WagClient, error) {
-	url, err := discovery.URL("%s", "http")
+	url, err := discovery.URL("{{.ServiceName}}", "http")
 	if err != nil {
 		return nil, err
 	}
@@ -94,22 +101,39 @@ func (c *WagClient) WithTimeout(timeout time.Duration) *WagClient {
 	return c
 }
 
-`, packageName,
-		s.Info.InfoProps.Title,
-		strings.ToUpper(strings.Replace(s.Info.InfoProps.Title, "-", "_", -1)),
-		s.Info.InfoProps.Title)
+{{.BaseParamToStringCode}}
 
-	g.Printf(swagger.BaseParamToStringCode())
+{{range $methodCode := .Methods}}
+	{{$methodCode}}
+{{end}}
+
+`
+
+func generateClient(packageName string, s spec.Swagger) error {
+
+	codeTemplate := clientCodeTemplate{
+		PackageName:           packageName,
+		ServiceName:           s.Info.InfoProps.Title,
+		FormattedServiceName:  strings.ToUpper(strings.Replace(s.Info.InfoProps.Title, "-", "_", -1)),
+		BaseParamToStringCode: swagger.BaseParamToStringCode(),
+	}
 
 	for _, path := range swagger.SortedPathItemKeys(s.Paths.Paths) {
 		pathItem := s.Paths.Paths[path]
 		pathItemOps := swagger.PathItemOperations(pathItem)
 		for _, method := range swagger.SortedOperationsKeys(pathItemOps) {
 			op := pathItemOps[method]
-			g.Printf(methodCode(op, s.BasePath, method, path))
+			codeTemplate.Methods = append(codeTemplate.Methods, methodCode(op, s.BasePath, method, path))
 		}
 	}
 
+	clientCode, err := templates.WriteTemplate(clientCodeTemplateStr, codeTemplate)
+	if err != nil {
+		return err
+	}
+
+	g := swagger.Generator{PackageName: packageName}
+	g.Printf(clientCode)
 	return g.WriteFile("client/client.go")
 }
 

--- a/client/genclients.go
+++ b/client/genclients.go
@@ -274,97 +274,6 @@ func buildRequestCode(op *spec.Operation, method string) string {
 	return buf.String()
 }
 
-// parseResponseCode generates the code for handling the http response.
-// In the client code we want to return a different object depending on the status code, so
-// let's generate code that switches on the status code and returns the right object in each
-// case. This includes the default 400 and 500 cases.
-func parseResponseCode(op *spec.Operation, capOpID string) string {
-	var buf bytes.Buffer
-
-	buf.WriteString("\tswitch resp.StatusCode {\n")
-
-	noSuccessType := swagger.NoSuccessType(op)
-	for _, statusCode := range swagger.SortedStatusCodeKeys(op.Responses.StatusCodeResponses) {
-		response := op.Responses.StatusCodeResponses[statusCode]
-		outputName, _ := swagger.OutputType(op, statusCode)
-		buf.WriteString(fmt.Sprintf("\tcase %d:\n", statusCode))
-
-		if noSuccessType && statusCode < 400 {
-			buf.WriteString("\t\treturn nil\n")
-		} else if response.Schema == nil {
-			buf.WriteString(fmt.Sprintf("\t\tvar output %s\n", outputName))
-			if statusCode < 400 {
-				buf.WriteString("\t\treturn output, nil\n")
-			} else {
-				if noSuccessType {
-					buf.WriteString("\t\treturn output\n")
-				} else {
-					buf.WriteString("\t\treturn nil, output\n")
-				}
-			}
-		} else {
-			if statusCode < 400 {
-				pointer := "&"
-				// No pointer for array types (TODO: consider factoring this out...)
-				if response.Schema.Ref.String() == "" {
-					pointer = ""
-				}
-				buf.WriteString(fmt.Sprintf(successResponse(outputName, pointer)))
-			} else {
-				buf.WriteString(fmt.Sprintf("\t\treturn nil, %s{}\n", outputName))
-			}
-		}
-	}
-
-	if !swagger.NoSuccessType(op) {
-		buf.WriteString(`
-	case 400:
-		var output models.DefaultBadRequest
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
-			return nil, models.DefaultInternalError{Msg: err.Error()}
-		}
-		return nil, output
-
-	case 500:
-		var output models.DefaultInternalError
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
-			return nil, models.DefaultInternalError{Msg: err.Error()}
-		}
-		return nil, output
-
-	default:
-		return nil, models.DefaultInternalError{Msg: "Unknown response"}
-	}
-}
-
-`)
-	} else {
-		buf.WriteString(`
-	case 400:
-		var output models.DefaultBadRequest
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
-			return models.DefaultInternalError{Msg: err.Error()}
-		}
-		return output
-
-	case 500:
-		var output models.DefaultInternalError
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
-			return models.DefaultInternalError{Msg: err.Error()}
-		}
-		return output
-
-	default:
-		return models.DefaultInternalError{Msg: "Unknown response"}
-	}
-}
-
-`)
-	}
-
-	return buf.String()
-}
-
 func errorMessage(err string, op *spec.Operation) string {
 	if swagger.NoSuccessType(op) {
 		return fmt.Sprintf(`
@@ -380,12 +289,119 @@ func errorMessage(err string, op *spec.Operation) string {
 `, err)
 }
 
-func successResponse(outputName, pointer string) string {
-	return fmt.Sprintf(`
-		var output %s
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
-			return nil, models.DefaultInternalError{Msg: err.Error()}
+// TODO: Add a nice comment and ultimately move this to the (maybe an interface object with all
+// this...)
+// Response:
+//   success
+//   failure
+//   decode
+//   makePointer
+// TODO: make this into a struct
+// TODO: Change this to a list of return values??? (have 2 cases, nil and a type...)
+func pair(op *spec.Operation, statusCode int) (string, string, bool, bool) {
+
+	noSuccessType := swagger.NoSuccessType(op)
+	successReturn := "nil"
+	if noSuccessType {
+		successReturn = ""
+	}
+	if statusCode == 400 {
+		return successReturn, "models.DefaultBadRequest", true, false
+	} else if statusCode == 500 {
+		return successReturn, "models.DefaultInternalError", true, false
+	}
+
+	response := op.Responses.StatusCodeResponses[statusCode]
+	outputName, makePointer := swagger.OutputType(op, statusCode)
+	if noSuccessType && statusCode < 400 {
+		return "", "nil", false, false
+	} else if response.Schema == nil {
+		if statusCode < 400 {
+			return outputName, "nil", false, false
 		}
-		return %soutput, nil
-`, outputName, pointer)
+		// TODO: Understand this case...
+		if noSuccessType {
+			return outputName, "nil", false, false
+		}
+		return "nil", outputName, false, false
+	}
+	if statusCode < 400 {
+		return outputName, "nil", true, makePointer
+	}
+	return "nil", fmt.Sprintf("%s", outputName), false, false
+}
+
+// parseResponseCode generates the code for handling the http response.
+// In the client code we want to return a different object depending on the status code, so
+// let's generate code that switches on the status code and returns the right object in each
+// case. This includes the default 400 and 500 cases.
+func parseResponseCode(op *spec.Operation, capOpID string) string {
+	var buf bytes.Buffer
+
+	buf.WriteString("\tswitch resp.StatusCode {\n")
+
+	for _, statusCode := range swagger.SortedStatusCodeKeys(op.Responses.StatusCodeResponses) {
+		buf.WriteString(writeStatusCodeDecoder(op, statusCode))
+	}
+
+	buf.WriteString(writeStatusCodeDecoder(op, 400))
+	buf.WriteString(writeStatusCodeDecoder(op, 500))
+
+	// It would be nice if we could remove this too
+	noSuccessType := swagger.NoSuccessType(op)
+	successReturn := "nil, "
+	if noSuccessType {
+		successReturn = ""
+	}
+
+	buf.WriteString(fmt.Sprintf(`
+	default:
+		return %smodels.DefaultInternalError{Msg: "Unknown response"}
+	}
+}
+
+`, successReturn))
+
+	return buf.String()
+}
+
+func writeStatusCodeDecoder(op *spec.Operation, statusCode int) string {
+	var buf bytes.Buffer
+	success, failure, decode, makePointer := pair(op, statusCode)
+
+	buf.WriteString(fmt.Sprintf("\tcase %d:\n", statusCode))
+
+	if success != "" && success != "nil" {
+		buf.WriteString(fmt.Sprintf("var output %s\n", success))
+	} else if failure != "" && failure != "nil" {
+		buf.WriteString(fmt.Sprintf("var output %s\n", failure))
+	}
+	if decode {
+		nilString := ""
+		if success != "" {
+			nilString = "nil, "
+		}
+		buf.WriteString(fmt.Sprintf(`
+
+	if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
+		return %smodels.DefaultInternalError{Msg: err.Error()}
+	}
+
+`, nilString))
+
+	}
+	if success != "" && success != "nil" {
+		if makePointer {
+			buf.WriteString("return &output, nil\n")
+		} else {
+			buf.WriteString("return output, nil\n")
+		}
+	} else {
+		if success == "" {
+			buf.WriteString("return output\n")
+		} else {
+			buf.WriteString("return nil, output\n")
+		}
+	}
+	return buf.String()
 }

--- a/gen-go/client/client.go
+++ b/gen-go/client/client.go
@@ -447,7 +447,7 @@ func (c *WagClient) HealthCheck(ctx context.Context) error {
 	defer resp.Body.Close()
 	switch resp.StatusCode {
 	case 200:
-		return output
+		return nil
 	case 400:
 		var output models.DefaultBadRequest
 

--- a/gen-go/client/client.go
+++ b/gen-go/client/client.go
@@ -235,7 +235,7 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
 
-		return output, nil
+		return &output, nil
 	case 204:
 		var output models.GetBookByID204Output
 		return output, nil

--- a/gen-go/client/client.go
+++ b/gen-go/client/client.go
@@ -153,25 +153,28 @@ func (c *WagClient) GetBooks(ctx context.Context, i *models.GetBooksInput) ([]mo
 	defer resp.Body.Close()
 	switch resp.StatusCode {
 	case 200:
-
 		var output []models.Book
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
-		return output, nil
 
+		return output, nil
 	case 400:
 		var output models.DefaultBadRequest
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
-		return nil, output
 
+		return nil, output
 	case 500:
 		var output models.DefaultInternalError
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
+
 		return nil, output
 
 	default:
@@ -226,12 +229,13 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 	defer resp.Body.Close()
 	switch resp.StatusCode {
 	case 200:
-
 		var output models.GetBookByID200Output
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
-		return &output, nil
+
+		return output, nil
 	case 204:
 		var output models.GetBookByID204Output
 		return output, nil
@@ -239,20 +243,23 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 		var output models.GetBookByID401Output
 		return nil, output
 	case 404:
-		return nil, models.GetBookByID404Output{}
-
+		var output models.GetBookByID404Output
+		return nil, output
 	case 400:
 		var output models.DefaultBadRequest
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
-		return nil, output
 
+		return nil, output
 	case 500:
 		var output models.DefaultInternalError
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
+
 		return nil, output
 
 	default:
@@ -307,25 +314,28 @@ func (c *WagClient) CreateBook(ctx context.Context, i *models.Book) (*models.Boo
 	defer resp.Body.Close()
 	switch resp.StatusCode {
 	case 200:
-
 		var output models.Book
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
-		return &output, nil
 
+		return &output, nil
 	case 400:
 		var output models.DefaultBadRequest
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
-		return nil, output
 
+		return nil, output
 	case 500:
 		var output models.DefaultInternalError
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
+
 		return nil, output
 
 	default:
@@ -370,28 +380,31 @@ func (c *WagClient) GetBookByID2(ctx context.Context, i *models.GetBookByID2Inpu
 	defer resp.Body.Close()
 	switch resp.StatusCode {
 	case 200:
-
 		var output models.Book
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
+
 		return &output, nil
 	case 404:
 		var output models.GetBookByID2404Output
 		return nil, output
-
 	case 400:
 		var output models.DefaultBadRequest
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
-		return nil, output
 
+		return nil, output
 	case 500:
 		var output models.DefaultInternalError
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, models.DefaultInternalError{Msg: err.Error()}
 		}
+
 		return nil, output
 
 	default:
@@ -434,20 +447,22 @@ func (c *WagClient) HealthCheck(ctx context.Context) error {
 	defer resp.Body.Close()
 	switch resp.StatusCode {
 	case 200:
-		return nil
-
+		return output
 	case 400:
 		var output models.DefaultBadRequest
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return models.DefaultInternalError{Msg: err.Error()}
 		}
-		return output
 
+		return output
 	case 500:
 		var output models.DefaultInternalError
+
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return models.DefaultInternalError{Msg: err.Error()}
 		}
+
 		return output
 
 	default:

--- a/gen-go/server/handlers.go
+++ b/gen-go/server/handlers.go
@@ -83,6 +83,7 @@ func statusCodeForGetBooks(obj interface{}) int {
 		return -1
 	}
 }
+
 func (h handler) GetBooksHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	input, err := newGetBooksInput(r)
@@ -268,6 +269,7 @@ func statusCodeForGetBookByID(obj interface{}) int {
 		return -1
 	}
 }
+
 func (h handler) GetBookByIDHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	input, err := newGetBookByIDInput(r)
@@ -381,6 +383,7 @@ func statusCodeForCreateBook(obj interface{}) int {
 		return -1
 	}
 }
+
 func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	input, err := newCreateBookInput(r)
@@ -460,6 +463,7 @@ func statusCodeForGetBookByID2(obj interface{}) int {
 		return -1
 	}
 }
+
 func (h handler) GetBookByID2Handler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	input, err := newGetBookByID2Input(r)
@@ -540,6 +544,7 @@ func statusCodeForHealthCheck(obj interface{}) int {
 		return -1
 	}
 }
+
 func (h handler) HealthCheckHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	err := h.HealthCheck(ctx)

--- a/gen-go/server/handlers.go
+++ b/gen-go/server/handlers.go
@@ -249,6 +249,18 @@ func statusCodeForGetBookByID(obj interface{}) int {
 
 	switch obj.(type) {
 
+	case *models.GetBookByID200Output:
+		return 200
+
+	case *models.GetBookByID204Output:
+		return 204
+
+	case *models.GetBookByID401Output:
+		return 401
+
+	case *models.GetBookByID404Output:
+		return 404
+
 	case models.GetBookByID200Output:
 		return 200
 
@@ -375,6 +387,9 @@ func statusCodeForCreateBook(obj interface{}) int {
 	case *models.Book:
 		return 200
 
+	case models.Book:
+		return 200
+
 	case models.DefaultBadRequest:
 		return 400
 	case models.DefaultInternalError:
@@ -450,6 +465,12 @@ func statusCodeForGetBookByID2(obj interface{}) int {
 	switch obj.(type) {
 
 	case *models.Book:
+		return 200
+
+	case *models.GetBookByID2404Output:
+		return 404
+
+	case models.Book:
 		return 200
 
 	case models.GetBookByID2404Output:

--- a/gen-go/server/router.go
+++ b/gen-go/server/router.go
@@ -77,6 +77,7 @@ func New(c Controller, addr string) *Server {
 		logger.FromContext(r.Context()).AddContext("op", "healthCheck")
 		h.HealthCheckHandler(r.Context(), w, r)
 	})
+
 	handler := withMiddleware("swagger-test", r)
 	return &Server{Handler: handler, addr: addr, l: l}
 }

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -274,6 +274,11 @@ func generateOperationHandler(op *spec.Operation) (string, error) {
 	for code, typeStr := range swagger.CodeToTypeMap(op) {
 		if typeStr != "" {
 			typeToCode[typeStr] = code
+			// Support non-pointer types too so that the implementer can
+			// return either (this is a bit icky)
+			if len(typeStr) > 0 && typeStr[0] == '*' {
+				typeToCode[typeStr[1:]] = code
+			}
 		} else {
 			emptyResponseCode = code
 		}

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -8,8 +8,7 @@ import (
 	"github.com/go-openapi/spec"
 
 	"github.com/Clever/wag/swagger"
-
-	"text/template"
+	"github.com/Clever/wag/templates"
 )
 
 // Generate server package for a swagger spec.
@@ -126,7 +125,7 @@ func generateRouter(packageName string, s spec.Swagger, paths *spec.Paths) error
 		}
 	}
 
-	routerCode, err := writeTemplate(routerTemplateStr, template)
+	routerCode, err := templates.WriteTemplate(routerTemplateStr, template)
 	if err != nil {
 		return err
 	}
@@ -181,7 +180,7 @@ func generateInterface(packageName string, serviceName string, paths *spec.Paths
 		}
 	}
 
-	interfaceCode, err := writeTemplate(interfaceTemplateStr, tmpl)
+	interfaceCode, err := templates.WriteTemplate(interfaceTemplateStr, tmpl)
 	if err != nil {
 		return err
 	}
@@ -255,7 +254,7 @@ func generateHandlers(packageName string, paths *spec.Paths) error {
 		}
 	}
 
-	handlerCode, err := writeTemplate(handlerFileTemplateStr, tmpl)
+	handlerCode, err := templates.WriteTemplate(handlerFileTemplateStr, tmpl)
 	if err != nil {
 		return err
 	}
@@ -289,7 +288,7 @@ func generateOperationHandler(op *spec.Operation) (string, error) {
 		EmptyStatusCode:    emptyResponseCode,
 		TypesToStatusCodes: typeToCode,
 	}
-	handlerCode, err := writeTemplate(handlerTemplate, handlerOp)
+	handlerCode, err := templates.WriteTemplate(handlerTemplate, handlerOp)
 	if err != nil {
 		return "", err
 	}
@@ -304,23 +303,6 @@ func generateOperationHandler(op *spec.Operation) (string, error) {
 	buf.WriteString(newInputCode)
 
 	return buf.String(), nil
-}
-
-// writeTemplate takes in the template and the definition of its variables
-// and returns a filled-out template.
-func writeTemplate(templateStr string, templateStruct interface{}) (string, error) {
-
-	tmpl, err := template.New("test").Parse(templateStr)
-	if err != nil {
-		return "", err
-	}
-
-	var tmpBuf bytes.Buffer
-	err = tmpl.Execute(&tmpBuf, templateStruct)
-	if err != nil {
-		return "", err
-	}
-	return tmpBuf.String(), nil
 }
 
 // handlerOp contains the template variables for the handlerTemplate

--- a/swagger/operation.go
+++ b/swagger/operation.go
@@ -66,7 +66,7 @@ func OutputType(op *spec.Operation, statusCode int) (string, bool) {
 	if statusCode == -1 {
 		return fmt.Sprintf("models.%sOutput", Capitalize(op.ID)), false
 	}
-	return fmt.Sprintf("models.%s%dOutput", Capitalize(op.ID), statusCode), false
+	return fmt.Sprintf("models.%s%dOutput", Capitalize(op.ID), statusCode), true
 }
 
 // NoSuccessType returns true if the operation has no-success response type. This includes

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -1,0 +1,23 @@
+package templates
+
+import (
+	"bytes"
+	"text/template"
+)
+
+// WriteTemplate takes in the template and the definition of its variables
+// and returns a filled-out template.
+func WriteTemplate(templateStr string, templateStruct interface{}) (string, error) {
+
+	tmpl, err := template.New("test").Parse(templateStr)
+	if err != nil {
+		return "", err
+	}
+
+	var tmpBuf bytes.Buffer
+	err = tmpl.Execute(&tmpBuf, templateStruct)
+	if err != nil {
+		return "", err
+	}
+	return tmpBuf.String(), nil
+}


### PR DESCRIPTION
This change starts the process of simplifying the code generation logic. We had (and still have) a lot of code that generates code based on complex analysis of the swagger operation type. Since all this logic isn't cleanly abstracted the code can be fairly hard to change. It's gotten to the point that I think it's worth refactoring.

This change has two major parts:
1. I started moving a lot more code into templates. I want to do this both because templates are fairly easy to read and also because I want to start tearing out most of the logic from the templates. Ideally the code-generation's goal is just conversion and not logic about things like which arguments should be pointers - and moving this to templates makes it more obvious when this isn't true.

2. Following the first, I want to start having most of the code never interact directly with a *swag.Operation object. If we move that behind an interface it will limit what the rest of the code can do, hopefully making it easier to maintain.

More changes are coming. I didn't have any particular reason for dividing up the change here other than this is what I could get done this afternoon.