### PR TITLE
Change error types for sample ymls

### DIFF
--- a/samples/deprecated.yml
+++ b/samples/deprecated.yml
@@ -15,7 +15,7 @@ responses:
   BadRequest:
     description: "Bad Request"
     schema:
-      $ref: "#/definitions/BadRequestError"
+      $ref: "#/definitions/BadRequest"
   InternalError:
     description: "Internal Error"
     schema:
@@ -36,10 +36,10 @@ paths:
         404:
           description: OK response
           schema:
-            $ref: "#/definitions/NotFoundError"
+            $ref: "#/definitions/NotFound"
 
 definitions:
-  BadRequestError:
+  BadRequest:
     type: object
     properties:
       msg:
@@ -51,7 +51,7 @@ definitions:
       msg:
         type: string
 
-  NotFoundError:
+  NotFound:
     type: object
     properties:
       msg:

--- a/samples/errors.yml
+++ b/samples/errors.yml
@@ -15,7 +15,7 @@ responses:
   BadRequest:
     description: "Bad Request"
     schema:
-      $ref: "#/definitions/BadRequestError"
+      $ref: "#/definitions/BadRequest"
   InternalError:
     description: "Internal Error"
     schema:
@@ -23,7 +23,7 @@ responses:
   NotFound:
     description: "Not found"
     schema:
-      $ref: "#/definitions/NotFoundError"
+      $ref: "#/definitions/NotFound"
 
 paths:
   /books/{id}:
@@ -49,13 +49,13 @@ paths:
 
 definitions:
 
-  NotFoundError:
+  NotFound:
     type: object
     properties:
       msg:
         type: string
 
-  BadRequestError:
+  BadRequest:
     type: object
     properties:
       msg:

--- a/samples/gen-go-deprecated/models/bad_request.go
+++ b/samples/gen-go-deprecated/models/bad_request.go
@@ -9,16 +9,16 @@ import (
 	"github.com/go-openapi/errors"
 )
 
