### PR TITLE
Standardize client APIs

### DIFF
--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -23,11 +23,10 @@ func Generate(packageName string, s spec.Swagger) error {
 }
 
 type clientCodeTemplate struct {
-	PackageName           string
-	ServiceName           string
-	FormattedServiceName  string
-	BaseParamToStringCode string
-	Methods               []string
+	PackageName          string
+	ServiceName          string
+	FormattedServiceName string
+	Methods              []string
 }
 
 var clientCodeTemplateStr = `
@@ -154,14 +153,12 @@ func (c *WagClient) SetCircuitBreakerSettings(settings CircuitBreakerSettings) {
 	})
 }
 
-// WithTimeout returns a new client that has the specified timeout on all operations. To make a single request
-// have a timeout use context.WithTimeout as described here: https://godoc.org/golang.org/x/net/context#WithTimeout.
-func (c *WagClient) WithTimeout(timeout time.Duration) *WagClient {
+// SetTimeout sets a timeout on all operations for the client. To make a single request
+// with a timeout use context.SetTimeout as described here: https://godoc.org/golang.org/x/net/context#SetTimeout.
+func (c *WagClient) SetTimeout(timeout time.Duration){
 	c.defaultTimeout = timeout
 	return c
 }
-
-{{.BaseParamToStringCode}}
 
 {{range $methodCode := .Methods}}
 	{{$methodCode}}
@@ -175,10 +172,9 @@ func shortHash(s string) string {
 func generateClient(packageName string, s spec.Swagger) error {
 
 	codeTemplate := clientCodeTemplate{
-		PackageName:           packageName,
-		ServiceName:           s.Info.InfoProps.Title,
-		FormattedServiceName:  strings.ToUpper(strings.Replace(s.Info.InfoProps.Title, "-", "_", -1)),
-		BaseParamToStringCode: swagger.BaseParamToStringCode(),
+		PackageName:          packageName,
+		ServiceName:          s.Info.InfoProps.Title,
+		FormattedServiceName: strings.ToUpper(strings.Replace(s.Info.InfoProps.Title, "-", "_", -1)),
 	}
 
 	for _, path := range swagger.SortedPathItemKeys(s.Paths.Paths) {

--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -102,11 +102,9 @@ func NewFromDiscovery() (*WagClient, error) {
 	return New(url), nil
 }
 
-// WithRetryPolicy returns a new client that will use the given retry policy for
-// all requests.
-func (c *WagClient) WithRetryPolicy(retryPolicy RetryPolicy) *WagClient {
+// SetRetryPolicy sets a the given retry policy for all requests.
+func (c *WagClient) SetRetryPolicy(retryPolicy RetryPolicy) {
 	c.retryDoer.retryPolicy = retryPolicy
-	return c
 }
 
 // SetCircuitBreakerDebug puts the circuit
@@ -154,10 +152,9 @@ func (c *WagClient) SetCircuitBreakerSettings(settings CircuitBreakerSettings) {
 }
 
 // SetTimeout sets a timeout on all operations for the client. To make a single request
-// with a timeout use context.SetTimeout as described here: https://godoc.org/golang.org/x/net/context#SetTimeout.
+// with a timeout use context.WithTimeout as described here: https://godoc.org/golang.org/x/net/context#WithTimeout.
 func (c *WagClient) SetTimeout(timeout time.Duration){
 	c.defaultTimeout = timeout
-	return c
 }
 
 {{range $methodCode := .Methods}}

--- a/samples/gen-go-deprecated/client/client.go
+++ b/samples/gen-go-deprecated/client/client.go
@@ -69,11 +69,9 @@ func NewFromDiscovery() (*WagClient, error) {
 	return New(url), nil
 }
 
-// WithRetryPolicy returns a new client that will use the given retry policy for
-// all requests.
-func (c *WagClient) WithRetryPolicy(retryPolicy RetryPolicy) *WagClient {
+// SetRetryPolicy sets a the given retry policy for all requests.
+func (c *WagClient) SetRetryPolicy(retryPolicy RetryPolicy) {
 	c.retryDoer.retryPolicy = retryPolicy
-	return c
 }
 
 // SetCircuitBreakerDebug puts the circuit
@@ -120,11 +118,10 @@ func (c *WagClient) SetCircuitBreakerSettings(settings CircuitBreakerSettings) {
 	})
 }
 
-// WithTimeout returns a new client that has the specified timeout on all operations. To make a single request
-// have a timeout use context.WithTimeout as described here: https://godoc.org/golang.org/x/net/context#WithTimeout.
-func (c *WagClient) WithTimeout(timeout time.Duration) *WagClient {
+// SetTimeout sets a timeout on all operations for the client. To make a single request
+// with a timeout use context.WithTimeout as described here: https://godoc.org/golang.org/x/net/context#WithTimeout.
+func (c *WagClient) SetTimeout(timeout time.Duration) {
 	c.defaultTimeout = timeout
-	return c
 }
 
 func shortHash(s string) string {

--- a/samples/gen-go-deprecated/client/client.go
+++ b/samples/gen-go-deprecated/client/client.go
@@ -127,29 +127,6 @@ func (c *WagClient) WithTimeout(timeout time.Duration) *WagClient {
 	return c
 }
 
-// JoinByFormat joins a string array by a known format:
-//	 csv: comma separated value (default)
-//	 ssv: space separated value
-//	 tsv: tab separated value
-//	 pipes: pipe (|) separated value
-func JoinByFormat(data []string, format string) string {
-	if len(data) == 0 {
-		return ""
-	}
-	var sep string
-	switch format {
-	case "ssv":
-		sep = " "
-	case "tsv":
-		sep = "\t"
-	case "pipes":
-		sep = "|"
-	default:
-		sep = ","
-	}
-	return strings.Join(data, sep)
-}
-
 func shortHash(s string) string {
 	return fmt.Sprintf("%x", md5.Sum([]byte(s)))[0:6]
 }

--- a/samples/gen-go-errors/client/client.go
+++ b/samples/gen-go-errors/client/client.go
@@ -69,11 +69,9 @@ func NewFromDiscovery() (*WagClient, error) {
 	return New(url), nil
 }
 
-// WithRetryPolicy returns a new client that will use the given retry policy for
-// all requests.
-func (c *WagClient) WithRetryPolicy(retryPolicy RetryPolicy) *WagClient {
+// SetRetryPolicy sets a the given retry policy for all requests.
+func (c *WagClient) SetRetryPolicy(retryPolicy RetryPolicy) {
 	c.retryDoer.retryPolicy = retryPolicy
-	return c
 }
 
 // SetCircuitBreakerDebug puts the circuit
@@ -120,11 +118,10 @@ func (c *WagClient) SetCircuitBreakerSettings(settings CircuitBreakerSettings) {
 	})
 }
 
-// WithTimeout returns a new client that has the specified timeout on all operations. To make a single request
-// have a timeout use context.WithTimeout as described here: https://godoc.org/golang.org/x/net/context#WithTimeout.
-func (c *WagClient) WithTimeout(timeout time.Duration) *WagClient {
+// SetTimeout sets a timeout on all operations for the client. To make a single request
+// with a timeout use context.WithTimeout as described here: https://godoc.org/golang.org/x/net/context#WithTimeout.
+func (c *WagClient) SetTimeout(timeout time.Duration) {
 	c.defaultTimeout = timeout
-	return c
 }
 
 // GetBook makes a GET request to /books/{id}.

--- a/samples/gen-go-errors/client/client.go
+++ b/samples/gen-go-errors/client/client.go
@@ -127,29 +127,6 @@ func (c *WagClient) WithTimeout(timeout time.Duration) *WagClient {
 	return c
 }
 
-// JoinByFormat joins a string array by a known format:
-//	 csv: comma separated value (default)
-//	 ssv: space separated value
-//	 tsv: tab separated value
-//	 pipes: pipe (|) separated value
-func JoinByFormat(data []string, format string) string {
-	if len(data) == 0 {
-		return ""
-	}
-	var sep string
-	switch format {
-	case "ssv":
-		sep = " "
-	case "tsv":
-		sep = "\t"
-	case "pipes":
-		sep = "|"
-	default:
-		sep = ","
-	}
-	return strings.Join(data, sep)
-}
-
 // GetBook makes a GET request to /books/{id}.
 func (c *WagClient) GetBook(ctx context.Context, i *models.GetBookInput) error {
 	path := c.basePath + "/v1/books/{id}"

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -69,11 +69,9 @@ func NewFromDiscovery() (*WagClient, error) {
 	return New(url), nil
 }
 
-// WithRetryPolicy returns a new client that will use the given retry policy for
-// all requests.
-func (c *WagClient) WithRetryPolicy(retryPolicy RetryPolicy) *WagClient {
+// SetRetryPolicy sets a the given retry policy for all requests.
+func (c *WagClient) SetRetryPolicy(retryPolicy RetryPolicy) {
 	c.retryDoer.retryPolicy = retryPolicy
-	return c
 }
 
 // SetCircuitBreakerDebug puts the circuit
@@ -120,11 +118,10 @@ func (c *WagClient) SetCircuitBreakerSettings(settings CircuitBreakerSettings) {
 	})
 }
 
-// WithTimeout returns a new client that has the specified timeout on all operations. To make a single request
-// have a timeout use context.WithTimeout as described here: https://godoc.org/golang.org/x/net/context#WithTimeout.
-func (c *WagClient) WithTimeout(timeout time.Duration) *WagClient {
+// SetTimeout sets a timeout on all operations for the client. To make a single request
+// with a timeout use context.WithTimeout as described here: https://godoc.org/golang.org/x/net/context#WithTimeout.
+func (c *WagClient) SetTimeout(timeout time.Duration) {
 	c.defaultTimeout = timeout
-	return c
 }
 
 // GetBooks makes a GET request to /books.

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -127,29 +127,6 @@ func (c *WagClient) WithTimeout(timeout time.Duration) *WagClient {
 	return c
 }
 
-// JoinByFormat joins a string array by a known format:
-//	 csv: comma separated value (default)
-//	 ssv: space separated value
-//	 tsv: tab separated value
-//	 pipes: pipe (|) separated value
-func JoinByFormat(data []string, format string) string {
-	if len(data) == 0 {
-		return ""
-	}
-	var sep string
-	switch format {
-	case "ssv":
-		sep = " "
-	case "tsv":
-		sep = "\t"
-	case "pipes":
-		sep = "|"
-	default:
-		sep = ","
-	}
-	return strings.Join(data, sep)
-}
-
 // GetBooks makes a GET request to /books.
 // Returns a list of books
 func (c *WagClient) GetBooks(ctx context.Context, i *models.GetBooksInput) ([]models.Book, error) {

--- a/swagger/parameter.go
+++ b/swagger/parameter.go
@@ -20,35 +20,6 @@ import (
 // 3. String -> Go type
 // 4. Validation logic
 
-// BaseParamToStringCode returns the code for a function that joins a string
-// array by a known format (csv, ssv, tsv, pipes).
-func BaseParamToStringCode() string {
-	return `
-// JoinByFormat joins a string array by a known format:
-//	 csv: comma separated value (default)
-//	 ssv: space separated value
-//	 tsv: tab separated value
-//	 pipes: pipe (|) separated value
-func JoinByFormat(data []string, format string) string {
-	if len(data) == 0 {
-		return ""
-	}
-	var sep string
-	switch format {
-	case "ssv":
-		sep = " "
-	case "tsv":
-		sep = "\t"
-	case "pipes":
-		sep = "|"
-	default:
-		sep = ","
-	}
-	return strings.Join(data, sep)
-}
-`
-}
-
 // ParamToStringCode returns a function that converts a Parameter into the code to convert
 // it into a string (for serialization). For example, a integer named 'Size' becomes
 // `strconv.FormatInt(i.Size, 10)`

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -111,7 +111,8 @@ func TestCustomClientRetries(t *testing.T) {
 	defer testServer.Close()
 
 	// Should fail if no retries
-	c := client.New(testServer.URL).WithRetryPolicy(client.NoRetryPolicy{})
+	c := client.New(testServer.URL)
+	c.SetRetryPolicy(client.NoRetryPolicy{})
 	_, err := c.GetBooks(context.Background(), &models.GetBooksInput{})
 	assert.Error(t, err)
 	assert.Equal(t, 1, controller.getCount)

--- a/test/server_test.go
+++ b/test/server_test.go
@@ -265,7 +265,7 @@ func TestTimeout(t *testing.T) {
 	assert.True(t, end.Sub(start) < 80*time.Millisecond)
 
 	// Try with a global client setting
-	c = c.WithTimeout(10 * time.Millisecond)
+	c.SetTimeout(10 * time.Millisecond)
 	_, err = c.GetBooks(context.Background(), &models.GetBooksInput{})
 	require.Error(t, err)
 	assert.Equal(t, "context deadline exceeded", err.Error())


### PR DESCRIPTION
I was doing a last pass on the APIs to make sure they were ready for v1 and I noticed that sometimes we use `With*` and sometimes `Set*` for setting client fields. I think I like Set better, so I standardized on that. Let me know if you would rather go with `With*`

I also removed JoinByFormat now that we don't encode array values that way any more.