### PR TITLE
JS Error Types

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,2 @@
-0.6.0
-- Remove support for multiple success types
-- Change field requirement from 'msg' to 'message'
-
+0.6.1
+- Convert errors into rich JS types, and export those types.

--- a/samples/gen-js-deprecated/index.js
+++ b/samples/gen-js-deprecated/index.js
@@ -1,7 +1,8 @@
 const discovery = require("@clever/discovery");
 const request = require("request");
-const url = require("url");
 const opentracing = require("opentracing");
+
+const { Errors } = require("./types");
 
 const defaultRetryPolicy = {
   backoffs() {
@@ -9,13 +10,13 @@ const defaultRetryPolicy = {
     let next = 100.0; // milliseconds
     const e = 0.05; // +/- 5% jitter
     while (ret.length < 5) {
-      const jitter = (Math.random()*2-1.0)*e*next;
+      const jitter = ((Math.random() * 2) - 1) * e * next;
       ret.push(next + jitter);
       next *= 2;
     }
     return ret;
   },
-  retry(requestOptions, err, res, body) {
+  retry(requestOptions, err, res) {
     if (err || requestOptions.method === "POST" ||
         requestOptions.method === "PATCH" ||
         res.statusCode < 500) {
@@ -29,7 +30,7 @@ const noRetryPolicy = {
   backoffs() {
     return [];
   },
-  retry(requestOptions, err, res, body) {
+  retry() {
     return false;
   },
 };
@@ -44,22 +45,23 @@ module.exports = class SwaggerTest {
         this.address = discovery("swagger-test", "http").url();
       } catch (e) {
         this.address = discovery("swagger-test", "default").url();
-      };
+      }
     } else if (options.address) {
       this.address = options.address;
     } else {
       throw new Error("Cannot initialize swagger-test without discovery or address");
     }
     if (options.timeout) {
-      this.timeout = options.timeout
+      this.timeout = options.timeout;
     }
     if (options.retryPolicy) {
       this.retryPolicy = options.retryPolicy;
     }
   }
-}
+};
 
 module.exports.RetryPolicies = {
   Default: defaultRetryPolicy,
   None: noRetryPolicy,
 };
+module.exports.Errors = Errors;

--- a/samples/gen-js-deprecated/types.js
+++ b/samples/gen-js-deprecated/types.js
@@ -1,0 +1,27 @@
+module.exports.Errors = {};
+
+module.exports.Errors.BadRequest = class extends Error {
+  constructor(body) {
+    super(body.message);
+    for (const k of Object.keys(body)) {
+      this[k] = body[k];
+    }
+  }
+};
+module.exports.Errors.NotFound = class extends Error {
+  constructor(body) {
+    super(body.message);
+    for (const k of Object.keys(body)) {
+      this[k] = body[k];
+    }
+  }
+};
+module.exports.Errors.InternalError = class extends Error {
+  constructor(body) {
+    super(body.message);
+    for (const k of Object.keys(body)) {
+      this[k] = body[k];
+    }
+  }
+};
+

--- a/samples/gen-js-errors/index.js
+++ b/samples/gen-js-errors/index.js
@@ -1,7 +1,8 @@
 const discovery = require("@clever/discovery");
 const request = require("request");
-const url = require("url");
 const opentracing = require("opentracing");
+
+const { Errors } = require("./types");
 
 const defaultRetryPolicy = {
   backoffs() {
@@ -9,13 +10,13 @@ const defaultRetryPolicy = {
     let next = 100.0; // milliseconds
     const e = 0.05; // +/- 5% jitter
     while (ret.length < 5) {
-      const jitter = (Math.random()*2-1.0)*e*next;
+      const jitter = ((Math.random() * 2) - 1) * e * next;
       ret.push(next + jitter);
       next *= 2;
     }
     return ret;
   },
-  retry(requestOptions, err, res, body) {
+  retry(requestOptions, err, res) {
     if (err || requestOptions.method === "POST" ||
         requestOptions.method === "PATCH" ||
         res.statusCode < 500) {
@@ -29,7 +30,7 @@ const noRetryPolicy = {
   backoffs() {
     return [];
   },
-  retry(requestOptions, err, res, body) {
+  retry() {
     return false;
   },
 };
@@ -44,14 +45,14 @@ module.exports = class SwaggerTest {
         this.address = discovery("swagger-test", "http").url();
       } catch (e) {
         this.address = discovery("swagger-test", "default").url();
-      };
+      }
     } else if (options.address) {
       this.address = options.address;
     } else {
       throw new Error("Cannot initialize swagger-test without discovery or address");
     }
     if (options.timeout) {
-      this.timeout = options.timeout
+      this.timeout = options.timeout;
     }
     if (options.retryPolicy) {
       this.retryPolicy = options.retryPolicy;
@@ -99,13 +100,13 @@ module.exports = class SwaggerTest {
         if (cb) {
           cb(err);
         }
-      }
+      };
       const resolver = (data) => {
         resolve(data);
         if (cb) {
           cb(null, data);
         }
-      }
+      };
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || defaultRetryPolicy;
       const backoffs = retryPolicy.backoffs();
@@ -115,22 +116,38 @@ module.exports = class SwaggerTest {
           if (retries < backoffs.length && retryPolicy.retry(requestOptions, err, response, body)) {
             const backoff = backoffs[retries];
             retries += 1;
-            return setTimeout(requestOnce, backoff);
+            setTimeout(requestOnce, backoff);
+            return;
           }
           if (err) {
-            return rejecter(err);
+            rejecter(err);
+            return;
           }
-          if (response.statusCode >= 400) {
-            return rejecter(new Error(body));
+          switch (response.statusCode) {
+            case 200:
+              resolver();
+              break;
+            case 400:
+              rejecter(new Errors.ExtendedError(body || {}));
+              break;
+            case 404:
+              rejecter(new Errors.NotFound(body || {}));
+              break;
+            case 500:
+              rejecter(new Errors.InternalError(body || {}));
+              break;
+            default:
+              rejecter(new Error("Recieved unexpected statusCode " + response.statusCode));
           }
-          resolver(body);
+          return;
         });
-      })();
+      }());
     });
   }