-// BadRequestError bad request error
-// swagger:model BadRequestError
-type BadRequestError struct {
+// BadRequest bad request
+// swagger:model BadRequest
+type BadRequest struct {
 
 	// msg
 	Msg string `json:"msg,omitempty"`
 }
 
-// Validate validates this bad request error
-func (m *BadRequestError) Validate(formats strfmt.Registry) error {
+// Validate validates this bad request
+func (m *BadRequest) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if len(res) > 0 {

--- a/samples/gen-go-deprecated/models/not_found.go
+++ b/samples/gen-go-deprecated/models/not_found.go
@@ -9,16 +9,16 @@ import (
 	"github.com/go-openapi/errors"
 )
 
-// NotFoundError not found error
-// swagger:model NotFoundError
-type NotFoundError struct {
+// NotFound not found
+// swagger:model NotFound
+type NotFound struct {
 
 	// msg
 	Msg string `json:"msg,omitempty"`
 }
 
-// Validate validates this not found error
-func (m *NotFoundError) Validate(formats strfmt.Registry) error {
+// Validate validates this not found
+func (m *NotFound) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if len(res) > 0 {

--- a/samples/gen-go-deprecated/models/outputs.go
+++ b/samples/gen-go-deprecated/models/outputs.go
@@ -1,6 +1,6 @@
 package models
 
-func (o BadRequestError) Error() string {
+func (o BadRequest) Error() string {
 	return o.Msg
 }
 
@@ -8,6 +8,6 @@ func (o InternalError) Error() string {
 	return o.Msg
 }
 
-func (o NotFoundError) Error() string {
+func (o NotFound) Error() string {
 	return o.Msg
 }

--- a/samples/gen-go-deprecated/server/handlers.go
+++ b/samples/gen-go-deprecated/server/handlers.go
@@ -72,22 +72,22 @@ func statusCodeForGetBook(obj interface{}) int {
 
 	switch obj.(type) {
 
-	case *models.BadRequestError:
+	case *models.BadRequest:
 		return 400
 
 	case *models.InternalError:
 		return 500
 
-	case *models.NotFoundError:
+	case *models.NotFound:
 		return 404
 
-	case models.BadRequestError:
+	case models.BadRequest:
 		return 400
 
 	case models.InternalError:
 		return 500
 
-	case models.NotFoundError:
+	case models.NotFound:
 		return 404
 
 	default:
@@ -101,7 +101,7 @@ func (h handler) GetBookHandler(ctx context.Context, w http.ResponseWriter, r *h
 
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
-		http.Error(w, jsonMarshalNoError(models.BadRequestError{Msg: err.Error()}), http.StatusBadRequest)
+		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)
 		return
 	}
 
@@ -109,7 +109,7 @@ func (h handler) GetBookHandler(ctx context.Context, w http.ResponseWriter, r *h
 
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
-		http.Error(w, jsonMarshalNoError(models.BadRequestError{Msg: err.Error()}), http.StatusBadRequest)
+		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)
 		return
 	}
 

--- a/samples/gen-go-errors/client/client.go
+++ b/samples/gen-go-errors/client/client.go
@@ -202,7 +202,7 @@ func (c *WagClient) GetBook(ctx context.Context, i *models.GetBookInput) error {
 
 	case 404:
 
-		var output models.NotFoundError
+		var output models.NotFound
 		// Any errors other than EOF should result in an error. EOF is acceptable for empty
 		// types.
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {

--- a/samples/gen-go-errors/models/bad_request.go
+++ b/samples/gen-go-errors/models/bad_request.go
@@ -9,16 +9,16 @@ import (
 	"github.com/go-openapi/errors"
 )
 
-// BadRequestError bad request error
-// swagger:model BadRequestError
-type BadRequestError struct {
+// BadRequest bad request
+// swagger:model BadRequest
+type BadRequest struct {
 
 	// msg
 	Msg string `json:"msg,omitempty"`
 }
 
-// Validate validates this bad request error
-func (m *BadRequestError) Validate(formats strfmt.Registry) error {
+// Validate validates this bad request
+func (m *BadRequest) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if len(res) > 0 {

--- a/samples/gen-go-errors/models/not_found.go
+++ b/samples/gen-go-errors/models/not_found.go
@@ -9,16 +9,16 @@ import (
 	"github.com/go-openapi/errors"
 )
 
-// UnathorizedError unathorized error
-// swagger:model UnathorizedError
-type UnathorizedError struct {
+// NotFound not found
+// swagger:model NotFound
+type NotFound struct {
 
 	// msg
 	Msg string `json:"msg,omitempty"`
 }
 
-// Validate validates this unathorized error
-func (m *UnathorizedError) Validate(formats strfmt.Registry) error {
+// Validate validates this not found
+func (m *NotFound) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if len(res) > 0 {

--- a/samples/gen-go-errors/models/outputs.go
+++ b/samples/gen-go-errors/models/outputs.go
@@ -8,6 +8,6 @@ func (o InternalError) Error() string {
 	return o.Msg
 }
 
-func (o NotFoundError) Error() string {
+func (o NotFound) Error() string {
 	return o.Msg
 }

--- a/samples/gen-go-errors/server/handlers.go
+++ b/samples/gen-go-errors/server/handlers.go
@@ -78,7 +78,7 @@ func statusCodeForGetBook(obj interface{}) int {
 	case *models.InternalError:
 		return 500
 
-	case *models.NotFoundError:
+	case *models.NotFound:
 		return 404
 
 	case models.ExtendedError:
@@ -87,7 +87,7 @@ func statusCodeForGetBook(obj interface{}) int {
 	case models.InternalError:
 		return 500
 
-	case models.NotFoundError:
+	case models.NotFound:
 		return 404
 
 	default:

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -227,7 +227,7 @@ func (c *WagClient) GetBooks(ctx context.Context, i *models.GetBooksInput) ([]mo
 
 	case 400:
 
-		var output models.BadRequestError
+		var output models.BadRequest
 		// Any errors other than EOF should result in an error. EOF is acceptable for empty
 		// types.
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
@@ -309,7 +309,7 @@ func (c *WagClient) CreateBook(ctx context.Context, i *models.Book) (*models.Boo
 
 	case 400:
 
-		var output models.BadRequestError
+		var output models.BadRequest
 		// Any errors other than EOF should result in an error. EOF is acceptable for empty
 		// types.
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
@@ -401,7 +401,7 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 
 	case 400:
 
-		var output models.BadRequestError
+		var output models.BadRequest
 		// Any errors other than EOF should result in an error. EOF is acceptable for empty
 		// types.
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
@@ -411,7 +411,7 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 
 	case 401:
 
-		var output models.UnathorizedError
+		var output models.Unathorized
 		// Any errors other than EOF should result in an error. EOF is acceptable for empty
 		// types.
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
@@ -493,7 +493,7 @@ func (c *WagClient) GetBookByID2(ctx context.Context, id string) (*models.Book, 
 
 	case 400:
 
-		var output models.BadRequestError
+		var output models.BadRequest
 		// Any errors other than EOF should result in an error. EOF is acceptable for empty
 		// types.
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
@@ -567,7 +567,7 @@ func (c *WagClient) HealthCheck(ctx context.Context) error {
 
 	case 400:
 
-		var output models.BadRequestError
+		var output models.BadRequest
 		// Any errors other than EOF should result in an error. EOF is acceptable for empty
 		// types.
 		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {

--- a/samples/gen-go/models/bad_request.go
+++ b/samples/gen-go/models/bad_request.go
@@ -9,16 +9,16 @@ import (
 	"github.com/go-openapi/errors"
 )
 
-// NotFoundError not found error
-// swagger:model NotFoundError
-type NotFoundError struct {
+// BadRequest bad request
+// swagger:model BadRequest
+type BadRequest struct {
 
 	// msg
 	Msg string `json:"msg,omitempty"`
 }
 
-// Validate validates this not found error
-func (m *NotFoundError) Validate(formats strfmt.Registry) error {
+// Validate validates this bad request
+func (m *BadRequest) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if len(res) > 0 {

--- a/samples/gen-go/models/outputs.go
+++ b/samples/gen-go/models/outputs.go
@@ -1,6 +1,6 @@
 package models
 
-func (o BadRequestError) Error() string {
+func (o BadRequest) Error() string {
 	return o.Msg
 }
 
@@ -12,7 +12,7 @@ func (o InternalError) Error() string {
 	return o.Msg
 }
 
-func (o UnathorizedError) Error() string {
+func (o Unathorized) Error() string {
 	return o.Msg
 }
 

--- a/samples/gen-go/models/unathorized.go
+++ b/samples/gen-go/models/unathorized.go
@@ -9,16 +9,16 @@ import (
 	"github.com/go-openapi/errors"
 )
 
-// BadRequestError bad request error
-// swagger:model BadRequestError
-type BadRequestError struct {
+// Unathorized unathorized
+// swagger:model Unathorized
+type Unathorized struct {
 
 	// msg
 	Msg string `json:"msg,omitempty"`
 }
 
-// Validate validates this bad request error
-func (m *BadRequestError) Validate(formats strfmt.Registry) error {
+// Validate validates this unathorized
+func (m *Unathorized) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if len(res) > 0 {

--- a/samples/gen-go/server/handlers.go
+++ b/samples/gen-go/server/handlers.go
@@ -75,7 +75,7 @@ func statusCodeForGetBooks(obj interface{}) int {
 	case *[]models.Book:
 		return 200
 
-	case *models.BadRequestError:
+	case *models.BadRequest:
 		return 400
 
 	case *models.InternalError:
@@ -84,7 +84,7 @@ func statusCodeForGetBooks(obj interface{}) int {
 	case []models.Book:
 		return 200
 
-	case models.BadRequestError:
+	case models.BadRequest:
 		return 400
 
 	case models.InternalError:
@@ -101,7 +101,7 @@ func (h handler) GetBooksHandler(ctx context.Context, w http.ResponseWriter, r *
 
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
-		http.Error(w, jsonMarshalNoError(models.BadRequestError{Msg: err.Error()}), http.StatusBadRequest)
+		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)
 		return
 	}
 
@@ -109,7 +109,7 @@ func (h handler) GetBooksHandler(ctx context.Context, w http.ResponseWriter, r *
 
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
-		http.Error(w, jsonMarshalNoError(models.BadRequestError{Msg: err.Error()}), http.StatusBadRequest)
+		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)
 		return
 	}
 
@@ -258,7 +258,7 @@ func statusCodeForCreateBook(obj interface{}) int {
 
 	switch obj.(type) {
 
-	case *models.BadRequestError:
+	case *models.BadRequest:
 		return 400
 
 	case *models.Book:
@@ -267,7 +267,7 @@ func statusCodeForCreateBook(obj interface{}) int {
 	case *models.InternalError:
 		return 500
 
-	case models.BadRequestError:
+	case models.BadRequest:
 		return 400
 
 	case models.Book:
@@ -287,7 +287,7 @@ func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r
 
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
-		http.Error(w, jsonMarshalNoError(models.BadRequestError{Msg: err.Error()}), http.StatusBadRequest)
+		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)
 		return
 	}
 
@@ -295,7 +295,7 @@ func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r
 
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
-		http.Error(w, jsonMarshalNoError(models.BadRequestError{Msg: err.Error()}), http.StatusBadRequest)
+		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)
 		return
 	}
 
@@ -351,7 +351,7 @@ func statusCodeForGetBookByID(obj interface{}) int {
 
 	switch obj.(type) {
 
-	case *models.BadRequestError:
+	case *models.BadRequest:
 		return 400
 
 	case *models.Error:
@@ -366,10 +366,10 @@ func statusCodeForGetBookByID(obj interface{}) int {
 	case *models.InternalError:
 		return 500
 
-	case *models.UnathorizedError:
+	case *models.Unathorized:
 		return 401
 
-	case models.BadRequestError:
+	case models.BadRequest:
 		return 400
 
 	case models.Error:
@@ -384,7 +384,7 @@ func statusCodeForGetBookByID(obj interface{}) int {
 	case models.InternalError:
 		return 500
 
-	case models.UnathorizedError:
+	case models.Unathorized:
 		return 401
 
 	default:
@@ -398,7 +398,7 @@ func (h handler) GetBookByIDHandler(ctx context.Context, w http.ResponseWriter, 
 
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
-		http.Error(w, jsonMarshalNoError(models.BadRequestError{Msg: err.Error()}), http.StatusBadRequest)
+		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)
 		return
 	}
 
@@ -406,7 +406,7 @@ func (h handler) GetBookByIDHandler(ctx context.Context, w http.ResponseWriter, 
 
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
-		http.Error(w, jsonMarshalNoError(models.BadRequestError{Msg: err.Error()}), http.StatusBadRequest)
+		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)
 		return
 	}
 
@@ -499,7 +499,7 @@ func statusCodeForGetBookByID2(obj interface{}) int {
 
 	switch obj.(type) {
 
-	case *models.BadRequestError:
+	case *models.BadRequest:
 		return 400
 
 	case *models.Book:
@@ -511,7 +511,7 @@ func statusCodeForGetBookByID2(obj interface{}) int {
 	case *models.InternalError:
 		return 500
 
-	case models.BadRequestError:
+	case models.BadRequest:
 		return 400
 
 	case models.Book:
@@ -534,7 +534,7 @@ func (h handler) GetBookByID2Handler(ctx context.Context, w http.ResponseWriter,
 
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
-		http.Error(w, jsonMarshalNoError(models.BadRequestError{Msg: err.Error()}), http.StatusBadRequest)
+		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)
 		return
 	}
 
@@ -542,7 +542,7 @@ func (h handler) GetBookByID2Handler(ctx context.Context, w http.ResponseWriter,
 
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
-		http.Error(w, jsonMarshalNoError(models.BadRequestError{Msg: err.Error()}), http.StatusBadRequest)
+		http.Error(w, jsonMarshalNoError(models.BadRequest{Msg: err.Error()}), http.StatusBadRequest)
 		return
 	}
 
@@ -591,13 +591,13 @@ func statusCodeForHealthCheck(obj interface{}) int {
 
 	switch obj.(type) {
 
-	case *models.BadRequestError:
+	case *models.BadRequest:
 		return 400
 
 	case *models.InternalError:
 		return 500
 
-	case models.BadRequestError:
+	case models.BadRequest:
 		return 400
 
 	case models.InternalError:

--- a/samples/swagger.yml
+++ b/samples/swagger.yml
@@ -15,7 +15,7 @@ responses:
   BadRequest:
     description: "Bad Request"
     schema:
-      $ref: "#/definitions/BadRequestError"
+      $ref: "#/definitions/BadRequest"
   InternalError:
     description: "Internal Error"
     schema:
@@ -67,7 +67,7 @@ paths:
         401:
           description: "Unauthorized"
           schema:
-            $ref: "#/definitions/UnathorizedError"
+            $ref: "#/definitions/Unathorized"
         404:
           description: "Not found"
           schema:
@@ -198,7 +198,7 @@ definitions:
       msg:
         type: string
 
-  BadRequestError:
+  BadRequest:
     type: object
     properties:
       msg:
@@ -210,7 +210,7 @@ definitions:
       msg:
         type: string
 
-  UnathorizedError:
+  Unathorized:
     type: object
     properties:
       msg:

--- a/test/errors_test.go
+++ b/test/errors_test.go
@@ -17,7 +17,7 @@ type ErrorsController struct{}
 
 func (e *ErrorsController) GetBook(ctx context.Context, i *models.GetBookInput) error {
 	if i.ID == 404 {
-		return models.NotFoundError{}
+		return models.NotFound{}
 	}
 	return nil
 }
@@ -29,7 +29,7 @@ func TestGlobal404(t *testing.T) {
 
 	err := c.GetBook(context.Background(), &models.GetBookInput{ID: 404})
 	require.Error(t, err)
-	assert.IsType(t, &models.NotFoundError{}, err)
+	assert.IsType(t, &models.NotFound{}, err)
 }
 
 func TestOverridenBadRequest(t *testing.T) {

--- a/test/sample_server.go
+++ b/test/sample_server.go
@@ -26,7 +26,7 @@ func (c *ControllerImpl) GetBooks(ctx context.Context, input *models.GetBooksInp
 // GetBookByID returns a book by ID.
 func (c *ControllerImpl) GetBookByID(ctx context.Context, input *models.GetBookByIDInput) (models.GetBookByIDOutput, error) {
 	if input.BookID == 400 {
-		return nil, models.BadRequestError{Msg: "My 400 failure"}
+		return nil, models.BadRequest{Msg: "My 400 failure"}
 	}
 
 	book, ok := c.books[input.BookID]

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -80,7 +80,7 @@ func TestDefaultErrorResponse(t *testing.T) {
 
 	_, err := c.GetBookByID(context.Background(), &models.GetBookByIDInput{BookID: 400})
 	assert.Error(t, err)
-	badReq, ok := err.(*models.BadRequestError)
+	badReq, ok := err.(*models.BadRequest)
 	assert.True(t, ok)
 	assert.Equal(t, "My 400 failure", badReq.Msg)
 }
@@ -92,7 +92,7 @@ func TestValidationErrorResponse(t *testing.T) {
 	// Book ID should be a multiple of two
 	_, err := c.GetBookByID(context.Background(), &models.GetBookByIDInput{BookID: 123})
 	assert.Error(t, err)
-	assert.IsType(t, &models.BadRequestError{}, err)
+	assert.IsType(t, &models.BadRequest{}, err)
 }
 
 func TestClientSideError(t *testing.T) {
@@ -132,7 +132,7 @@ func TestCustomStringValidation(t *testing.T) {
 	_, err = c.GetBookByID(context.Background(),
 		&models.GetBookByIDInput{BookID: bookID, AuthorID: &badFormat})
 	require.Error(t, err)
-	assert.IsType(t, &models.BadRequestError{}, err)
+	assert.IsType(t, &models.BadRequest{}, err)
 
 	validFormat := "012345678901234567890123"
 	_, err = c.GetBookByID(context.Background(),


### PR DESCRIPTION
I like `BadRequest` better than `BadRequestError` and so on. Let me know what you think.

The change with the new yml is the first one: https://github.com/Clever/wag/commit/8b63074441967d8be39a7e2d6008ffad9c437335

The other commit isn't interesting.