### PR TITLE
Remove io.EOF checking

### DIFF
--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -37,7 +37,6 @@ import (
 		"context"
 		"strings"
 		"bytes"
-		"io"
 		"net/http"
 		"net/url"
 		"strconv"
@@ -452,9 +451,7 @@ var codeDetectorTmplStr = `
 	{{if .NoSuccessType}}
 		{{if .ErrorType}}
 		var output {{.TypeName}}
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return &{{.InternalErrorType}}{Message: err.Error()}
 		}
 		return {{.OutputType}}
@@ -464,17 +461,13 @@ var codeDetectorTmplStr = `
 	{{else}}
 		{{if .ErrorType}}
 		var output {{.TypeName}}
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, &{{.InternalErrorType}}{Message: err.Error()}
 		}
 		return nil, {{.OutputType}}
 		{{else}}
 		var output {{.TypeName}}
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, &{{.InternalErrorType}}{Message: err.Error()}
 		}
 		return {{.OutputType}}, nil

--- a/samples/gen-go-deprecated/client/client.go
+++ b/samples/gen-go-deprecated/client/client.go
@@ -6,7 +6,6 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"

--- a/samples/gen-go-errors/client/client.go
+++ b/samples/gen-go-errors/client/client.go
@@ -6,7 +6,6 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -193,9 +192,7 @@ func (c *WagClient) GetBook(ctx context.Context, i *models.GetBookInput) error {
 	case 400:
 
 		var output models.ExtendedError
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return &models.InternalError{Message: err.Error()}
 		}
 		return &output
@@ -203,9 +200,7 @@ func (c *WagClient) GetBook(ctx context.Context, i *models.GetBookInput) error {
 	case 404:
 
 		var output models.NotFound
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return &models.InternalError{Message: err.Error()}
 		}
 		return &output
@@ -213,9 +208,7 @@ func (c *WagClient) GetBook(ctx context.Context, i *models.GetBookInput) error {
 	case 500:
 
 		var output models.InternalError
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return &models.InternalError{Message: err.Error()}
 		}
 		return &output

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -6,7 +6,6 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -218,9 +217,7 @@ func (c *WagClient) GetBooks(ctx context.Context, i *models.GetBooksInput) ([]mo
 	case 200:
 
 		var output []models.Book
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, &models.InternalError{Message: err.Error()}
 		}
 		return output, nil
@@ -228,9 +225,7 @@ func (c *WagClient) GetBooks(ctx context.Context, i *models.GetBooksInput) ([]mo
 	case 400:
 
 		var output models.BadRequest
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, &models.InternalError{Message: err.Error()}
 		}
 		return nil, &output
@@ -238,9 +233,7 @@ func (c *WagClient) GetBooks(ctx context.Context, i *models.GetBooksInput) ([]mo
 	case 500:
 
 		var output models.InternalError
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, &models.InternalError{Message: err.Error()}
 		}
 		return nil, &output
@@ -300,9 +293,7 @@ func (c *WagClient) CreateBook(ctx context.Context, i *models.Book) (*models.Boo
 	case 200:
 
 		var output models.Book
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, &models.InternalError{Message: err.Error()}
 		}
 		return &output, nil
@@ -310,9 +301,7 @@ func (c *WagClient) CreateBook(ctx context.Context, i *models.Book) (*models.Boo
 	case 400:
 
 		var output models.BadRequest
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, &models.InternalError{Message: err.Error()}
 		}
 		return nil, &output
@@ -320,9 +309,7 @@ func (c *WagClient) CreateBook(ctx context.Context, i *models.Book) (*models.Boo
 	case 500:
 
 		var output models.InternalError
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, &models.InternalError{Message: err.Error()}
 		}
 		return nil, &output
@@ -382,9 +369,7 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 	case 200:
 
 		var output models.Book
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, &models.InternalError{Message: err.Error()}
 		}
 		return &output, nil
@@ -392,9 +377,7 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 	case 400:
 
 		var output models.BadRequest
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, &models.InternalError{Message: err.Error()}
 		}
 		return nil, &output
@@ -402,9 +385,7 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 	case 401:
 
 		var output models.Unathorized
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, &models.InternalError{Message: err.Error()}
 		}
 		return nil, &output
@@ -412,9 +393,7 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 	case 404:
 
 		var output models.Error
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, &models.InternalError{Message: err.Error()}
 		}
 		return nil, &output
@@ -422,9 +401,7 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 	case 500:
 
 		var output models.InternalError
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, &models.InternalError{Message: err.Error()}
 		}
 		return nil, &output
@@ -474,9 +451,7 @@ func (c *WagClient) GetBookByID2(ctx context.Context, id string) (*models.Book, 
 	case 200:
 
 		var output models.Book
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, &models.InternalError{Message: err.Error()}
 		}
 		return &output, nil
@@ -484,9 +459,7 @@ func (c *WagClient) GetBookByID2(ctx context.Context, id string) (*models.Book, 
 	case 400:
 
 		var output models.BadRequest
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, &models.InternalError{Message: err.Error()}
 		}
 		return nil, &output
@@ -494,9 +467,7 @@ func (c *WagClient) GetBookByID2(ctx context.Context, id string) (*models.Book, 
 	case 404:
 
 		var output models.Error
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, &models.InternalError{Message: err.Error()}
 		}
 		return nil, &output
@@ -504,9 +475,7 @@ func (c *WagClient) GetBookByID2(ctx context.Context, id string) (*models.Book, 
 	case 500:
 
 		var output models.InternalError
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return nil, &models.InternalError{Message: err.Error()}
 		}
 		return nil, &output
@@ -558,9 +527,7 @@ func (c *WagClient) HealthCheck(ctx context.Context) error {
 	case 400:
 
 		var output models.BadRequest
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return &models.InternalError{Message: err.Error()}
 		}
 		return &output
@@ -568,9 +535,7 @@ func (c *WagClient) HealthCheck(ctx context.Context) error {
 	case 500:
 
 		var output models.InternalError
-		// Any errors other than EOF should result in an error. EOF is acceptable for empty
-		// types.
-		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil && err != io.EOF {
+		if err := json.NewDecoder(resp.Body).Decode(&output); err != nil {
 			return &models.InternalError{Message: err.Error()}
 		}
 		return &output


### PR DESCRIPTION
This was wonky error checking that we added because we didn't always
have types and so we sometimes serialized the data to the empty string.
Now that this case isn't possible (as of https://github.com/Clever/wag/pull/101) let's remove the error checking since
EOF should be an error.