-}
+};
 
 module.exports.RetryPolicies = {
   Default: defaultRetryPolicy,
   None: noRetryPolicy,
 };
+module.exports.Errors = Errors;

--- a/samples/gen-js-errors/types.js
+++ b/samples/gen-js-errors/types.js
@@ -1,0 +1,27 @@
+module.exports.Errors = {};
+
+module.exports.Errors.ExtendedError = class extends Error {
+  constructor(body) {
+    super(body.message);
+    for (const k of Object.keys(body)) {
+      this[k] = body[k];
+    }
+  }
+};
+module.exports.Errors.NotFound = class extends Error {
+  constructor(body) {
+    super(body.message);
+    for (const k of Object.keys(body)) {
+      this[k] = body[k];
+    }
+  }
+};
+module.exports.Errors.InternalError = class extends Error {
+  constructor(body) {
+    super(body.message);
+    for (const k of Object.keys(body)) {
+      this[k] = body[k];
+    }
+  }
+};
+

--- a/samples/gen-js/types.js
+++ b/samples/gen-js/types.js
@@ -1,0 +1,35 @@
+module.exports.Errors = {};
+
+module.exports.Errors.BadRequest = class extends Error {
+  constructor(body) {
+    super(body.message);
+    for (const k of Object.keys(body)) {
+      this[k] = body[k];
+    }
+  }
+};
+module.exports.Errors.InternalError = class extends Error {
+  constructor(body) {
+    super(body.message);
+    for (const k of Object.keys(body)) {
+      this[k] = body[k];
+    }
+  }
+};
+module.exports.Errors.Unathorized = class extends Error {
+  constructor(body) {
+    super(body.message);
+    for (const k of Object.keys(body)) {
+      this[k] = body[k];
+    }
+  }
+};
+module.exports.Errors.Error = class extends Error {
+  constructor(body) {
+    super(body.message);
+    for (const k of Object.keys(body)) {
+      this[k] = body[k];
+    }
+  }
+};
+

--- a/test/js/operations.js
+++ b/test/js/operations.js
@@ -30,10 +30,11 @@ describe("operations", function() {
     const c = new Client({address: mockAddress});
     const scope = nock(mockAddress)
       .get(`/v1/books`)
-      .reply(400, {problems: 99});
+      .reply(400, {problems: 99, message: "hit me"});
     c.getBooks({}, {}, function(err, resp) {
       assert.equal(resp, undefined);
-      assert.equal(err.message, "[object Object]"); // TODO
+      assert.equal(err.message, "hit me");
+      assert.equal(err.problems, 99);
       done();
     });
   });
@@ -53,11 +54,12 @@ describe("operations", function() {
     const c = new Client({address: mockAddress});
     const scope = nock(mockAddress)
       .get(`/v1/books`)
-      .reply(400, {problems: 99});
+      .reply(400, {problems: 99, message: "hit me"});
     c.getBooks({}, {}).then(function() {
       assert(false, "then callback should not have been called");
     }).catch(function(err) {
-      assert.equal(err.message, "[object Object]"); // TODO
+      assert.equal(err.message, "hit me");
+      assert.equal(err.problems, 99);
       done();
     });
   });


### PR DESCRIPTION
Due to the simplification we discussed earlier js types were...very easy. 

This branch adds `module.exports.Errors` which export all the possible error classes. When we get a response error back we turn it into one of these error types. This also improves the general response handling to support functions that don't return any data for example. 

Also fixes a bunch of random lint stuff I caught while linting the types. 