### PR TITLE
Fix array encoding

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-0.2.2
-- Fix release process to include v prefix
+0.3.0
+- Don't comma encode arrays in querystring params - instead use multiple querystring items.

--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -273,9 +273,13 @@ func buildRequestCode(op *spec.Operation, method string) string {
 			// TODO: Should this be done with regex at some point?
 			buf.WriteString(fmt.Sprintf("\tpath = strings.Replace(path, \"%s\", %s, -1)\n",
 				"{"+param.Name+"}", swagger.ParamToStringCode(param)))
-
 		} else if param.In == "query" {
-			queryAddCode := fmt.Sprintf("\turlVals.Add(\"%s\", %s)\n", param.Name, swagger.ParamToStringCode(param))
+			var queryAddCode string
+			if param.Type == "array" {
+				queryAddCode = fmt.Sprintf("\tfor _, v := range i.%s {\n\t\turlVals.Add(\"%s\", v)\n\t}\n", swagger.StructParamName(param), param.Name)
+			} else {
+				queryAddCode = fmt.Sprintf("\turlVals.Add(\"%s\", %s)\n", param.Name, swagger.ParamToStringCode(param))
+			}
 			if param.Required {
 				buf.WriteString(fmt.Sprintf(queryAddCode))
 			} else {

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -157,7 +157,9 @@ func (c *WagClient) GetBooks(ctx context.Context, i *models.GetBooksInput) ([]mo
 	var body []byte
 
 	if i.Authors != nil {
-		urlVals.Add("authors", JoinByFormat(i.Authors, ""))
+		for _, v := range i.Authors {
+			urlVals.Add("authors", v)
+		}
 	}
 	if i.Available != nil {
 		urlVals.Add("available", strconv.FormatBool(*i.Available))

--- a/samples/gen-go/server/handlers.go
+++ b/samples/gen-go/server/handlers.go
@@ -136,15 +136,8 @@ func newGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 	var err error
 	_ = err
 
-	authorsStr := r.URL.Query().Get("authors")
-	if len(authorsStr) != 0 {
-		var authorsTmp []string
-		authorsTmp, err = swag.SplitByFormat(authorsStr, ""), error(nil)
-		if err != nil {
-			return nil, err
-		}
-		input.Authors = authorsTmp
-
+	if authors, ok := r.URL.Query()["authors"]; ok {
+		input.Authors = authors
 	}
 	availableStr := r.URL.Query().Get("available")
 	if len(availableStr) == 0 {

--- a/samples/gen-js-deprecated/index.js
+++ b/samples/gen-js-deprecated/index.js
@@ -3,16 +3,6 @@ const request = require("request");
 const url = require("url");
 const opentracing = require("opentracing");
 
-// go-swagger treats handles/expects arrays in the query string to be a string of comma joined values
-// so...do that thing. It's worth noting that this has lots of issues ("what if my values have commas in them?")
-// but that's an issue with go-swagger
-function serializeQueryString(data) {
-  if (Array.isArray(data)) {
-    return data.join(",");
-  }
-  return data;
-}
-
 const defaultRetryPolicy = {
   backoffs() {
     const ret = [];

--- a/samples/gen-js-no-definitions/index.js
+++ b/samples/gen-js-no-definitions/index.js
@@ -3,16 +3,6 @@ const request = require("request");
 const url = require("url");
 const opentracing = require("opentracing");
 
-// go-swagger treats handles/expects arrays in the query string to be a string of comma joined values
-// so...do that thing. It's worth noting that this has lots of issues ("what if my values have commas in them?")
-// but that's an issue with go-swagger
-function serializeQueryString(data) {
-  if (Array.isArray(data)) {
-    return data.join(",");
-  }
-  return data;
-}
-
 const defaultRetryPolicy = {
   backoffs() {
     const ret = [];
@@ -100,6 +90,7 @@ module.exports = class SwaggerTest {
       timeout,
       headers,
       qs: query,
+      useQuerystring: true,
     };
 
     return new Promise((resolve, reject) => {

--- a/samples/gen-js/index.js
+++ b/samples/gen-js/index.js
@@ -3,16 +3,6 @@ const request = require("request");
 const url = require("url");
 const opentracing = require("opentracing");
 
-// go-swagger treats handles/expects arrays in the query string to be a string of comma joined values
-// so...do that thing. It's worth noting that this has lots of issues ("what if my values have commas in them?")
-// but that's an issue with go-swagger
-function serializeQueryString(data) {
-  if (Array.isArray(data)) {
-    return data.join(",");
-  }
-  return data;
-}
-
 const defaultRetryPolicy = {
   backoffs() {
     const ret = [];
@@ -84,15 +74,42 @@ module.exports = class SwaggerTest {
     const headers = {};
 
     const query = {};
-    query["authors"] = serializeQueryString(params.authors);
-    query["available"] = serializeQueryString(params.available);
-    query["state"] = serializeQueryString(params.state);
-    query["published"] = serializeQueryString(params.published);
-    query["snake_case"] = serializeQueryString(params.snakeCase);
-    query["completed"] = serializeQueryString(params.completed);
-    query["maxPages"] = serializeQueryString(params.maxPages);
-    query["min_pages"] = serializeQueryString(params.minPages);
-    query["pagesToTime"] = serializeQueryString(params.pagesToTime);
+    if (typeof params.authors !== "undefined") {
+      query["authors"] = params.authors;
+    }
+
+    if (typeof params.available !== "undefined") {
+      query["available"] = params.available;
+    }
+
+    if (typeof params.state !== "undefined") {
+      query["state"] = params.state;
+    }
+
+    if (typeof params.published !== "undefined") {
+      query["published"] = params.published;
+    }
+
+    if (typeof params.snakeCase !== "undefined") {
+      query["snake_case"] = params.snakeCase;
+    }
+
+    if (typeof params.completed !== "undefined") {
+      query["completed"] = params.completed;
+    }
+
+    if (typeof params.maxPages !== "undefined") {
+      query["maxPages"] = params.maxPages;
+    }
+
+    if (typeof params.minPages !== "undefined") {
+      query["min_pages"] = params.minPages;
+    }
+
+    if (typeof params.pagesToTime !== "undefined") {
+      query["pagesToTime"] = params.pagesToTime;
+    }
+
 
     if (span) {
       opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
@@ -106,6 +123,7 @@ module.exports = class SwaggerTest {
       timeout,
       headers,
       qs: query,
+      useQuerystring: true,
     };
 
     return new Promise((resolve, reject) => {
@@ -176,6 +194,7 @@ module.exports = class SwaggerTest {
       timeout,
       headers,
       qs: query,
+      useQuerystring: true,
     };
 
     requestOptions.body = params.newBook;
@@ -233,8 +252,14 @@ module.exports = class SwaggerTest {
     headers["authorization"] = params.authorization;
 
     const query = {};
-    query["authorID"] = serializeQueryString(params.authorID);
-    query["randomBytes"] = serializeQueryString(params.randomBytes);
+    if (typeof params.authorID !== "undefined") {
+      query["authorID"] = params.authorID;
+    }
+
+    if (typeof params.randomBytes !== "undefined") {
+      query["randomBytes"] = params.randomBytes;
+    }
+
 
     if (span) {
       opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
@@ -248,6 +273,7 @@ module.exports = class SwaggerTest {
       timeout,
       headers,
       qs: query,
+      useQuerystring: true,
     };
 
     return new Promise((resolve, reject) => {
@@ -318,6 +344,7 @@ module.exports = class SwaggerTest {
       timeout,
       headers,
       qs: query,
+      useQuerystring: true,
     };
 
     return new Promise((resolve, reject) => {
@@ -387,6 +414,7 @@ module.exports = class SwaggerTest {
       timeout,
       headers,
       qs: query,
+      useQuerystring: true,
     };
 
     return new Promise((resolve, reject) => {

--- a/swagger/parameter.go
+++ b/swagger/parameter.go
@@ -85,11 +85,6 @@ func ParamToStringCode(param spec.Parameter) string {
 		return fmt.Sprintf("strconv.FormatFloat(%s, 'E', -1, 64)", valToSet)
 	case "boolean":
 		return fmt.Sprintf("strconv.FormatBool(%s)", valToSet)
-	case "array":
-		if param.Items.Type != "string" {
-			panic(fmt.Errorf("Array parameters must have string sub-types"))
-		}
-		return fmt.Sprintf("JoinByFormat(%s, \"%s\")", valToSet, param.Format)
 	default:
 		// Theoretically should have validated before getting here
 		panic(fmt.Errorf("unsupported parameter type %s", param.Type))


### PR DESCRIPTION
Fixes go server gen to accept arrays in query strings in the format

```
/path?key=val1&key=val2&key=val3
```

Instead
```
/path?key=val1,val2,val3
```

Also update the JS clients to not hack themselves to support this backwards model. 

## TODO
- [x] Verify this actually works by doing E2E testing of some form. 