### PR TITLE
Validation fixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ func main() {
 	}
 	swaggerSpec := *doc.Spec()
 
-	if err := validation.Validate(swaggerSpec); err != nil {
+	if err := validation.Validate(*doc); err != nil {
 		log.Fatalf("Swagger file not valid: %s", err)
 	}
 

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -184,6 +184,82 @@ func (c *WagClient) GetBooks(ctx context.Context, i *models.GetBooksInput) ([]mo
 	}
 }
 
+// CreateBook makes a POST request to /books.
+// Creates a book
+func (c *WagClient) CreateBook(ctx context.Context, i *models.Book) (*models.Book, error) {
+	path := c.basePath + "/v1/books"
+	urlVals := url.Values{}
+	var body []byte
+
+	path = path + "?" + urlVals.Encode()
+
+	if i != nil {
+
+		var err error
+		body, err = json.Marshal(i)
+
+		if err != nil {
+			return nil, err
+		}
+
+	}
+
+	client := &http.Client{Transport: c.transport}
+	req, err := http.NewRequest("POST", path, bytes.NewBuffer(body))
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Add the opname for doers like tracing
+	ctx = context.WithValue(ctx, opNameCtx{}, "createBook")
+	req = req.WithContext(ctx)
+	// Don't add the timeout in a "doer" because we don't want to call "defer.cancel()"
+	// until we've finished all the processing of the request object. Otherwise we'll cancel
+	// our own request before we've finished it.
+	if c.defaultTimeout != 0 {
+		ctx, cancel := context.WithTimeout(req.Context(), c.defaultTimeout)
+		defer cancel()
+		req = req.WithContext(ctx)
+	}
+	resp, err := c.requestDoer.Do(client, req)
+
+	if err != nil {
+		return nil, models.DefaultInternalError{Msg: err.Error()}
+	}
+
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case 200:
+		var output models.Book
+
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
+			return nil, models.DefaultInternalError{Msg: err.Error()}
+		}
+
+		return &output, nil
+	case 400:
+		var output models.DefaultBadRequest
+
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
+			return nil, models.DefaultInternalError{Msg: err.Error()}
+		}
+
+		return nil, output
+	case 500:
+		var output models.DefaultInternalError
+
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
+			return nil, models.DefaultInternalError{Msg: err.Error()}
+		}
+
+		return nil, output
+
+	default:
+		return nil, models.DefaultInternalError{Msg: "Unknown response"}
+	}
+}
+
 // GetBookByID makes a GET request to /books/{book_id}.
 // Returns a book
 func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
@@ -269,86 +345,10 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 	}
 }
 
