### PR TITLE
remove wrapper struct for methods with a single string parameter

### DIFF
--- a/samples/gen-go-deprecated/server/handlers.go
+++ b/samples/gen-go-deprecated/server/handlers.go
@@ -98,6 +98,7 @@ func statusCodeForGetBook(obj interface{}) int {
 func (h handler) GetBookHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	input, err := newGetBookInput(r)
+
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
 		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)
@@ -105,6 +106,7 @@ func (h handler) GetBookHandler(ctx context.Context, w http.ResponseWriter, r *h
 	}
 
 	err = input.Validate()
+
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
 		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)

--- a/samples/gen-go-errors/server/handlers.go
+++ b/samples/gen-go-errors/server/handlers.go
@@ -98,6 +98,7 @@ func statusCodeForGetBook(obj interface{}) int {
 func (h handler) GetBookHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	input, err := newGetBookInput(r)
+
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
 		http.Error(w, jsonMarshalNoError(models.GetBook400Output{Msg: err.Error()}), http.StatusBadRequest)
@@ -105,6 +106,7 @@ func (h handler) GetBookHandler(ctx context.Context, w http.ResponseWriter, r *h
 	}
 
 	err = input.Validate()
+
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
 		http.Error(w, jsonMarshalNoError(models.GetBook400Output{Msg: err.Error()}), http.StatusBadRequest)

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -446,12 +446,12 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 
 // GetBookByID2 makes a GET request to /books2/{id}.
 // Retrieve a book
-func (c *WagClient) GetBookByID2(ctx context.Context, i *models.GetBookByID2Input) (*models.Book, error) {
+func (c *WagClient) GetBookByID2(ctx context.Context, id string) (*models.Book, error) {
 	path := c.basePath + "/v1/books2/{id}"
 	urlVals := url.Values{}
 	var body []byte
 
-	path = strings.Replace(path, "{id}", i.ID, -1)
+	path = strings.Replace(path, "{id}", id, -1)
 	path = path + "?" + urlVals.Encode()
 
 	client := &http.Client{Transport: c.transport}

--- a/samples/gen-go/client/interface.go
+++ b/samples/gen-go/client/interface.go
@@ -25,7 +25,7 @@ type Client interface {
 
 	// GetBookByID2 makes a GET request to /books2/{id}.
 	// Retrieve a book
-	GetBookByID2(ctx context.Context, i *models.GetBookByID2Input) (*models.Book, error)
+	GetBookByID2(ctx context.Context, id string) (*models.Book, error)
 
 	// HealthCheck makes a GET request to /health/check.
 	HealthCheck(ctx context.Context) error

--- a/samples/gen-go/client/mock_client.go
+++ b/samples/gen-go/client/mock_client.go
@@ -63,8 +63,8 @@ func (_mr *_MockClientRecorder) GetBookByID(arg0, arg1 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetBookByID", arg0, arg1)
 }
 
-func (_m *MockClient) GetBookByID2(ctx context.Context, i *models.GetBookByID2Input) (*models.Book, error) {
-	ret := _m.ctrl.Call(_m, "GetBookByID2", ctx, i)
+func (_m *MockClient) GetBookByID2(ctx context.Context, id string) (*models.Book, error) {
+	ret := _m.ctrl.Call(_m, "GetBookByID2", ctx, id)
 	ret0, _ := ret[0].(*models.Book)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1

--- a/samples/gen-go/models/inputs.go
+++ b/samples/gen-go/models/inputs.go
@@ -136,10 +136,10 @@ type GetBookByID2Input struct {
 	ID string
 }
 
-// Validate returns an error if any of the GetBookByID2Input parameters don't satisfy the
-// requirements from the swagger yml file.
-func (i GetBookByID2Input) Validate() error {
-	if err := validate.Pattern("id", "path", string(i.ID), "^[0-9a-f]{24}$"); err != nil {
+// ValidateGetBookByID2Input returns an error if the input parameter doesn't
+// satisfy the requirements in the swagger yml file.
+func ValidateGetBookByID2Input(id string) error {
+	if err := validate.Pattern("id", "path", string(id), "^[0-9a-f]{24}$"); err != nil {
 		return err
 	}
 	return nil

--- a/samples/gen-go/server/handlers.go
+++ b/samples/gen-go/server/handlers.go
@@ -98,6 +98,7 @@ func statusCodeForGetBooks(obj interface{}) int {
 func (h handler) GetBooksHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	input, err := newGetBooksInput(r)
+
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
 		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)
@@ -105,6 +106,7 @@ func (h handler) GetBooksHandler(ctx context.Context, w http.ResponseWriter, r *
 	}
 
 	err = input.Validate()
+
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
 		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)
@@ -282,6 +284,7 @@ func statusCodeForCreateBook(obj interface{}) int {
 func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	input, err := newCreateBookInput(r)
+
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
 		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)
@@ -289,6 +292,7 @@ func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r
 	}
 
 	err = input.Validate(nil)
+
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
 		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)
@@ -391,6 +395,7 @@ func statusCodeForGetBookByID(obj interface{}) int {
 func (h handler) GetBookByIDHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
 	input, err := newGetBookByIDInput(r)
+
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
 		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)
@@ -398,6 +403,7 @@ func (h handler) GetBookByIDHandler(ctx context.Context, w http.ResponseWriter, 
 	}
 
 	err = input.Validate()
+
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
 		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)
@@ -524,21 +530,23 @@ func statusCodeForGetBookByID2(obj interface{}) int {
 
 func (h handler) GetBookByID2Handler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
-	input, err := newGetBookByID2Input(r)
+	id, err := newGetBookByID2Input(r)
+
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
 		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)
 		return
 	}
 
-	err = input.Validate()
+	err = models.ValidateGetBookByID2Input(id)
+
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
 		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)
 		return
 	}
 
-	resp, err := h.GetBookByID2(ctx, input)
+	resp, err := h.GetBookByID2(ctx, id)
 
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
@@ -567,28 +575,14 @@ func (h handler) GetBookByID2Handler(ctx context.Context, w http.ResponseWriter,
 
 }
 
-// newGetBookByID2Input takes in an http.Request an returns the input struct.
-func newGetBookByID2Input(r *http.Request) (*models.GetBookByID2Input, error) {
-	var input models.GetBookByID2Input
-
-	var err error
-	_ = err
-
-	iDStr := mux.Vars(r)["id"]
-	if len(iDStr) == 0 {
-		return nil, errors.New("Parameter must be specified")
+// newGetBookByID2Input takes in an http.Request an returns the id parameter
+// that it contains. It returns an error if the request doesn't contain the parameter.
+func newGetBookByID2Input(r *http.Request) (string, error) {
+	id := mux.Vars(r)["id"]
+	if len(id) == 0 {
+		return "", errors.New("Parameter id must be specified")
 	}
-	if len(iDStr) != 0 {
-		var iDTmp string
-		iDTmp, err = iDStr, error(nil)
-		if err != nil {
-			return nil, err
-		}
-		input.ID = iDTmp
-
-	}
-
-	return &input, nil
+	return id, nil
 }
 
 // statusCodeForHealthCheck returns the status code corresponding to the returned

--- a/samples/gen-go/server/interface.go
+++ b/samples/gen-go/server/interface.go
@@ -25,7 +25,7 @@ type Controller interface {
 
 	// GetBookByID2 makes a GET request to /books2/{id}.
 	// Retrieve a book
-	GetBookByID2(ctx context.Context, i *models.GetBookByID2Input) (*models.Book, error)
+	GetBookByID2(ctx context.Context, id string) (*models.Book, error)
 
 	// HealthCheck makes a GET request to /health/check.
 	HealthCheck(ctx context.Context) error

--- a/samples/gen-go/server/mock_controller.go
+++ b/samples/gen-go/server/mock_controller.go
@@ -63,8 +63,8 @@ func (_mr *_MockControllerRecorder) GetBookByID(arg0, arg1 interface{}) *gomock.
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetBookByID", arg0, arg1)
 }
 
-func (_m *MockController) GetBookByID2(ctx context.Context, i *models.GetBookByID2Input) (*models.Book, error) {
-	ret := _m.ctrl.Call(_m, "GetBookByID2", ctx, i)
+func (_m *MockController) GetBookByID2(ctx context.Context, id string) (*models.Book, error) {
+	ret := _m.ctrl.Call(_m, "GetBookByID2", ctx, id)
 	ret0, _ := ret[0].(*models.Book)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1

--- a/samples/gen-js-errors/index.js
+++ b/samples/gen-js-errors/index.js
@@ -3,16 +3,6 @@ const request = require("request");
 const url = require("url");
 const opentracing = require("opentracing");
 
-// go-swagger treats handles/expects arrays in the query string to be a string of comma joined values
-// so...do that thing. It's worth noting that this has lots of issues ("what if my values have commas in them?")
-// but that's an issue with go-swagger
-function serializeQueryString(data) {
-  if (Array.isArray(data)) {
-    return data.join(",");
-  }
-  return data;
-}
-
 const defaultRetryPolicy = {
   backoffs() {
     const ret = [];
@@ -100,6 +90,7 @@ module.exports = class SwaggerTest {
       timeout,
       headers,
       qs: query,
+      useQuerystring: true,
     };
 
     return new Promise((resolve, reject) => {

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -38,7 +38,7 @@ func (c *ClientContextTest) GetBooks(ctx context.Context, input *models.GetBooks
 func (c *ClientContextTest) GetBookByID(ctx context.Context, input *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
 	return nil, nil
 }
-func (c *ClientContextTest) GetBookByID2(ctx context.Context, input *models.GetBookByID2Input) (*models.Book, error) {
+func (c *ClientContextTest) GetBookByID2(ctx context.Context, id string) (*models.Book, error) {
 	return nil, nil
 }
 func (c *ClientContextTest) CreateBook(ctx context.Context, input *models.Book) (*models.Book, error) {
@@ -69,7 +69,7 @@ func (c *ClientCircuitTest) GetBookByID(ctx context.Context, input *models.GetBo
 	}
 	return nil, nil
 }
-func (c *ClientCircuitTest) GetBookByID2(ctx context.Context, input *models.GetBookByID2Input) (*models.Book, error) {
+func (c *ClientCircuitTest) GetBookByID2(ctx context.Context, id string) (*models.Book, error) {
 	if c.down {
 		return nil, errors.New("fail")
 	}

--- a/test/sample_server.go
+++ b/test/sample_server.go
@@ -40,7 +40,7 @@ func (c *ControllerImpl) GetBookByID(ctx context.Context, input *models.GetBookB
 }
 
 // GetBookByID2 returns a book by ID.
-func (c *ControllerImpl) GetBookByID2(ctx context.Context, input *models.GetBookByID2Input) (*models.Book, error) {
+func (c *ControllerImpl) GetBookByID2(ctx context.Context, id string) (*models.Book, error) {
 	i, err := strconv.Atoi("-42")
 	if err != nil {
 		return nil, err

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -159,7 +159,7 @@ func (d *LastCallServer) GetBooks(ctx context.Context, input *models.GetBooksInp
 func (d *LastCallServer) GetBookByID(ctx context.Context, input *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
 	return nil, nil
 }
-func (d *LastCallServer) GetBookByID2(ctx context.Context, input *models.GetBookByID2Input) (*models.Book, error) {
+func (d *LastCallServer) GetBookByID2(ctx context.Context, id string) (*models.Book, error) {
 	return nil, nil
 }
 func (d *LastCallServer) CreateBook(ctx context.Context, input *models.Book) (*models.Book, error) {
@@ -208,7 +208,7 @@ func (m *MiddlewareContextTest) GetBooks(ctx context.Context, input *models.GetB
 func (m *MiddlewareContextTest) GetBookByID(ctx context.Context, input *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
 	return nil, nil
 }
-func (m *MiddlewareContextTest) GetBookByID2(ctx context.Context, input *models.GetBookByID2Input) (*models.Book, error) {
+func (m *MiddlewareContextTest) GetBookByID2(ctx context.Context, id string) (*models.Book, error) {
 	return nil, nil
 }
 func (m *MiddlewareContextTest) CreateBook(ctx context.Context, input *models.Book) (*models.Book, error) {
@@ -250,7 +250,7 @@ func (m *TimeoutController) GetBooks(ctx context.Context, input *models.GetBooks
 func (m *TimeoutController) GetBookByID(ctx context.Context, input *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
 	return nil, nil
 }
-func (m *TimeoutController) GetBookByID2(ctx context.Context, input *models.GetBookByID2Input) (*models.Book, error) {
+func (m *TimeoutController) GetBookByID2(ctx context.Context, id string) (*models.Book, error) {
 	return nil, nil
 }
 func (m *TimeoutController) CreateBook(ctx context.Context, input *models.Book) (*models.Book, error) {


### PR DESCRIPTION
For a method spec like this:

```yaml
  /books2/{id}:
    get:
      operationId: getBookByID2
      description: Retrieve a book
      parameters:
        - name: id
          in: path
          required: true
          type: string
          pattern: "^[0-9a-f]{24}$"
      responses:
        200:
          description: OK response
          schema:
            $ref: '#/definitions/Book'
```

We used to generate a client / server interface + input struct like this

```go
type ServerAndClientInterface interface {
    GetBookByID2(ctx context.Context, i *models.GetBookByID2Input) (*models.Book, error)
}

type GetBookByID2Input struct {
	ID string
}
```

This PR removes the input struct and uses the basic type (string) instead:

```go
type ServerAndClientInterface interface {
    GetBookByID2(ctx context.Context, id string) (*models.Book, error)
}
```

https://clever.atlassian.net/browse/CREW-12