-// CreateBook makes a POST request to /books/{book_id}.
-// Creates a book
-func (c *WagClient) CreateBook(ctx context.Context, i *models.Book) (*models.Book, error) {
-	path := c.basePath + "/v1/books/{book_id}"
-	urlVals := url.Values{}
-	var body []byte
-
-	path = path + "?" + urlVals.Encode()
-
-	if i != nil {
-
-		var err error
-		body, err = json.Marshal(i)
-
-		if err != nil {
-			return nil, err
-		}
-
-	}
-
-	client := &http.Client{Transport: c.transport}
-	req, err := http.NewRequest("POST", path, bytes.NewBuffer(body))
-
-	if err != nil {
-		return nil, err
-	}
-
-	// Add the opname for doers like tracing
-	ctx = context.WithValue(ctx, opNameCtx{}, "createBook")
-	req = req.WithContext(ctx)
-	// Don't add the timeout in a "doer" because we don't want to call "defer.cancel()"
-	// until we've finished all the processing of the request object. Otherwise we'll cancel
-	// our own request before we've finished it.
-	if c.defaultTimeout != 0 {
-		ctx, cancel := context.WithTimeout(req.Context(), c.defaultTimeout)
-		defer cancel()
-		req = req.WithContext(ctx)
-	}
-	resp, err := c.requestDoer.Do(client, req)
-
-	if err != nil {
-		return nil, models.DefaultInternalError{Msg: err.Error()}
-	}
-
-	defer resp.Body.Close()
-	switch resp.StatusCode {
-	case 200:
-		var output models.Book
-
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
-			return nil, models.DefaultInternalError{Msg: err.Error()}
-		}
-
-		return &output, nil
-	case 400:
-		var output models.DefaultBadRequest
-
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
-			return nil, models.DefaultInternalError{Msg: err.Error()}
-		}
-
-		return nil, output
-	case 500:
-		var output models.DefaultInternalError
-
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
-			return nil, models.DefaultInternalError{Msg: err.Error()}
-		}
-
-		return nil, output
-
-	default:
-		return nil, models.DefaultInternalError{Msg: "Unknown response"}
-	}
-}
-
-// GetBookByID2 makes a GET request to /books/{id}.
+// GetBookByID2 makes a GET request to /books2/{id}.
 // Retrieve a book
 func (c *WagClient) GetBookByID2(ctx context.Context, i *models.GetBookByID2Input) (*models.Book, error) {
-	path := c.basePath + "/v1/books/{id}"
+	path := c.basePath + "/v1/books2/{id}"
 	urlVals := url.Values{}
 	var body []byte
 

--- a/samples/gen-go/client/interface.go
+++ b/samples/gen-go/client/interface.go
@@ -15,15 +15,15 @@ type Client interface {
 	// Returns a list of books
 	GetBooks(ctx context.Context, i *models.GetBooksInput) ([]models.Book, error)
 
+	// CreateBook makes a POST request to /books.
+	// Creates a book
+	CreateBook(ctx context.Context, i *models.Book) (*models.Book, error)
+
 	// GetBookByID makes a GET request to /books/{book_id}.
 	// Returns a book
 	GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (models.GetBookByIDOutput, error)
 
-	// CreateBook makes a POST request to /books/{book_id}.
-	// Creates a book
-	CreateBook(ctx context.Context, i *models.Book) (*models.Book, error)
-
-	// GetBookByID2 makes a GET request to /books/{id}.
+	// GetBookByID2 makes a GET request to /books2/{id}.
 	// Retrieve a book
 	GetBookByID2(ctx context.Context, i *models.GetBookByID2Input) (*models.Book, error)
 

--- a/samples/gen-go/client/mock_client.go
+++ b/samples/gen-go/client/mock_client.go
@@ -41,17 +41,6 @@ func (_mr *_MockClientRecorder) GetBooks(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetBooks", arg0, arg1)
 }
 
-func (_m *MockClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
-	ret := _m.ctrl.Call(_m, "GetBookByID", ctx, i)
-	ret0, _ := ret[0].(models.GetBookByIDOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockClientRecorder) GetBookByID(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetBookByID", arg0, arg1)
-}
-
 func (_m *MockClient) CreateBook(ctx context.Context, i *models.Book) (*models.Book, error) {
 	ret := _m.ctrl.Call(_m, "CreateBook", ctx, i)
 	ret0, _ := ret[0].(*models.Book)
@@ -61,6 +50,17 @@ func (_m *MockClient) CreateBook(ctx context.Context, i *models.Book) (*models.B
 
 func (_mr *_MockClientRecorder) CreateBook(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateBook", arg0, arg1)
+}
+
+func (_m *MockClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
+	ret := _m.ctrl.Call(_m, "GetBookByID", ctx, i)
+	ret0, _ := ret[0].(models.GetBookByIDOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockClientRecorder) GetBookByID(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetBookByID", arg0, arg1)
 }
 
 func (_m *MockClient) GetBookByID2(ctx context.Context, i *models.GetBookByID2Input) (*models.Book, error) {

--- a/samples/gen-go/server/interface.go
+++ b/samples/gen-go/server/interface.go
@@ -15,15 +15,15 @@ type Controller interface {
 	// Returns a list of books
 	GetBooks(ctx context.Context, i *models.GetBooksInput) ([]models.Book, error)
 
+	// CreateBook makes a POST request to /books.
+	// Creates a book
+	CreateBook(ctx context.Context, i *models.Book) (*models.Book, error)
+
 	// GetBookByID makes a GET request to /books/{book_id}.
 	// Returns a book
 	GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (models.GetBookByIDOutput, error)
 
-	// CreateBook makes a POST request to /books/{book_id}.
-	// Creates a book
-	CreateBook(ctx context.Context, i *models.Book) (*models.Book, error)
-
-	// GetBookByID2 makes a GET request to /books/{id}.
+	// GetBookByID2 makes a GET request to /books2/{id}.
 	// Retrieve a book
 	GetBookByID2(ctx context.Context, i *models.GetBookByID2Input) (*models.Book, error)
 

--- a/samples/gen-go/server/mock_controller.go
+++ b/samples/gen-go/server/mock_controller.go
@@ -41,17 +41,6 @@ func (_mr *_MockControllerRecorder) GetBooks(arg0, arg1 interface{}) *gomock.Cal
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetBooks", arg0, arg1)
 }
 
-func (_m *MockController) GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
-	ret := _m.ctrl.Call(_m, "GetBookByID", ctx, i)
-	ret0, _ := ret[0].(models.GetBookByIDOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-func (_mr *_MockControllerRecorder) GetBookByID(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetBookByID", arg0, arg1)
-}
-
 func (_m *MockController) CreateBook(ctx context.Context, i *models.Book) (*models.Book, error) {
 	ret := _m.ctrl.Call(_m, "CreateBook", ctx, i)
 	ret0, _ := ret[0].(*models.Book)
@@ -61,6 +50,17 @@ func (_m *MockController) CreateBook(ctx context.Context, i *models.Book) (*mode
 
 func (_mr *_MockControllerRecorder) CreateBook(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "CreateBook", arg0, arg1)
+}
+
+func (_m *MockController) GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
+	ret := _m.ctrl.Call(_m, "GetBookByID", ctx, i)
+	ret0, _ := ret[0].(models.GetBookByIDOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockControllerRecorder) GetBookByID(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetBookByID", arg0, arg1)
 }
 
 func (_m *MockController) GetBookByID2(ctx context.Context, i *models.GetBookByID2Input) (*models.Book, error) {

--- a/samples/gen-go/server/router.go
+++ b/samples/gen-go/server/router.go
@@ -58,17 +58,17 @@ func New(c Controller, addr string) *Server {
 		h.GetBooksHandler(r.Context(), w, r)
 	})
 
+	r.Methods("POST").Path("/v1/books").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger.FromContext(r.Context()).AddContext("op", "createBook")
+		h.CreateBookHandler(r.Context(), w, r)
+	})
+
 	r.Methods("GET").Path("/v1/books/{book_id}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.FromContext(r.Context()).AddContext("op", "getBookByID")
 		h.GetBookByIDHandler(r.Context(), w, r)
 	})
 
-	r.Methods("POST").Path("/v1/books/{book_id}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).AddContext("op", "createBook")
-		h.CreateBookHandler(r.Context(), w, r)
-	})
-
-	r.Methods("GET").Path("/v1/books/{id}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Methods("GET").Path("/v1/books2/{id}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.FromContext(r.Context()).AddContext("op", "getBookByID2")
 		h.GetBookByID2Handler(r.Context(), w, r)
 	})

--- a/samples/swagger.yml
+++ b/samples/swagger.yml
@@ -63,24 +63,7 @@ paths:
           description: "Error"
           schema:
             $ref: "#/definitions/Error"
-    post:
-      operationId: createBook
-      description: Creates a book
-      parameters:
-        - name: newBook
-          in: body
-          schema:
-            $ref: "#/definitions/Book"
-      responses:
-        200:
-          description: "Success"
-          schema:
-            $ref: "#/definitions/Book"
-        default:
-          description: "Error"
-          schema:
-            $ref: "#/definitions/Error"
-  /books/{id}:
+  /books2/{id}:
     get:
       operationId: getBookByID2
       description: Retrieve a book
@@ -160,6 +143,23 @@ paths:
             type: array
             items:
               $ref: "#/definitions/Book"
+        default:
+          description: "Error"
+          schema:
+            $ref: "#/definitions/Error"
+    post:
+      operationId: createBook
+      description: Creates a book
+      parameters:
+        - name: newBook
+          in: body
+          schema:
+            $ref: "#/definitions/Book"
+      responses:
+        200:
+          description: "Success"
+          schema:
+            $ref: "#/definitions/Book"
         default:
           description: "Error"
           schema:


### PR DESCRIPTION
Previously we weren't validating the sample ymls very well. This meant we had invalid yml files which caused me some confusion with the js codegen. 

I ran `go-swagger validate` against each sample file and fixed any errors I found. Then I added a call to go-swagger's validation code in our validate function so now validation is 100% contained within `wag` instead of having to put a goswagger validate call in the Makefile(s). 

I think I've seen a few tickets about consolidating the validation logic so this should accomplish those as well. 
