### PR TITLE
Generate docs for the JS client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,19 @@ test: build generate $(PKGS) js-tests
 js-tests:
 	cd test/js && npm install && npm test
 
-generate: hardcoded/hardcoded.go $(MOCKGEN)
+jsdoc2md:
+	hash npm 2>/dev/null || (echo "Could not run npm, please install node" && false)
+	hash jsdoc2md 2>/dev/null || npm install -g jsdoc-to-markdown@^2.0.0
+
+generate: hardcoded/hardcoded.go $(MOCKGEN) jsdoc2md
 	./bin/wag -file samples/swagger.yml -go-package $(PKG)/samples/gen-go -js-path $(GOPATH)/src/$(PKG)/samples/gen-js
+	(cd $(GOPATH)/src/$(PKG)/samples/gen-js && jsdoc2md index.js types.js > ./README.md)
 	go generate $(PKG)/samples/gen-go...
 	./bin/wag -file samples/deprecated.yml -go-package $(PKG)/samples/gen-go-deprecated -js-path $(GOPATH)/src/$(PKG)/samples/gen-js-deprecated
+	(cd $(GOPATH)/src/$(PKG)/samples/gen-js-deprecated && jsdoc2md index.js types.js > ./README.md)
 	go generate ${PKG}/samples/gen-go-deprecated...
 	./bin/wag -file samples/errors.yml -go-package $(PKG)/samples/gen-go-errors -js-path $(GOPATH)/src/$(PKG)/samples/gen-js-errors
+	(cd $(GOPATH)/src/$(PKG)/samples/gen-js-errors && jsdoc2md index.js types.js > ./README.md)
 	go generate ${PKG}/samples/gen-go-errors...
 
 $(PKGS): golang-test-all-strict-deps

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -2,7 +2,9 @@ package jsclient
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
+	"log"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -86,7 +88,17 @@ const opentracing = require("opentracing");
 
 const { Errors } = require("./types");
 
+/**
+ * The default retry policy will retry five times with an exponential backoff.
+ * @alias module:{{.ServiceName}}.RetryPolicies.Default
+ */
 const defaultRetryPolicy = {
+  /**
+   * backoffs returns an array of five backoffs: 100ms, 200ms, 400ms, 800ms, and
+   * 1.6s. It adds a random 5% jitter to each backoff.
+   * @function
+   * @returns {Array<number>}
+   */
   backoffs() {
     const ret = [];
     let next = 100.0; // milliseconds
@@ -98,6 +110,13 @@ const defaultRetryPolicy = {
     }
     return ret;
   },
+  /**
+   * retry will not retry a request if the HTTP client returns an error, if the
+   * is a POST or PATCH, or if the status code is less than 500. It will retry
+   * all other requests.
+   * @function
+   * @returns {boolean}
+   */
   retry(requestOptions, err, res) {
     if (err || requestOptions.method === "POST" ||
         requestOptions.method === "PATCH" ||
@@ -108,17 +127,49 @@ const defaultRetryPolicy = {
   },
 };
 
+/**
+ * Use this retry policy to turn off retries.
+ * @alias module:{{.ServiceName}}.RetryPolicies.None
+ */
 const noRetryPolicy = {
+  /**
+   * returns an empty array
+   */
   backoffs() {
     return [];
   },
+  /**
+   * returns false
+   */
   retry() {
     return false;
   },
 };
 
-module.exports = class {{.ClassName}} {
+/**
+ * {{.ServiceName}} client library.
+ * @module {{.ServiceName}}
+ * @typicalname {{.ClassName}}
+ */
 
+/**
+ * The main client object to instantiate.
+ * @alias module:{{.ServiceName}}
+ */
+class {{.ClassName}} {
+
+  /**
+   * Create a new client object.
+   * @param {Object} options - Options for constructing a client object.
+   * @param {string} options.address - URL where the server is located. If not
+   * specified, the address will be discovered via @clever/discovery.
+   * @param {number} options.timeout - The timeout to use for all client requests,
+   * in milliseconds. This can be overridden on a per-request basis.
+   * @param {Object} [options.retryPolicy=RetryPolicies.Default] - The logic to
+   * determine which requests to retry, as well as how many times to retry.
+   * @param {function} options.retryPolicy.backoffs
+   * @param {function} options.retryPolicy.retry
+   */
   constructor(options) {
     options = options || {};
 
@@ -142,10 +193,21 @@ module.exports = class {{.ClassName}} {
   }
 {{range $methodCode := .Methods}}{{$methodCode}}{{end}}};
 
+module.exports = {{.ClassName}};
+
+/**
+ * Retry policies available to use.
+ * @alias module:{{.ServiceName}}.RetryPolicies
+ */
 module.exports.RetryPolicies = {
   Default: defaultRetryPolicy,
   None: noRetryPolicy,
 };
+
+/**
+ * Errors returned by methods.
+ * @alias module:{{.ServiceName}}.Errors
+ */
 module.exports.Errors = Errors;
 `
 
@@ -251,17 +313,38 @@ var methodTmplStr = `
   }
 `
 
-var singleParamMethodDefinionTemplateString = `{{.MethodName}}({{range $param := .Params}}{{$param.JSName}}, {{end}}options, cb) {
+var singleParamMethodDefinitionTemplateString = `/**{{if .Description}}
+   * {{.Description}}{{end}}{{range $param := .Params}}
+   * @param {{if $param.JSDocType}}{{.JSDocType}} {{end}}{{$param.JSName}}{{if $param.Default}}={{$param.Default}}{{end}}{{end}}
+   * @param {function} [cb]
+   * @returns {Promise}
+   * @fulfill{{if .JSDocSuccessReturnType}} {{.JSDocSuccessReturnType}}{{else}} {*}{{end}}{{$ServiceName := .ServiceName}}{{range $response := .Responses}}{{if $response.IsError}}
+   * @reject {module:{{$ServiceName}}.Errors.{{$response.Name}}}{{end}}{{end}}
+   * @reject {Error}
+   */
+  {{.MethodName}}({{range $param := .Params}}{{$param.JSName}}, {{end}}options, cb) {
     const params = {};{{range $param := .Params}}
     params["{{$param.JSName}}"] = {{$param.JSName}};{{end}}
 `
 
-var pluralParamMethodDefinionTemplateString = `{{.MethodName}}(params, options, cb) {`
+var pluralParamMethodDefinitionTemplateString = `/**{{if .Description}}
+   * {{.Description}}{{end}}
+   * @param {Object} params{{range $param := .Params}}
+   * @param {{if $param.JSDocType}}{{.JSDocType}} {{end}}{{if not $param.Required}}[{{end}}params.{{$param.JSName}}{{if $param.Default}}={{$param.Default}}{{end}}{{if not $param.Required}}]{{end}}{{end}}
+   * @param {function} [cb]
+   * @returns {Promise}
+   * @fulfill{{if .JSDocSuccessReturnType}} {{.JSDocSuccessReturnType}}{{else}} {*}{{end}}{{$ServiceName := .ServiceName}}{{range $response := .Responses}}{{if $response.IsError}}
+   * @reject {module:{{$ServiceName}}.Errors.{{$response.Name}}}{{end}}{{end}}
+   * @reject {Error}
+   */
+  {{.MethodName}}(params, options, cb) {`
 
 type paramMapping struct {
-	JSName   string
-	WagName  string
-	Required bool
+	JSName    string
+	WagName   string
+	Required  bool
+	JSDocType string
+	Default   interface{}
 }
 
 type responseMapping struct {
@@ -272,16 +355,19 @@ type responseMapping struct {
 }
 
 type methodTemplate struct {
-	MethodName       string
-	MethodDefinition string
-	Params           []paramMapping
-	Method           string
-	PathCode         string
-	Path             string
-	HeaderParams     []paramMapping
-	QueryParams      []paramMapping
-	BodyParam        string
-	Responses        []responseMapping
+	ServiceName            string
+	MethodName             string
+	Description            string
+	MethodDefinition       string
+	Params                 []paramMapping
+	Method                 string
+	PathCode               string
+	Path                   string
+	HeaderParams           []paramMapping
+	QueryParams            []paramMapping
+	BodyParam              string
+	Responses              []responseMapping
+	JSDocSuccessReturnType string
 }
 
 // This function takes in a swagger path such as "/path/goes/to/{location}/and/to/{other_Location}"
@@ -299,13 +385,20 @@ func fillOutPath(path string) string {
 func methodCode(s spec.Swagger, op *spec.Operation, method, basePath, path string) (string, error) {
 
 	tmplInfo := methodTemplate{
-		MethodName: op.ID,
-		Method:     method,
-		PathCode:   basePath + fillOutPath(path),
-		Path:       basePath + path,
+		ServiceName: s.Info.InfoProps.Title,
+		MethodName:  op.ID,
+		Description: op.Description,
+		Method:      method,
+		PathCode:    basePath + fillOutPath(path),
+		Path:        basePath + path,
 	}
 
+	var successResponse *spec.Response
 	for _, statusCode := range swagger.SortedStatusCodeKeys(op.Responses.StatusCodeResponses) {
+		if successResponse == nil && statusCode >= 200 && statusCode < 400 {
+			r := op.Responses.StatusCodeResponses[statusCode]
+			successResponse = &r
+		}
 		response := responseMapping{
 			StatusCode: statusCode,
 			IsError:    statusCode >= 400,
@@ -320,12 +413,15 @@ func methodCode(s spec.Swagger, op *spec.Operation, method, basePath, path strin
 		}
 		tmplInfo.Responses = append(tmplInfo.Responses, response)
 	}
+	tmplInfo.JSDocSuccessReturnType = responseToJSDocReturnType(successResponse)
 
 	for _, wagParam := range op.Parameters {
 		param := paramMapping{
-			JSName:   utils.CamelCase(wagParam.Name, false),
-			WagName:  wagParam.Name,
-			Required: wagParam.Required,
+			JSName:    utils.CamelCase(wagParam.Name, false),
+			WagName:   wagParam.Name,
+			Required:  wagParam.Required,
+			JSDocType: paramToJSDocType(wagParam),
+			Default:   wagParam.Default,
 		}
 
 		tmplInfo.Params = append(tmplInfo.Params, param)
@@ -342,9 +438,9 @@ func methodCode(s spec.Swagger, op *spec.Operation, method, basePath, path strin
 	var err error
 	var methodDefinition string
 	if len(op.Parameters) <= 1 {
-		methodDefinition, err = templates.WriteTemplate(singleParamMethodDefinionTemplateString, tmplInfo)
+		methodDefinition, err = templates.WriteTemplate(singleParamMethodDefinitionTemplateString, tmplInfo)
 	} else {
-		methodDefinition, err = templates.WriteTemplate(pluralParamMethodDefinionTemplateString, tmplInfo)
+		methodDefinition, err = templates.WriteTemplate(pluralParamMethodDefinitionTemplateString, tmplInfo)
 	}
 	if err != nil {
 		return "", err
@@ -353,9 +449,61 @@ func methodCode(s spec.Swagger, op *spec.Operation, method, basePath, path strin
 	return templates.WriteTemplate(methodTmplStr, tmplInfo)
 }
 
-var typeTmplString = `module.exports.Errors = {};
+// paramToJSDocType returns the JSDoc type to assign a parameter.
+// It returns empty string if it cannot discern a type for the parameter.
+func paramToJSDocType(param spec.Parameter) string {
+	if param.Type == "string" || param.Type == "number" || param.Type == "boolean" {
+		return "{" + param.Type + "}"
+	} else if param.Type == "integer" {
+		return "{number}"
+	} else if param.Type == "array" && param.Items != nil &&
+		(param.Items.Type == "string" || param.Items.Type == "number" || param.Items.Type == "boolean") {
+		return fmt.Sprintf("{%s[]}", param.Items.Type)
+	}
+	log.Printf("TODO: unhandled param name=%s. Documentation will be incomplete for this parameter.", param.Name)
+	return ""
+}
 
-{{ range .}}module.exports.Errors.{{ .Name }} = class extends Error {
+// schemaToJSDocType returns the JSDoc type to assign a schema.
+// It returns empty string if it cannot discern a type for the schema.
+func schemaToJSDocType(schema *spec.Schema) string {
+	if len(schema.Type) == 1 {
+		typ := schema.Type[0]
+		if typ == "string" {
+			return "{string}"
+		} else if typ == "integer" {
+			return "{number}"
+		}
+	}
+	log.Printf("TODO: unhandled schema type %v.", schema.Type)
+	return ""
+}
+
+// responseToJSDocReturnType returns the JS Doc type for a response.
+// It returns empty string if it cannot determine the type.
+func responseToJSDocReturnType(r *spec.Response) string {
+	if r.Schema == nil {
+		return "{undefined}"
+	} else if r.Schema.Type != nil && len(r.Schema.Type) == 1 && r.Schema.Type[0] == "array" &&
+		r.Schema.Items != nil && r.Schema.Items.Schema != nil {
+		return "{Object[]}" // in the future, a more specific type would be nice
+	} else if r.Schema.Ref.String() != "" {
+		return "{Object}" // in the future, a more specific type would be nice
+	}
+	log.Printf("TODO: unhandled response: %#v. Documentation will be incomplete for this response type.", *r)
+	return ""
+}
+
+var typeTmplString = `module.exports.Errors = {};
+{{$ServiceName := .ServiceName}}
+{{range .ErrorTypes}}/**
+ * {{.Name}}
+ * @extends Error
+ * @memberof module:{{$ServiceName}}
+ * @alias module:{{$ServiceName}}.Errors.{{.Name}}{{range .JSDocProperties}}
+ * @property {{.Type}} {{.Name}}{{end}}
+ */
+module.exports.Errors.{{ .Name }} = class extends Error {
   constructor(body) {
     super(body.message);
     for (const k of Object.keys(body)) {
@@ -363,11 +511,36 @@ var typeTmplString = `module.exports.Errors = {};
     }
   }
 };
-{{ end }}
-`
+
+{{ end }}`
+
+type typesTemplate struct {
+	ServiceName string
+	ErrorTypes  []errorType
+}
+
+type errorType struct {
+	StatusCode      int
+	Name            string
+	JSDocProperties []jsDocProperty
+}
+
+type jsDocProperty struct {
+	Type string
+	Name string
+}
+
+func jsDocPropertyFromSchema(name string, schema *spec.Schema) jsDocProperty {
+	return jsDocProperty{
+		Name: name,
+		Type: schemaToJSDocType(schema),
+	}
+}
 
 func generateTypesFile(s spec.Swagger) (string, error) {
-	var responses []responseMapping
+	typesTmpl := typesTemplate{
+		ServiceName: s.Info.InfoProps.Title,
+	}
 
 	typeNames := stringset.New()
 
@@ -388,14 +561,24 @@ func generateTypesFile(s spec.Swagger) (string, error) {
 					continue
 				}
 				typeNames.Add(typeName)
-				response := responseMapping{
+
+				etype := errorType{
 					StatusCode: statusCode,
 					Name:       typeName,
 				}
-				responses = append(responses, response)
+
+				if schema, ok := s.Definitions[typeName]; !ok {
+					log.Printf("TODO: could not find schema for %s, JS documentation will be incomplete", typeName)
+				} else if len(schema.Properties) > 0 {
+					for name, propertySchema := range schema.Properties {
+						etype.JSDocProperties = append(etype.JSDocProperties, jsDocPropertyFromSchema(name, &propertySchema))
+					}
+				}
+
+				typesTmpl.ErrorTypes = append(typesTmpl.ErrorTypes, etype)
 			}
 		}
 	}
 
-	return templates.WriteTemplate(typeTmplString, responses)
+	return templates.WriteTemplate(typeTmplString, typesTmpl)
 }

--- a/samples/gen-js-deprecated/README.md
+++ b/samples/gen-js-deprecated/README.md
@@ -1,0 +1,157 @@
+<a name="module_swagger-test"></a>
+
+## swagger-test
+swagger-test client library.
+
+
+* [swagger-test](#module_swagger-test)
+    * [SwaggerTest](#exp_module_swagger-test--SwaggerTest) ⏏
+        * [new SwaggerTest(options)](#new_module_swagger-test--SwaggerTest_new)
+        * [.RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)
+            * [.Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)
+                * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs) ⇒ <code>Array.&lt;number&gt;</code>
+                * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.retry) ⇒ <code>boolean</code>
+            * [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
+                * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs)
+                * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.None.retry)
+        * [.Errors](#module_swagger-test--SwaggerTest.Errors)
+            * [.BadRequest](#module_swagger-test--SwaggerTest.Errors.BadRequest) ⇐ <code>Error</code>
+            * [.NotFound](#module_swagger-test--SwaggerTest.Errors.NotFound) ⇐ <code>Error</code>
+            * [.InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError) ⇐ <code>Error</code>
+
+<a name="exp_module_swagger-test--SwaggerTest"></a>
+
+### SwaggerTest ⏏
+The main client object to instantiate.
+
+**Kind**: Exported class  
+<a name="new_module_swagger-test--SwaggerTest_new"></a>
+
+#### new SwaggerTest(options)
+Create a new client object.
+
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| options | <code>Object</code> |  | Options for constructing a client object. |
+| options.address | <code>string</code> |  | URL where the server is located. If not specified, the address will be discovered via @clever/discovery. |
+| options.timeout | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. |
+| [options.retryPolicy] | <code>Object</code> | <code>RetryPolicies.Default</code> | The logic to determine which requests to retry, as well as how many times to retry. |
+| options.retryPolicy.backoffs | <code>function</code> |  |  |
+| options.retryPolicy.retry | <code>function</code> |  |  |
+
+<a name="module_swagger-test--SwaggerTest.RetryPolicies"></a>
+
+#### SwaggerTest.RetryPolicies
+Retry policies available to use.
+
+**Kind**: static property of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
+
+* [.RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)
+    * [.Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)
+        * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs) ⇒ <code>Array.&lt;number&gt;</code>
+        * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.retry) ⇒ <code>boolean</code>
+    * [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
+        * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs)
+        * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.None.retry)
+
+<a name="module_swagger-test--SwaggerTest.RetryPolicies.Default"></a>
+
+##### RetryPolicies.Default
+The default retry policy will retry five times with an exponential backoff.
+
+**Kind**: static constant of <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code>  
+
+* [.Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)
+    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs) ⇒ <code>Array.&lt;number&gt;</code>
+    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.retry) ⇒ <code>boolean</code>
+
+<a name="module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs"></a>
+
+###### Default.backoffs() ⇒ <code>Array.&lt;number&gt;</code>
+backoffs returns an array of five backoffs: 100ms, 200ms, 400ms, 800ms, and
+1.6s. It adds a random 5% jitter to each backoff.
+
+**Kind**: static method of <code>[Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)</code>  
+<a name="module_swagger-test--SwaggerTest.RetryPolicies.Default.retry"></a>
+
+###### Default.retry() ⇒ <code>boolean</code>
+retry will not retry a request if the HTTP client returns an error, if the
+is a POST or PATCH, or if the status code is less than 500. It will retry
+all other requests.
+
+**Kind**: static method of <code>[Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)</code>  
+<a name="module_swagger-test--SwaggerTest.RetryPolicies.None"></a>
+
+##### RetryPolicies.None
+Use this retry policy to turn off retries.
+
+**Kind**: static constant of <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code>  
+
+* [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
+    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs)
+    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.None.retry)
+
+<a name="module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs"></a>
+
+###### None.backoffs()
+returns an empty array
+
+**Kind**: static method of <code>[None](#module_swagger-test--SwaggerTest.RetryPolicies.None)</code>  
+<a name="module_swagger-test--SwaggerTest.RetryPolicies.None.retry"></a>
+
+###### None.retry()
+returns false
+
+**Kind**: static method of <code>[None](#module_swagger-test--SwaggerTest.RetryPolicies.None)</code>  
+<a name="module_swagger-test--SwaggerTest.Errors"></a>
+
+#### SwaggerTest.Errors
+Errors returned by methods.
+
+**Kind**: static property of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
+
+* [.Errors](#module_swagger-test--SwaggerTest.Errors)
+    * [.BadRequest](#module_swagger-test--SwaggerTest.Errors.BadRequest) ⇐ <code>Error</code>
+    * [.NotFound](#module_swagger-test--SwaggerTest.Errors.NotFound) ⇐ <code>Error</code>
+    * [.InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError) ⇐ <code>Error</code>
+
+<a name="module_swagger-test--SwaggerTest.Errors.BadRequest"></a>
+
+##### Errors.BadRequest ⇐ <code>Error</code>
+BadRequest
+
+**Kind**: static class of <code>[Errors](#module_swagger-test--SwaggerTest.Errors)</code>  
+**Extends:** <code>Error</code>  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| message | <code>string</code> | 
+
+<a name="module_swagger-test--SwaggerTest.Errors.NotFound"></a>
+
+##### Errors.NotFound ⇐ <code>Error</code>
+NotFound
+
+**Kind**: static class of <code>[Errors](#module_swagger-test--SwaggerTest.Errors)</code>  
+**Extends:** <code>Error</code>  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| message | <code>string</code> | 
+
+<a name="module_swagger-test--SwaggerTest.Errors.InternalError"></a>
+
+##### Errors.InternalError ⇐ <code>Error</code>
+InternalError
+
+**Kind**: static class of <code>[Errors](#module_swagger-test--SwaggerTest.Errors)</code>  
+**Extends:** <code>Error</code>  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| message | <code>string</code> | 
+

--- a/samples/gen-js-deprecated/README.md
+++ b/samples/gen-js-deprecated/README.md
@@ -9,11 +9,7 @@ swagger-test client library.
         * [new SwaggerTest(options)](#new_module_swagger-test--SwaggerTest_new)
         * [.RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)
             * [.Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)
-                * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs) ⇒ <code>Array.&lt;number&gt;</code>
-                * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.retry) ⇒ <code>boolean</code>
             * [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
-                * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs)
-                * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.None.retry)
         * [.Errors](#module_swagger-test--SwaggerTest.Errors)
             * [.BadRequest](#module_swagger-test--SwaggerTest.Errors.BadRequest) ⇐ <code>Error</code>
             * [.NotFound](#module_swagger-test--SwaggerTest.Errors.NotFound) ⇐ <code>Error</code>
@@ -22,7 +18,7 @@ swagger-test client library.
 <a name="exp_module_swagger-test--SwaggerTest"></a>
 
 ### SwaggerTest ⏏
-The main client object to instantiate.
+swagger-test client
 
 **Kind**: Exported class  
 <a name="new_module_swagger-test--SwaggerTest_new"></a>
@@ -34,11 +30,10 @@ Create a new client object.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | options | <code>Object</code> |  | Options for constructing a client object. |
-| options.address | <code>string</code> |  | URL where the server is located. If not specified, the address will be discovered via @clever/discovery. |
-| options.timeout | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. |
-| [options.retryPolicy] | <code>Object</code> | <code>RetryPolicies.Default</code> | The logic to determine which requests to retry, as well as how many times to retry. |
-| options.retryPolicy.backoffs | <code>function</code> |  |  |
-| options.retryPolicy.retry | <code>function</code> |  |  |
+| [options.address] | <code>string</code> |  | URL where the server is located. Must provide this or the discovery argument |
+| [options.discovery] | <code>bool</code> |  | Use @clever/discovery to locate the server. Must provide this or the address argument |
+| [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. |
+| [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | <code>RetryPolicies.Default</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 
 <a name="module_swagger-test--SwaggerTest.RetryPolicies"></a>
 
@@ -49,11 +44,7 @@ Retry policies available to use.
 
 * [.RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)
     * [.Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)
-        * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs) ⇒ <code>Array.&lt;number&gt;</code>
-        * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.retry) ⇒ <code>boolean</code>
     * [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
-        * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs)
-        * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.None.retry)
 
 <a name="module_swagger-test--SwaggerTest.RetryPolicies.Default"></a>
 
@@ -61,49 +52,12 @@ Retry policies available to use.
 The default retry policy will retry five times with an exponential backoff.
 
 **Kind**: static constant of <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code>  
-
-* [.Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)
-    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs) ⇒ <code>Array.&lt;number&gt;</code>
-    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.retry) ⇒ <code>boolean</code>
-
-<a name="module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs"></a>
-
-###### Default.backoffs() ⇒ <code>Array.&lt;number&gt;</code>
-backoffs returns an array of five backoffs: 100ms, 200ms, 400ms, 800ms, and
-1.6s. It adds a random 5% jitter to each backoff.
-
-**Kind**: static method of <code>[Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)</code>  
-<a name="module_swagger-test--SwaggerTest.RetryPolicies.Default.retry"></a>
-
-###### Default.retry() ⇒ <code>boolean</code>
-retry will not retry a request if the HTTP client returns an error, if the
-is a POST or PATCH, or if the status code is less than 500. It will retry
-all other requests.
-
-**Kind**: static method of <code>[Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)</code>  
 <a name="module_swagger-test--SwaggerTest.RetryPolicies.None"></a>
 
 ##### RetryPolicies.None
 Use this retry policy to turn off retries.
 
 **Kind**: static constant of <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code>  
-
-* [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
-    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs)
-    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.None.retry)
-
-<a name="module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs"></a>
-
-###### None.backoffs()
-returns an empty array
-
-**Kind**: static method of <code>[None](#module_swagger-test--SwaggerTest.RetryPolicies.None)</code>  
-<a name="module_swagger-test--SwaggerTest.RetryPolicies.None.retry"></a>
-
-###### None.retry()
-returns false
-
-**Kind**: static method of <code>[None](#module_swagger-test--SwaggerTest.RetryPolicies.None)</code>  
 <a name="module_swagger-test--SwaggerTest.Errors"></a>
 
 #### SwaggerTest.Errors

--- a/samples/gen-js-deprecated/index.js
+++ b/samples/gen-js-deprecated/index.js
@@ -4,7 +4,17 @@ const opentracing = require("opentracing");
 
 const { Errors } = require("./types");
 
+/**
+ * The default retry policy will retry five times with an exponential backoff.
+ * @alias module:swagger-test.RetryPolicies.Default
+ */
 const defaultRetryPolicy = {
+  /**
+   * backoffs returns an array of five backoffs: 100ms, 200ms, 400ms, 800ms, and
+   * 1.6s. It adds a random 5% jitter to each backoff.
+   * @function
+   * @returns {Array<number>}
+   */
   backoffs() {
     const ret = [];
     let next = 100.0; // milliseconds
@@ -16,6 +26,13 @@ const defaultRetryPolicy = {
     }
     return ret;
   },
+  /**
+   * retry will not retry a request if the HTTP client returns an error, if the
+   * is a POST or PATCH, or if the status code is less than 500. It will retry
+   * all other requests.
+   * @function
+   * @returns {boolean}
+   */
   retry(requestOptions, err, res) {
     if (err || requestOptions.method === "POST" ||
         requestOptions.method === "PATCH" ||
@@ -26,17 +43,49 @@ const defaultRetryPolicy = {
   },
 };
 
+/**
+ * Use this retry policy to turn off retries.
+ * @alias module:swagger-test.RetryPolicies.None
+ */
 const noRetryPolicy = {
+  /**
+   * returns an empty array
+   */
   backoffs() {
     return [];
   },
+  /**
+   * returns false
+   */
   retry() {
     return false;
   },
 };
 
-module.exports = class SwaggerTest {
+/**
+ * swagger-test client library.
+ * @module swagger-test
+ * @typicalname SwaggerTest
+ */
 
+/**
+ * The main client object to instantiate.
+ * @alias module:swagger-test
+ */
+class SwaggerTest {
+
+  /**
+   * Create a new client object.
+   * @param {Object} options - Options for constructing a client object.
+   * @param {string} options.address - URL where the server is located. If not
+   * specified, the address will be discovered via @clever/discovery.
+   * @param {number} options.timeout - The timeout to use for all client requests,
+   * in milliseconds. This can be overridden on a per-request basis.
+   * @param {Object} [options.retryPolicy=RetryPolicies.Default] - The logic to
+   * determine which requests to retry, as well as how many times to retry.
+   * @param {function} options.retryPolicy.backoffs
+   * @param {function} options.retryPolicy.retry
+   */
   constructor(options) {
     options = options || {};
 
@@ -60,8 +109,19 @@ module.exports = class SwaggerTest {
   }
 };
 
+module.exports = SwaggerTest;
+
+/**
+ * Retry policies available to use.
+ * @alias module:swagger-test.RetryPolicies
+ */
 module.exports.RetryPolicies = {
   Default: defaultRetryPolicy,
   None: noRetryPolicy,
 };
+
+/**
+ * Errors returned by methods.
+ * @alias module:swagger-test.Errors
+ */
 module.exports.Errors = Errors;

--- a/samples/gen-js-deprecated/index.js
+++ b/samples/gen-js-deprecated/index.js
@@ -2,6 +2,11 @@ const discovery = require("@clever/discovery");
 const request = require("request");
 const opentracing = require("opentracing");
 
+/**
+ * @external Span
+ * @see {@link https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html}
+ */
+
 const { Errors } = require("./types");
 
 /**
@@ -9,12 +14,6 @@ const { Errors } = require("./types");
  * @alias module:swagger-test.RetryPolicies.Default
  */
 const defaultRetryPolicy = {
-  /**
-   * backoffs returns an array of five backoffs: 100ms, 200ms, 400ms, 800ms, and
-   * 1.6s. It adds a random 5% jitter to each backoff.
-   * @function
-   * @returns {Array<number>}
-   */
   backoffs() {
     const ret = [];
     let next = 100.0; // milliseconds
@@ -26,13 +25,6 @@ const defaultRetryPolicy = {
     }
     return ret;
   },
-  /**
-   * retry will not retry a request if the HTTP client returns an error, if the
-   * is a POST or PATCH, or if the status code is less than 500. It will retry
-   * all other requests.
-   * @function
-   * @returns {boolean}
-   */
   retry(requestOptions, err, res) {
     if (err || requestOptions.method === "POST" ||
         requestOptions.method === "PATCH" ||
@@ -48,15 +40,9 @@ const defaultRetryPolicy = {
  * @alias module:swagger-test.RetryPolicies.None
  */
 const noRetryPolicy = {
-  /**
-   * returns an empty array
-   */
   backoffs() {
     return [];
   },
-  /**
-   * returns false
-   */
   retry() {
     return false;
   },
@@ -69,7 +55,7 @@ const noRetryPolicy = {
  */
 
 /**
- * The main client object to instantiate.
+ * swagger-test client
  * @alias module:swagger-test
  */
 class SwaggerTest {
@@ -77,14 +63,14 @@ class SwaggerTest {
   /**
    * Create a new client object.
    * @param {Object} options - Options for constructing a client object.
-   * @param {string} options.address - URL where the server is located. If not
-   * specified, the address will be discovered via @clever/discovery.
-   * @param {number} options.timeout - The timeout to use for all client requests,
+   * @param {string} [options.address] - URL where the server is located. Must provide
+   * this or the discovery argument
+   * @param {bool} [options.discovery] - Use @clever/discovery to locate the server. Must provide
+   * this or the address argument
+   * @param {number} [options.timeout] - The timeout to use for all client requests,
    * in milliseconds. This can be overridden on a per-request basis.
-   * @param {Object} [options.retryPolicy=RetryPolicies.Default] - The logic to
+   * @param {module:swagger-test.RetryPolicies} [options.retryPolicy=RetryPolicies.Default] - The logic to
    * determine which requests to retry, as well as how many times to retry.
-   * @param {function} options.retryPolicy.backoffs
-   * @param {function} options.retryPolicy.retry
    */
   constructor(options) {
     options = options || {};

--- a/samples/gen-js-deprecated/types.js
+++ b/samples/gen-js-deprecated/types.js
@@ -1,5 +1,12 @@
 module.exports.Errors = {};
 
+/**
+ * BadRequest
+ * @extends Error
+ * @memberof module:swagger-test
+ * @alias module:swagger-test.Errors.BadRequest
+ * @property {string} message
+ */
 module.exports.Errors.BadRequest = class extends Error {
   constructor(body) {
     super(body.message);
@@ -8,6 +15,14 @@ module.exports.Errors.BadRequest = class extends Error {
     }
   }
 };
+
+/**
+ * NotFound
+ * @extends Error
+ * @memberof module:swagger-test
+ * @alias module:swagger-test.Errors.NotFound
+ * @property {string} message
+ */
 module.exports.Errors.NotFound = class extends Error {
   constructor(body) {
     super(body.message);
@@ -16,6 +31,14 @@ module.exports.Errors.NotFound = class extends Error {
     }
   }
 };
+
+/**
+ * InternalError
+ * @extends Error
+ * @memberof module:swagger-test
+ * @alias module:swagger-test.Errors.InternalError
+ * @property {string} message
+ */
 module.exports.Errors.InternalError = class extends Error {
   constructor(body) {
     super(body.message);

--- a/samples/gen-js-errors/README.md
+++ b/samples/gen-js-errors/README.md
@@ -8,15 +8,11 @@ swagger-test client library.
     * [SwaggerTest](#exp_module_swagger-test--SwaggerTest) ⏏
         * [new SwaggerTest(options)](#new_module_swagger-test--SwaggerTest_new)
         * _instance_
-            * [.getBook(id, [cb])](#module_swagger-test--SwaggerTest+getBook) ⇒ <code>Promise</code>
+            * [.getBook(id, [options], [cb])](#module_swagger-test--SwaggerTest+getBook) ⇒ <code>Promise</code>
         * _static_
             * [.RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)
                 * [.Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)
-                    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs) ⇒ <code>Array.&lt;number&gt;</code>
-                    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.retry) ⇒ <code>boolean</code>
                 * [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
-                    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs)
-                    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.None.retry)
             * [.Errors](#module_swagger-test--SwaggerTest.Errors)
                 * [.ExtendedError](#module_swagger-test--SwaggerTest.Errors.ExtendedError) ⇐ <code>Error</code>
                 * [.NotFound](#module_swagger-test--SwaggerTest.Errors.NotFound) ⇐ <code>Error</code>
@@ -25,7 +21,7 @@ swagger-test client library.
 <a name="exp_module_swagger-test--SwaggerTest"></a>
 
 ### SwaggerTest ⏏
-The main client object to instantiate.
+swagger-test client
 
 **Kind**: Exported class  
 <a name="new_module_swagger-test--SwaggerTest_new"></a>
@@ -37,15 +33,14 @@ Create a new client object.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | options | <code>Object</code> |  | Options for constructing a client object. |
-| options.address | <code>string</code> |  | URL where the server is located. If not specified, the address will be discovered via @clever/discovery. |
-| options.timeout | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. |
-| [options.retryPolicy] | <code>Object</code> | <code>RetryPolicies.Default</code> | The logic to determine which requests to retry, as well as how many times to retry. |
-| options.retryPolicy.backoffs | <code>function</code> |  |  |
-| options.retryPolicy.retry | <code>function</code> |  |  |
+| [options.address] | <code>string</code> |  | URL where the server is located. Must provide this or the discovery argument |
+| [options.discovery] | <code>bool</code> |  | Use @clever/discovery to locate the server. Must provide this or the address argument |
+| [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. |
+| [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | <code>RetryPolicies.Default</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 
 <a name="module_swagger-test--SwaggerTest+getBook"></a>
 
-#### swaggerTest.getBook(id, [cb]) ⇒ <code>Promise</code>
+#### swaggerTest.getBook(id, [options], [cb]) ⇒ <code>Promise</code>
 **Kind**: instance method of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
 **Fulfill**: <code>undefined</code>  
 **Reject**: <code>[ExtendedError](#module_swagger-test--SwaggerTest.Errors.ExtendedError)</code>  
@@ -53,10 +48,14 @@ Create a new client object.
 **Reject**: <code>[InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError)</code>  
 **Reject**: <code>Error</code>  
 
-| Param | Type |
-| --- | --- |
-| id | <code>number</code> | 
-| [cb] | <code>function</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| id | <code>number</code> |  |
+| [options] | <code>object</code> |  |
+| [options.timeout] | <code>number</code> | A request specific timeout |
+| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | A request specific retryPolicy |
+| [cb] | <code>function</code> |  |
 
 <a name="module_swagger-test--SwaggerTest.RetryPolicies"></a>
 
@@ -67,11 +66,7 @@ Retry policies available to use.
 
 * [.RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)
     * [.Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)
-        * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs) ⇒ <code>Array.&lt;number&gt;</code>
-        * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.retry) ⇒ <code>boolean</code>
     * [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
-        * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs)
-        * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.None.retry)
 
 <a name="module_swagger-test--SwaggerTest.RetryPolicies.Default"></a>
 
@@ -79,49 +74,12 @@ Retry policies available to use.
 The default retry policy will retry five times with an exponential backoff.
 
 **Kind**: static constant of <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code>  
-
-* [.Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)
-    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs) ⇒ <code>Array.&lt;number&gt;</code>
-    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.retry) ⇒ <code>boolean</code>
-
-<a name="module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs"></a>
-
-###### Default.backoffs() ⇒ <code>Array.&lt;number&gt;</code>
-backoffs returns an array of five backoffs: 100ms, 200ms, 400ms, 800ms, and
-1.6s. It adds a random 5% jitter to each backoff.
-
-**Kind**: static method of <code>[Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)</code>  
-<a name="module_swagger-test--SwaggerTest.RetryPolicies.Default.retry"></a>
-
-###### Default.retry() ⇒ <code>boolean</code>
-retry will not retry a request if the HTTP client returns an error, if the
-is a POST or PATCH, or if the status code is less than 500. It will retry
-all other requests.
-
-**Kind**: static method of <code>[Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)</code>  
 <a name="module_swagger-test--SwaggerTest.RetryPolicies.None"></a>
 
 ##### RetryPolicies.None
 Use this retry policy to turn off retries.
 
 **Kind**: static constant of <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code>  
-
-* [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
-    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs)
-    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.None.retry)
-
-<a name="module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs"></a>
-
-###### None.backoffs()
-returns an empty array
-
-**Kind**: static method of <code>[None](#module_swagger-test--SwaggerTest.RetryPolicies.None)</code>  
-<a name="module_swagger-test--SwaggerTest.RetryPolicies.None.retry"></a>
-
-###### None.retry()
-returns false
-
-**Kind**: static method of <code>[None](#module_swagger-test--SwaggerTest.RetryPolicies.None)</code>  
 <a name="module_swagger-test--SwaggerTest.Errors"></a>
 
 #### SwaggerTest.Errors

--- a/samples/gen-js-errors/README.md
+++ b/samples/gen-js-errors/README.md
@@ -1,0 +1,177 @@
+<a name="module_swagger-test"></a>
+
+## swagger-test
+swagger-test client library.
+
+
+* [swagger-test](#module_swagger-test)
+    * [SwaggerTest](#exp_module_swagger-test--SwaggerTest) ⏏
+        * [new SwaggerTest(options)](#new_module_swagger-test--SwaggerTest_new)
+        * _instance_
+            * [.getBook(id, [cb])](#module_swagger-test--SwaggerTest+getBook) ⇒ <code>Promise</code>
+        * _static_
+            * [.RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)
+                * [.Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)
+                    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs) ⇒ <code>Array.&lt;number&gt;</code>
+                    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.retry) ⇒ <code>boolean</code>
+                * [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
+                    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs)
+                    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.None.retry)
+            * [.Errors](#module_swagger-test--SwaggerTest.Errors)
+                * [.ExtendedError](#module_swagger-test--SwaggerTest.Errors.ExtendedError) ⇐ <code>Error</code>
+                * [.NotFound](#module_swagger-test--SwaggerTest.Errors.NotFound) ⇐ <code>Error</code>
+                * [.InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError) ⇐ <code>Error</code>
+
+<a name="exp_module_swagger-test--SwaggerTest"></a>
+
+### SwaggerTest ⏏
+The main client object to instantiate.
+
+**Kind**: Exported class  
+<a name="new_module_swagger-test--SwaggerTest_new"></a>
+
+#### new SwaggerTest(options)
+Create a new client object.
+
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| options | <code>Object</code> |  | Options for constructing a client object. |
+| options.address | <code>string</code> |  | URL where the server is located. If not specified, the address will be discovered via @clever/discovery. |
+| options.timeout | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. |
+| [options.retryPolicy] | <code>Object</code> | <code>RetryPolicies.Default</code> | The logic to determine which requests to retry, as well as how many times to retry. |
+| options.retryPolicy.backoffs | <code>function</code> |  |  |
+| options.retryPolicy.retry | <code>function</code> |  |  |
+
+<a name="module_swagger-test--SwaggerTest+getBook"></a>
+
+#### swaggerTest.getBook(id, [cb]) ⇒ <code>Promise</code>
+**Kind**: instance method of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
+**Fulfill**: <code>undefined</code>  
+**Reject**: <code>[ExtendedError](#module_swagger-test--SwaggerTest.Errors.ExtendedError)</code>  
+**Reject**: <code>[NotFound](#module_swagger-test--SwaggerTest.Errors.NotFound)</code>  
+**Reject**: <code>[InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError)</code>  
+**Reject**: <code>Error</code>  
+
+| Param | Type |
+| --- | --- |
+| id | <code>number</code> | 
+| [cb] | <code>function</code> | 
+
+<a name="module_swagger-test--SwaggerTest.RetryPolicies"></a>
+
+#### SwaggerTest.RetryPolicies
+Retry policies available to use.
+
+**Kind**: static property of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
+
+* [.RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)
+    * [.Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)
+        * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs) ⇒ <code>Array.&lt;number&gt;</code>
+        * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.retry) ⇒ <code>boolean</code>
+    * [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
+        * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs)
+        * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.None.retry)
+
+<a name="module_swagger-test--SwaggerTest.RetryPolicies.Default"></a>
+
+##### RetryPolicies.Default
+The default retry policy will retry five times with an exponential backoff.
+
+**Kind**: static constant of <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code>  
+
+* [.Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)
+    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs) ⇒ <code>Array.&lt;number&gt;</code>
+    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.retry) ⇒ <code>boolean</code>
+
+<a name="module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs"></a>
+
+###### Default.backoffs() ⇒ <code>Array.&lt;number&gt;</code>
+backoffs returns an array of five backoffs: 100ms, 200ms, 400ms, 800ms, and
+1.6s. It adds a random 5% jitter to each backoff.
+
+**Kind**: static method of <code>[Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)</code>  
+<a name="module_swagger-test--SwaggerTest.RetryPolicies.Default.retry"></a>
+
+###### Default.retry() ⇒ <code>boolean</code>
+retry will not retry a request if the HTTP client returns an error, if the
+is a POST or PATCH, or if the status code is less than 500. It will retry
+all other requests.
+
+**Kind**: static method of <code>[Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)</code>  
+<a name="module_swagger-test--SwaggerTest.RetryPolicies.None"></a>
+
+##### RetryPolicies.None
+Use this retry policy to turn off retries.
+
+**Kind**: static constant of <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code>  
+
+* [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
+    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs)
+    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.None.retry)
+
+<a name="module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs"></a>
+
+###### None.backoffs()
+returns an empty array
+
+**Kind**: static method of <code>[None](#module_swagger-test--SwaggerTest.RetryPolicies.None)</code>  
+<a name="module_swagger-test--SwaggerTest.RetryPolicies.None.retry"></a>
+
+###### None.retry()
+returns false
+
+**Kind**: static method of <code>[None](#module_swagger-test--SwaggerTest.RetryPolicies.None)</code>  
+<a name="module_swagger-test--SwaggerTest.Errors"></a>
+
+#### SwaggerTest.Errors
+Errors returned by methods.
+
+**Kind**: static property of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
+
+* [.Errors](#module_swagger-test--SwaggerTest.Errors)
+    * [.ExtendedError](#module_swagger-test--SwaggerTest.Errors.ExtendedError) ⇐ <code>Error</code>
+    * [.NotFound](#module_swagger-test--SwaggerTest.Errors.NotFound) ⇐ <code>Error</code>
+    * [.InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError) ⇐ <code>Error</code>
+
+<a name="module_swagger-test--SwaggerTest.Errors.ExtendedError"></a>
+
+##### Errors.ExtendedError ⇐ <code>Error</code>
+ExtendedError
+
+**Kind**: static class of <code>[Errors](#module_swagger-test--SwaggerTest.Errors)</code>  
+**Extends:** <code>Error</code>  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| code | <code>number</code> | 
+| message | <code>string</code> | 
+
+<a name="module_swagger-test--SwaggerTest.Errors.NotFound"></a>
+
+##### Errors.NotFound ⇐ <code>Error</code>
+NotFound
+
+**Kind**: static class of <code>[Errors](#module_swagger-test--SwaggerTest.Errors)</code>  
+**Extends:** <code>Error</code>  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| message | <code>string</code> | 
+
+<a name="module_swagger-test--SwaggerTest.Errors.InternalError"></a>
+
+##### Errors.InternalError ⇐ <code>Error</code>
+InternalError
+
+**Kind**: static class of <code>[Errors](#module_swagger-test--SwaggerTest.Errors)</code>  
+**Extends:** <code>Error</code>  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| code | <code>number</code> | 
+| message | <code>string</code> | 
+

--- a/samples/gen-js-errors/index.js
+++ b/samples/gen-js-errors/index.js
@@ -4,7 +4,17 @@ const opentracing = require("opentracing");
 
 const { Errors } = require("./types");
 
+/**
+ * The default retry policy will retry five times with an exponential backoff.
+ * @alias module:swagger-test.RetryPolicies.Default
+ */
 const defaultRetryPolicy = {
+  /**
+   * backoffs returns an array of five backoffs: 100ms, 200ms, 400ms, 800ms, and
+   * 1.6s. It adds a random 5% jitter to each backoff.
+   * @function
+   * @returns {Array<number>}
+   */
   backoffs() {
     const ret = [];
     let next = 100.0; // milliseconds
@@ -16,6 +26,13 @@ const defaultRetryPolicy = {
     }
     return ret;
   },
+  /**
+   * retry will not retry a request if the HTTP client returns an error, if the
+   * is a POST or PATCH, or if the status code is less than 500. It will retry
+   * all other requests.
+   * @function
+   * @returns {boolean}
+   */
   retry(requestOptions, err, res) {
     if (err || requestOptions.method === "POST" ||
         requestOptions.method === "PATCH" ||
@@ -26,17 +43,49 @@ const defaultRetryPolicy = {
   },
 };
 
+/**
+ * Use this retry policy to turn off retries.
+ * @alias module:swagger-test.RetryPolicies.None
+ */
 const noRetryPolicy = {
+  /**
+   * returns an empty array
+   */
   backoffs() {
     return [];
   },
+  /**
+   * returns false
+   */
   retry() {
     return false;
   },
 };
 
-module.exports = class SwaggerTest {
+/**
+ * swagger-test client library.
+ * @module swagger-test
+ * @typicalname SwaggerTest
+ */
 
+/**
+ * The main client object to instantiate.
+ * @alias module:swagger-test
+ */
+class SwaggerTest {
+
+  /**
+   * Create a new client object.
+   * @param {Object} options - Options for constructing a client object.
+   * @param {string} options.address - URL where the server is located. If not
+   * specified, the address will be discovered via @clever/discovery.
+   * @param {number} options.timeout - The timeout to use for all client requests,
+   * in milliseconds. This can be overridden on a per-request basis.
+   * @param {Object} [options.retryPolicy=RetryPolicies.Default] - The logic to
+   * determine which requests to retry, as well as how many times to retry.
+   * @param {function} options.retryPolicy.backoffs
+   * @param {function} options.retryPolicy.retry
+   */
   constructor(options) {
     options = options || {};
 
@@ -59,6 +108,16 @@ module.exports = class SwaggerTest {
     }
   }
 
+  /**
+   * @param {number} id
+   * @param {function} [cb]
+   * @returns {Promise}
+   * @fulfill {undefined}
+   * @reject {module:swagger-test.Errors.ExtendedError}
+   * @reject {module:swagger-test.Errors.NotFound}
+   * @reject {module:swagger-test.Errors.InternalError}
+   * @reject {Error}
+   */
   getBook(id, options, cb) {
     const params = {};
     params["id"] = id;
@@ -146,8 +205,19 @@ module.exports = class SwaggerTest {
   }
 };
 
+module.exports = SwaggerTest;
+
+/**
+ * Retry policies available to use.
+ * @alias module:swagger-test.RetryPolicies
+ */
 module.exports.RetryPolicies = {
   Default: defaultRetryPolicy,
   None: noRetryPolicy,
 };
+
+/**
+ * Errors returned by methods.
+ * @alias module:swagger-test.Errors
+ */
 module.exports.Errors = Errors;

--- a/samples/gen-js-errors/index.js
+++ b/samples/gen-js-errors/index.js
@@ -2,6 +2,11 @@ const discovery = require("@clever/discovery");
 const request = require("request");
 const opentracing = require("opentracing");
 
+/**
+ * @external Span
+ * @see {@link https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html}
+ */
+
 const { Errors } = require("./types");
 
 /**
@@ -9,12 +14,6 @@ const { Errors } = require("./types");
  * @alias module:swagger-test.RetryPolicies.Default
  */
 const defaultRetryPolicy = {
-  /**
-   * backoffs returns an array of five backoffs: 100ms, 200ms, 400ms, 800ms, and
-   * 1.6s. It adds a random 5% jitter to each backoff.
-   * @function
-   * @returns {Array<number>}
-   */
   backoffs() {
     const ret = [];
     let next = 100.0; // milliseconds
@@ -26,13 +25,6 @@ const defaultRetryPolicy = {
     }
     return ret;
   },
-  /**
-   * retry will not retry a request if the HTTP client returns an error, if the
-   * is a POST or PATCH, or if the status code is less than 500. It will retry
-   * all other requests.
-   * @function
-   * @returns {boolean}
-   */
   retry(requestOptions, err, res) {
     if (err || requestOptions.method === "POST" ||
         requestOptions.method === "PATCH" ||
@@ -48,15 +40,9 @@ const defaultRetryPolicy = {
  * @alias module:swagger-test.RetryPolicies.None
  */
 const noRetryPolicy = {
-  /**
-   * returns an empty array
-   */
   backoffs() {
     return [];
   },
-  /**
-   * returns false
-   */
   retry() {
     return false;
   },
@@ -69,7 +55,7 @@ const noRetryPolicy = {
  */
 
 /**
- * The main client object to instantiate.
+ * swagger-test client
  * @alias module:swagger-test
  */
 class SwaggerTest {
@@ -77,14 +63,14 @@ class SwaggerTest {
   /**
    * Create a new client object.
    * @param {Object} options - Options for constructing a client object.
-   * @param {string} options.address - URL where the server is located. If not
-   * specified, the address will be discovered via @clever/discovery.
-   * @param {number} options.timeout - The timeout to use for all client requests,
+   * @param {string} [options.address] - URL where the server is located. Must provide
+   * this or the discovery argument
+   * @param {bool} [options.discovery] - Use @clever/discovery to locate the server. Must provide
+   * this or the address argument
+   * @param {number} [options.timeout] - The timeout to use for all client requests,
    * in milliseconds. This can be overridden on a per-request basis.
-   * @param {Object} [options.retryPolicy=RetryPolicies.Default] - The logic to
+   * @param {module:swagger-test.RetryPolicies} [options.retryPolicy=RetryPolicies.Default] - The logic to
    * determine which requests to retry, as well as how many times to retry.
-   * @param {function} options.retryPolicy.backoffs
-   * @param {function} options.retryPolicy.retry
    */
   constructor(options) {
     options = options || {};
@@ -110,6 +96,10 @@ class SwaggerTest {
 
   /**
    * @param {number} id
+   * @param {object} [options]
+   * @param {number} [options.timeout] - A request specific timeout
+   * @param {external:Span} [options.span] - An OpenTracing span - For example from the parent request
+   * @param {module:swagger-test.RetryPolicies} [options.retryPolicy] - A request specific retryPolicy
    * @param {function} [cb]
    * @returns {Promise}
    * @fulfill {undefined}

--- a/samples/gen-js-errors/types.js
+++ b/samples/gen-js-errors/types.js
@@ -1,5 +1,13 @@
 module.exports.Errors = {};
 
+/**
+ * ExtendedError
+ * @extends Error
+ * @memberof module:swagger-test
+ * @alias module:swagger-test.Errors.ExtendedError
+ * @property {number} code
+ * @property {string} message
+ */
 module.exports.Errors.ExtendedError = class extends Error {
   constructor(body) {
     super(body.message);
@@ -8,6 +16,14 @@ module.exports.Errors.ExtendedError = class extends Error {
     }
   }
 };
+
+/**
+ * NotFound
+ * @extends Error
+ * @memberof module:swagger-test
+ * @alias module:swagger-test.Errors.NotFound
+ * @property {string} message
+ */
 module.exports.Errors.NotFound = class extends Error {
   constructor(body) {
     super(body.message);
@@ -16,6 +32,15 @@ module.exports.Errors.NotFound = class extends Error {
     }
   }
 };
+
+/**
+ * InternalError
+ * @extends Error
+ * @memberof module:swagger-test
+ * @alias module:swagger-test.Errors.InternalError
+ * @property {number} code
+ * @property {string} message
+ */
 module.exports.Errors.InternalError = class extends Error {
   constructor(body) {
     super(body.message);

--- a/samples/gen-js/README.md
+++ b/samples/gen-js/README.md
@@ -8,19 +8,15 @@ swagger-test client library.
     * [SwaggerTest](#exp_module_swagger-test--SwaggerTest) ⏏
         * [new SwaggerTest(options)](#new_module_swagger-test--SwaggerTest_new)
         * _instance_
-            * [.getBooks(params, [cb])](#module_swagger-test--SwaggerTest+getBooks) ⇒ <code>Promise</code>
-            * [.createBook(newBook, [cb])](#module_swagger-test--SwaggerTest+createBook) ⇒ <code>Promise</code>
-            * [.getBookByID(params, [cb])](#module_swagger-test--SwaggerTest+getBookByID) ⇒ <code>Promise</code>
-            * [.getBookByID2(id, [cb])](#module_swagger-test--SwaggerTest+getBookByID2) ⇒ <code>Promise</code>
-            * [.healthCheck([cb])](#module_swagger-test--SwaggerTest+healthCheck) ⇒ <code>Promise</code>
+            * [.getBooks(params, [options], [cb])](#module_swagger-test--SwaggerTest+getBooks) ⇒ <code>Promise</code>
+            * [.createBook(newBook, [options], [cb])](#module_swagger-test--SwaggerTest+createBook) ⇒ <code>Promise</code>
+            * [.getBookByID(params, [options], [cb])](#module_swagger-test--SwaggerTest+getBookByID) ⇒ <code>Promise</code>
+            * [.getBookByID2(id, [options], [cb])](#module_swagger-test--SwaggerTest+getBookByID2) ⇒ <code>Promise</code>
+            * [.healthCheck([options], [cb])](#module_swagger-test--SwaggerTest+healthCheck) ⇒ <code>Promise</code>
         * _static_
             * [.RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)
                 * [.Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)
-                    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs) ⇒ <code>Array.&lt;number&gt;</code>
-                    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.retry) ⇒ <code>boolean</code>
                 * [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
-                    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs)
-                    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.None.retry)
             * [.Errors](#module_swagger-test--SwaggerTest.Errors)
                 * [.BadRequest](#module_swagger-test--SwaggerTest.Errors.BadRequest) ⇐ <code>Error</code>
                 * [.InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError) ⇐ <code>Error</code>
@@ -30,7 +26,7 @@ swagger-test client library.
 <a name="exp_module_swagger-test--SwaggerTest"></a>
 
 ### SwaggerTest ⏏
-The main client object to instantiate.
+swagger-test client
 
 **Kind**: Exported class  
 <a name="new_module_swagger-test--SwaggerTest_new"></a>
@@ -42,15 +38,14 @@ Create a new client object.
 | Param | Type | Default | Description |
 | --- | --- | --- | --- |
 | options | <code>Object</code> |  | Options for constructing a client object. |
-| options.address | <code>string</code> |  | URL where the server is located. If not specified, the address will be discovered via @clever/discovery. |
-| options.timeout | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. |
-| [options.retryPolicy] | <code>Object</code> | <code>RetryPolicies.Default</code> | The logic to determine which requests to retry, as well as how many times to retry. |
-| options.retryPolicy.backoffs | <code>function</code> |  |  |
-| options.retryPolicy.retry | <code>function</code> |  |  |
+| [options.address] | <code>string</code> |  | URL where the server is located. Must provide this or the discovery argument |
+| [options.discovery] | <code>bool</code> |  | Use @clever/discovery to locate the server. Must provide this or the address argument |
+| [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. |
+| [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | <code>RetryPolicies.Default</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 
 <a name="module_swagger-test--SwaggerTest+getBooks"></a>
 
-#### swaggerTest.getBooks(params, [cb]) ⇒ <code>Promise</code>
+#### swaggerTest.getBooks(params, [options], [cb]) ⇒ <code>Promise</code>
 Returns a list of books
 
 **Kind**: instance method of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
@@ -59,23 +54,27 @@ Returns a list of books
 **Reject**: <code>[InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError)</code>  
 **Reject**: <code>Error</code>  
 
-| Param | Type | Default |
-| --- | --- | --- |
-| params | <code>Object</code> |  | 
-| [params.authors] | <code>Array.&lt;string&gt;</code> |  | 
-| [params.available] | <code>boolean</code> | <code>true</code> | 
-| [params.state] | <code>string</code> | <code>&quot;finished&quot;</code> | 
-| [params.published] | <code>string</code> |  | 
-| [params.snakeCase] | <code>string</code> |  | 
-| [params.completed] | <code>string</code> |  | 
-| [params.maxPages] | <code>number</code> | <code>500.5</code> | 
-| [params.minPages] | <code>number</code> | <code>5</code> | 
-| [params.pagesToTime] | <code>number</code> |  | 
-| [cb] | <code>function</code> |  | 
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| params | <code>Object</code> |  |  |
+| [params.authors] | <code>Array.&lt;string&gt;</code> |  | A list of authors. Must specify at least one and at most two |
+| [params.available] | <code>boolean</code> | <code>true</code> |  |
+| [params.state] | <code>string</code> | <code>&quot;finished&quot;</code> |  |
+| [params.published] | <code>string</code> |  |  |
+| [params.snakeCase] | <code>string</code> |  |  |
+| [params.completed] | <code>string</code> |  |  |
+| [params.maxPages] | <code>number</code> | <code>500.5</code> |  |
+| [params.minPages] | <code>number</code> | <code>5</code> |  |
+| [params.pagesToTime] | <code>number</code> |  |  |
+| [options] | <code>object</code> |  |  |
+| [options.timeout] | <code>number</code> |  | A request specific timeout |
+| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> |  | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> |  | A request specific retryPolicy |
+| [cb] | <code>function</code> |  |  |
 
 <a name="module_swagger-test--SwaggerTest+createBook"></a>
 
-#### swaggerTest.createBook(newBook, [cb]) ⇒ <code>Promise</code>
+#### swaggerTest.createBook(newBook, [options], [cb]) ⇒ <code>Promise</code>
 Creates a book
 
 **Kind**: instance method of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
@@ -84,14 +83,18 @@ Creates a book
 **Reject**: <code>[InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError)</code>  
 **Reject**: <code>Error</code>  
 
-| Param | Type |
-| --- | --- |
-| newBook |  | 
-| [cb] | <code>function</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| newBook |  |  |
+| [options] | <code>object</code> |  |
+| [options.timeout] | <code>number</code> | A request specific timeout |
+| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | A request specific retryPolicy |
+| [cb] | <code>function</code> |  |
 
 <a name="module_swagger-test--SwaggerTest+getBookByID"></a>
 
-#### swaggerTest.getBookByID(params, [cb]) ⇒ <code>Promise</code>
+#### swaggerTest.getBookByID(params, [options], [cb]) ⇒ <code>Promise</code>
 Returns a book
 
 **Kind**: instance method of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
@@ -102,18 +105,22 @@ Returns a book
 **Reject**: <code>[InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError)</code>  
 **Reject**: <code>Error</code>  
 
-| Param | Type |
-| --- | --- |
-| params | <code>Object</code> | 
-| params.bookID | <code>number</code> | 
-| [params.authorID] | <code>string</code> | 
-| [params.authorization] | <code>string</code> | 
-| [params.randomBytes] | <code>string</code> | 
-| [cb] | <code>function</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| params | <code>Object</code> |  |
+| params.bookID | <code>number</code> |  |
+| [params.authorID] | <code>string</code> |  |
+| [params.authorization] | <code>string</code> |  |
+| [params.randomBytes] | <code>string</code> |  |
+| [options] | <code>object</code> |  |
+| [options.timeout] | <code>number</code> | A request specific timeout |
+| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | A request specific retryPolicy |
+| [cb] | <code>function</code> |  |
 
 <a name="module_swagger-test--SwaggerTest+getBookByID2"></a>
 
-#### swaggerTest.getBookByID2(id, [cb]) ⇒ <code>Promise</code>
+#### swaggerTest.getBookByID2(id, [options], [cb]) ⇒ <code>Promise</code>
 Retrieve a book
 
 **Kind**: instance method of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
@@ -123,23 +130,31 @@ Retrieve a book
 **Reject**: <code>[InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError)</code>  
 **Reject**: <code>Error</code>  
 
-| Param | Type |
-| --- | --- |
-| id | <code>string</code> | 
-| [cb] | <code>function</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| id | <code>string</code> |  |
+| [options] | <code>object</code> |  |
+| [options.timeout] | <code>number</code> | A request specific timeout |
+| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | A request specific retryPolicy |
+| [cb] | <code>function</code> |  |
 
 <a name="module_swagger-test--SwaggerTest+healthCheck"></a>
 
-#### swaggerTest.healthCheck([cb]) ⇒ <code>Promise</code>
+#### swaggerTest.healthCheck([options], [cb]) ⇒ <code>Promise</code>
 **Kind**: instance method of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
 **Fulfill**: <code>undefined</code>  
 **Reject**: <code>[BadRequest](#module_swagger-test--SwaggerTest.Errors.BadRequest)</code>  
 **Reject**: <code>[InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError)</code>  
 **Reject**: <code>Error</code>  
 
-| Param | Type |
-| --- | --- |
-| [cb] | <code>function</code> | 
+| Param | Type | Description |
+| --- | --- | --- |
+| [options] | <code>object</code> |  |
+| [options.timeout] | <code>number</code> | A request specific timeout |
+| [options.span] | <code>[Span](https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html)</code> | An OpenTracing span - For example from the parent request |
+| [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | A request specific retryPolicy |
+| [cb] | <code>function</code> |  |
 
 <a name="module_swagger-test--SwaggerTest.RetryPolicies"></a>
 
@@ -150,11 +165,7 @@ Retry policies available to use.
 
 * [.RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)
     * [.Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)
-        * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs) ⇒ <code>Array.&lt;number&gt;</code>
-        * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.retry) ⇒ <code>boolean</code>
     * [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
-        * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs)
-        * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.None.retry)
 
 <a name="module_swagger-test--SwaggerTest.RetryPolicies.Default"></a>
 
@@ -162,49 +173,12 @@ Retry policies available to use.
 The default retry policy will retry five times with an exponential backoff.
 
 **Kind**: static constant of <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code>  
-
-* [.Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)
-    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs) ⇒ <code>Array.&lt;number&gt;</code>
-    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.retry) ⇒ <code>boolean</code>
-
-<a name="module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs"></a>
-
-###### Default.backoffs() ⇒ <code>Array.&lt;number&gt;</code>
-backoffs returns an array of five backoffs: 100ms, 200ms, 400ms, 800ms, and
-1.6s. It adds a random 5% jitter to each backoff.
-
-**Kind**: static method of <code>[Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)</code>  
-<a name="module_swagger-test--SwaggerTest.RetryPolicies.Default.retry"></a>
-
-###### Default.retry() ⇒ <code>boolean</code>
-retry will not retry a request if the HTTP client returns an error, if the
-is a POST or PATCH, or if the status code is less than 500. It will retry
-all other requests.
-
-**Kind**: static method of <code>[Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)</code>  
 <a name="module_swagger-test--SwaggerTest.RetryPolicies.None"></a>
 
 ##### RetryPolicies.None
 Use this retry policy to turn off retries.
 
 **Kind**: static constant of <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code>  
-
-* [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
-    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs)
-    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.None.retry)
-
-<a name="module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs"></a>
-
-###### None.backoffs()
-returns an empty array
-
-**Kind**: static method of <code>[None](#module_swagger-test--SwaggerTest.RetryPolicies.None)</code>  
-<a name="module_swagger-test--SwaggerTest.RetryPolicies.None.retry"></a>
-
-###### None.retry()
-returns false
-
-**Kind**: static method of <code>[None](#module_swagger-test--SwaggerTest.RetryPolicies.None)</code>  
 <a name="module_swagger-test--SwaggerTest.Errors"></a>
 
 #### SwaggerTest.Errors

--- a/samples/gen-js/README.md
+++ b/samples/gen-js/README.md
@@ -1,0 +1,273 @@
+<a name="module_swagger-test"></a>
+
+## swagger-test
+swagger-test client library.
+
+
+* [swagger-test](#module_swagger-test)
+    * [SwaggerTest](#exp_module_swagger-test--SwaggerTest) ⏏
+        * [new SwaggerTest(options)](#new_module_swagger-test--SwaggerTest_new)
+        * _instance_
+            * [.getBooks(params, [cb])](#module_swagger-test--SwaggerTest+getBooks) ⇒ <code>Promise</code>
+            * [.createBook(newBook, [cb])](#module_swagger-test--SwaggerTest+createBook) ⇒ <code>Promise</code>
+            * [.getBookByID(params, [cb])](#module_swagger-test--SwaggerTest+getBookByID) ⇒ <code>Promise</code>
+            * [.getBookByID2(id, [cb])](#module_swagger-test--SwaggerTest+getBookByID2) ⇒ <code>Promise</code>
+            * [.healthCheck([cb])](#module_swagger-test--SwaggerTest+healthCheck) ⇒ <code>Promise</code>
+        * _static_
+            * [.RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)
+                * [.Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)
+                    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs) ⇒ <code>Array.&lt;number&gt;</code>
+                    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.retry) ⇒ <code>boolean</code>
+                * [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
+                    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs)
+                    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.None.retry)
+            * [.Errors](#module_swagger-test--SwaggerTest.Errors)
+                * [.BadRequest](#module_swagger-test--SwaggerTest.Errors.BadRequest) ⇐ <code>Error</code>
+                * [.InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError) ⇐ <code>Error</code>
+                * [.Unathorized](#module_swagger-test--SwaggerTest.Errors.Unathorized) ⇐ <code>Error</code>
+                * [.Error](#module_swagger-test--SwaggerTest.Errors.Error) ⇐ <code>Error</code>
+
+<a name="exp_module_swagger-test--SwaggerTest"></a>
+
+### SwaggerTest ⏏
+The main client object to instantiate.
+
+**Kind**: Exported class  
+<a name="new_module_swagger-test--SwaggerTest_new"></a>
+
+#### new SwaggerTest(options)
+Create a new client object.
+
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| options | <code>Object</code> |  | Options for constructing a client object. |
+| options.address | <code>string</code> |  | URL where the server is located. If not specified, the address will be discovered via @clever/discovery. |
+| options.timeout | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. |
+| [options.retryPolicy] | <code>Object</code> | <code>RetryPolicies.Default</code> | The logic to determine which requests to retry, as well as how many times to retry. |
+| options.retryPolicy.backoffs | <code>function</code> |  |  |
+| options.retryPolicy.retry | <code>function</code> |  |  |
+
+<a name="module_swagger-test--SwaggerTest+getBooks"></a>
+
+#### swaggerTest.getBooks(params, [cb]) ⇒ <code>Promise</code>
+Returns a list of books
+
+**Kind**: instance method of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
+**Fulfill**: <code>Object[]</code>  
+**Reject**: <code>[BadRequest](#module_swagger-test--SwaggerTest.Errors.BadRequest)</code>  
+**Reject**: <code>[InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError)</code>  
+**Reject**: <code>Error</code>  
+
+| Param | Type | Default |
+| --- | --- | --- |
+| params | <code>Object</code> |  | 
+| [params.authors] | <code>Array.&lt;string&gt;</code> |  | 
+| [params.available] | <code>boolean</code> | <code>true</code> | 
+| [params.state] | <code>string</code> | <code>&quot;finished&quot;</code> | 
+| [params.published] | <code>string</code> |  | 
+| [params.snakeCase] | <code>string</code> |  | 
+| [params.completed] | <code>string</code> |  | 
+| [params.maxPages] | <code>number</code> | <code>500.5</code> | 
+| [params.minPages] | <code>number</code> | <code>5</code> | 
+| [params.pagesToTime] | <code>number</code> |  | 
+| [cb] | <code>function</code> |  | 
+
+<a name="module_swagger-test--SwaggerTest+createBook"></a>
+
+#### swaggerTest.createBook(newBook, [cb]) ⇒ <code>Promise</code>
+Creates a book
+
+**Kind**: instance method of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
+**Fulfill**: <code>Object</code>  
+**Reject**: <code>[BadRequest](#module_swagger-test--SwaggerTest.Errors.BadRequest)</code>  
+**Reject**: <code>[InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError)</code>  
+**Reject**: <code>Error</code>  
+
+| Param | Type |
+| --- | --- |
+| newBook |  | 
+| [cb] | <code>function</code> | 
+
+<a name="module_swagger-test--SwaggerTest+getBookByID"></a>
+
+#### swaggerTest.getBookByID(params, [cb]) ⇒ <code>Promise</code>
+Returns a book
+
+**Kind**: instance method of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
+**Fulfill**: <code>Object</code>  
+**Reject**: <code>[BadRequest](#module_swagger-test--SwaggerTest.Errors.BadRequest)</code>  
+**Reject**: <code>[Unathorized](#module_swagger-test--SwaggerTest.Errors.Unathorized)</code>  
+**Reject**: <code>[Error](#module_swagger-test--SwaggerTest.Errors.Error)</code>  
+**Reject**: <code>[InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError)</code>  
+**Reject**: <code>Error</code>  
+
+| Param | Type |
+| --- | --- |
+| params | <code>Object</code> | 
+| params.bookID | <code>number</code> | 
+| [params.authorID] | <code>string</code> | 
+| [params.authorization] | <code>string</code> | 
+| [params.randomBytes] | <code>string</code> | 
+| [cb] | <code>function</code> | 
+
+<a name="module_swagger-test--SwaggerTest+getBookByID2"></a>
+
+#### swaggerTest.getBookByID2(id, [cb]) ⇒ <code>Promise</code>
+Retrieve a book
+
+**Kind**: instance method of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
+**Fulfill**: <code>Object</code>  
+**Reject**: <code>[BadRequest](#module_swagger-test--SwaggerTest.Errors.BadRequest)</code>  
+**Reject**: <code>[Error](#module_swagger-test--SwaggerTest.Errors.Error)</code>  
+**Reject**: <code>[InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError)</code>  
+**Reject**: <code>Error</code>  
+
+| Param | Type |
+| --- | --- |
+| id | <code>string</code> | 
+| [cb] | <code>function</code> | 
+
+<a name="module_swagger-test--SwaggerTest+healthCheck"></a>
+
+#### swaggerTest.healthCheck([cb]) ⇒ <code>Promise</code>
+**Kind**: instance method of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
+**Fulfill**: <code>undefined</code>  
+**Reject**: <code>[BadRequest](#module_swagger-test--SwaggerTest.Errors.BadRequest)</code>  
+**Reject**: <code>[InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError)</code>  
+**Reject**: <code>Error</code>  
+
+| Param | Type |
+| --- | --- |
+| [cb] | <code>function</code> | 
+
+<a name="module_swagger-test--SwaggerTest.RetryPolicies"></a>
+
+#### SwaggerTest.RetryPolicies
+Retry policies available to use.
+
+**Kind**: static property of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
+
+* [.RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)
+    * [.Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)
+        * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs) ⇒ <code>Array.&lt;number&gt;</code>
+        * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.retry) ⇒ <code>boolean</code>
+    * [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
+        * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs)
+        * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.None.retry)
+
+<a name="module_swagger-test--SwaggerTest.RetryPolicies.Default"></a>
+
+##### RetryPolicies.Default
+The default retry policy will retry five times with an exponential backoff.
+
+**Kind**: static constant of <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code>  
+
+* [.Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)
+    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs) ⇒ <code>Array.&lt;number&gt;</code>
+    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.Default.retry) ⇒ <code>boolean</code>
+
+<a name="module_swagger-test--SwaggerTest.RetryPolicies.Default.backoffs"></a>
+
+###### Default.backoffs() ⇒ <code>Array.&lt;number&gt;</code>
+backoffs returns an array of five backoffs: 100ms, 200ms, 400ms, 800ms, and
+1.6s. It adds a random 5% jitter to each backoff.
+
+**Kind**: static method of <code>[Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)</code>  
+<a name="module_swagger-test--SwaggerTest.RetryPolicies.Default.retry"></a>
+
+###### Default.retry() ⇒ <code>boolean</code>
+retry will not retry a request if the HTTP client returns an error, if the
+is a POST or PATCH, or if the status code is less than 500. It will retry
+all other requests.
+
+**Kind**: static method of <code>[Default](#module_swagger-test--SwaggerTest.RetryPolicies.Default)</code>  
+<a name="module_swagger-test--SwaggerTest.RetryPolicies.None"></a>
+
+##### RetryPolicies.None
+Use this retry policy to turn off retries.
+
+**Kind**: static constant of <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code>  
+
+* [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
+    * [.backoffs()](#module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs)
+    * [.retry()](#module_swagger-test--SwaggerTest.RetryPolicies.None.retry)
+
+<a name="module_swagger-test--SwaggerTest.RetryPolicies.None.backoffs"></a>
+
+###### None.backoffs()
+returns an empty array
+
+**Kind**: static method of <code>[None](#module_swagger-test--SwaggerTest.RetryPolicies.None)</code>  
+<a name="module_swagger-test--SwaggerTest.RetryPolicies.None.retry"></a>
+
+###### None.retry()
+returns false
+
+**Kind**: static method of <code>[None](#module_swagger-test--SwaggerTest.RetryPolicies.None)</code>  
+<a name="module_swagger-test--SwaggerTest.Errors"></a>
+
+#### SwaggerTest.Errors
+Errors returned by methods.
+
+**Kind**: static property of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
+
+* [.Errors](#module_swagger-test--SwaggerTest.Errors)
+    * [.BadRequest](#module_swagger-test--SwaggerTest.Errors.BadRequest) ⇐ <code>Error</code>
+    * [.InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError) ⇐ <code>Error</code>
+    * [.Unathorized](#module_swagger-test--SwaggerTest.Errors.Unathorized) ⇐ <code>Error</code>
+    * [.Error](#module_swagger-test--SwaggerTest.Errors.Error) ⇐ <code>Error</code>
+
+<a name="module_swagger-test--SwaggerTest.Errors.BadRequest"></a>
+
+##### Errors.BadRequest ⇐ <code>Error</code>
+BadRequest
+
+**Kind**: static class of <code>[Errors](#module_swagger-test--SwaggerTest.Errors)</code>  
+**Extends:** <code>Error</code>  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| message | <code>string</code> | 
+
+<a name="module_swagger-test--SwaggerTest.Errors.InternalError"></a>
+
+##### Errors.InternalError ⇐ <code>Error</code>
+InternalError
+
+**Kind**: static class of <code>[Errors](#module_swagger-test--SwaggerTest.Errors)</code>  
+**Extends:** <code>Error</code>  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| message | <code>string</code> | 
+
+<a name="module_swagger-test--SwaggerTest.Errors.Unathorized"></a>
+
+##### Errors.Unathorized ⇐ <code>Error</code>
+Unathorized
+
+**Kind**: static class of <code>[Errors](#module_swagger-test--SwaggerTest.Errors)</code>  
+**Extends:** <code>Error</code>  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| message | <code>string</code> | 
+
+<a name="module_swagger-test--SwaggerTest.Errors.Error"></a>
+
+##### Errors.Error ⇐ <code>Error</code>
+Error
+
+**Kind**: static class of <code>[Errors](#module_swagger-test--SwaggerTest.Errors)</code>  
+**Extends:** <code>Error</code>  
+**Properties**
+
+| Name | Type |
+| --- | --- |
+| code | <code>number</code> | 
+| message | <code>string</code> | 
+

--- a/samples/gen-js/index.js
+++ b/samples/gen-js/index.js
@@ -4,7 +4,17 @@ const opentracing = require("opentracing");
 
 const { Errors } = require("./types");
 
+/**
+ * The default retry policy will retry five times with an exponential backoff.
+ * @alias module:swagger-test.RetryPolicies.Default
+ */
 const defaultRetryPolicy = {
+  /**
+   * backoffs returns an array of five backoffs: 100ms, 200ms, 400ms, 800ms, and
+   * 1.6s. It adds a random 5% jitter to each backoff.
+   * @function
+   * @returns {Array<number>}
+   */
   backoffs() {
     const ret = [];
     let next = 100.0; // milliseconds
@@ -16,6 +26,13 @@ const defaultRetryPolicy = {
     }
     return ret;
   },
+  /**
+   * retry will not retry a request if the HTTP client returns an error, if the
+   * is a POST or PATCH, or if the status code is less than 500. It will retry
+   * all other requests.
+   * @function
+   * @returns {boolean}
+   */
   retry(requestOptions, err, res) {
     if (err || requestOptions.method === "POST" ||
         requestOptions.method === "PATCH" ||
@@ -26,17 +43,49 @@ const defaultRetryPolicy = {
   },
 };
 
+/**
+ * Use this retry policy to turn off retries.
+ * @alias module:swagger-test.RetryPolicies.None
+ */
 const noRetryPolicy = {
+  /**
+   * returns an empty array
+   */
   backoffs() {
     return [];
   },
+  /**
+   * returns false
+   */
   retry() {
     return false;
   },
 };
 
-module.exports = class SwaggerTest {
+/**
+ * swagger-test client library.
+ * @module swagger-test
+ * @typicalname SwaggerTest
+ */
 
+/**
+ * The main client object to instantiate.
+ * @alias module:swagger-test
+ */
+class SwaggerTest {
+
+  /**
+   * Create a new client object.
+   * @param {Object} options - Options for constructing a client object.
+   * @param {string} options.address - URL where the server is located. If not
+   * specified, the address will be discovered via @clever/discovery.
+   * @param {number} options.timeout - The timeout to use for all client requests,
+   * in milliseconds. This can be overridden on a per-request basis.
+   * @param {Object} [options.retryPolicy=RetryPolicies.Default] - The logic to
+   * determine which requests to retry, as well as how many times to retry.
+   * @param {function} options.retryPolicy.backoffs
+   * @param {function} options.retryPolicy.retry
+   */
   constructor(options) {
     options = options || {};
 
@@ -59,6 +108,25 @@ module.exports = class SwaggerTest {
     }
   }
 
+  /**
+   * Returns a list of books
+   * @param {Object} params
+   * @param {string[]} [params.authors]
+   * @param {boolean} [params.available=true]
+   * @param {string} [params.state=finished]
+   * @param {string} [params.published]
+   * @param {string} [params.snakeCase]
+   * @param {string} [params.completed]
+   * @param {number} [params.maxPages=500.5]
+   * @param {number} [params.minPages=5]
+   * @param {number} [params.pagesToTime]
+   * @param {function} [cb]
+   * @returns {Promise}
+   * @fulfill {Object[]}
+   * @reject {module:swagger-test.Errors.BadRequest}
+   * @reject {module:swagger-test.Errors.InternalError}
+   * @reject {Error}
+   */
   getBooks(params, options, cb) {
     if (!cb && typeof options === "function") {
       cb = options;
@@ -175,6 +243,16 @@ module.exports = class SwaggerTest {
     });
   }
 
+  /**
+   * Creates a book
+   * @param newBook
+   * @param {function} [cb]
+   * @returns {Promise}
+   * @fulfill {Object}
+   * @reject {module:swagger-test.Errors.BadRequest}
+   * @reject {module:swagger-test.Errors.InternalError}
+   * @reject {Error}
+   */
   createBook(newBook, options, cb) {
     const params = {};
     params["newBook"] = newBook;
@@ -260,6 +338,22 @@ module.exports = class SwaggerTest {
     });
   }
 
+  /**
+   * Returns a book
+   * @param {Object} params
+   * @param {number} params.bookID
+   * @param {string} [params.authorID]
+   * @param {string} [params.authorization]
+   * @param {string} [params.randomBytes]
+   * @param {function} [cb]
+   * @returns {Promise}
+   * @fulfill {Object}
+   * @reject {module:swagger-test.Errors.BadRequest}
+   * @reject {module:swagger-test.Errors.Unathorized}
+   * @reject {module:swagger-test.Errors.Error}
+   * @reject {module:swagger-test.Errors.InternalError}
+   * @reject {Error}
+   */
   getBookByID(params, options, cb) {
     if (!cb && typeof options === "function") {
       cb = options;
@@ -355,6 +449,17 @@ module.exports = class SwaggerTest {
     });
   }
 
+  /**
+   * Retrieve a book
+   * @param {string} id
+   * @param {function} [cb]
+   * @returns {Promise}
+   * @fulfill {Object}
+   * @reject {module:swagger-test.Errors.BadRequest}
+   * @reject {module:swagger-test.Errors.Error}
+   * @reject {module:swagger-test.Errors.InternalError}
+   * @reject {Error}
+   */
   getBookByID2(id, options, cb) {
     const params = {};
     params["id"] = id;
@@ -441,6 +546,14 @@ module.exports = class SwaggerTest {
     });
   }
 
+  /**
+   * @param {function} [cb]
+   * @returns {Promise}
+   * @fulfill {undefined}
+   * @reject {module:swagger-test.Errors.BadRequest}
+   * @reject {module:swagger-test.Errors.InternalError}
+   * @reject {Error}
+   */
   healthCheck(options, cb) {
     const params = {};
 
@@ -524,8 +637,19 @@ module.exports = class SwaggerTest {
   }
 };
 
+module.exports = SwaggerTest;
+
+/**
+ * Retry policies available to use.
+ * @alias module:swagger-test.RetryPolicies
+ */
 module.exports.RetryPolicies = {
   Default: defaultRetryPolicy,
   None: noRetryPolicy,
 };
+
+/**
+ * Errors returned by methods.
+ * @alias module:swagger-test.Errors
+ */
 module.exports.Errors = Errors;

--- a/samples/gen-js/index.js
+++ b/samples/gen-js/index.js
@@ -2,6 +2,11 @@ const discovery = require("@clever/discovery");
 const request = require("request");
 const opentracing = require("opentracing");
 
+/**
+ * @external Span
+ * @see {@link https://doc.esdoc.org/github.com/opentracing/opentracing-javascript/class/src/span.js~Span.html}
+ */
+
 const { Errors } = require("./types");
 
 /**
@@ -9,12 +14,6 @@ const { Errors } = require("./types");
  * @alias module:swagger-test.RetryPolicies.Default
  */
 const defaultRetryPolicy = {
-  /**
-   * backoffs returns an array of five backoffs: 100ms, 200ms, 400ms, 800ms, and
-   * 1.6s. It adds a random 5% jitter to each backoff.
-   * @function
-   * @returns {Array<number>}
-   */
   backoffs() {
     const ret = [];
     let next = 100.0; // milliseconds
@@ -26,13 +25,6 @@ const defaultRetryPolicy = {
     }
     return ret;
   },
-  /**
-   * retry will not retry a request if the HTTP client returns an error, if the
-   * is a POST or PATCH, or if the status code is less than 500. It will retry
-   * all other requests.
-   * @function
-   * @returns {boolean}
-   */
   retry(requestOptions, err, res) {
     if (err || requestOptions.method === "POST" ||
         requestOptions.method === "PATCH" ||
@@ -48,15 +40,9 @@ const defaultRetryPolicy = {
  * @alias module:swagger-test.RetryPolicies.None
  */
 const noRetryPolicy = {
-  /**
-   * returns an empty array
-   */
   backoffs() {
     return [];
   },
-  /**
-   * returns false
-   */
   retry() {
     return false;
   },
@@ -69,7 +55,7 @@ const noRetryPolicy = {
  */
 
 /**
- * The main client object to instantiate.
+ * swagger-test client
  * @alias module:swagger-test
  */
 class SwaggerTest {
@@ -77,14 +63,14 @@ class SwaggerTest {
   /**
    * Create a new client object.
    * @param {Object} options - Options for constructing a client object.
-   * @param {string} options.address - URL where the server is located. If not
-   * specified, the address will be discovered via @clever/discovery.
-   * @param {number} options.timeout - The timeout to use for all client requests,
+   * @param {string} [options.address] - URL where the server is located. Must provide
+   * this or the discovery argument
+   * @param {bool} [options.discovery] - Use @clever/discovery to locate the server. Must provide
+   * this or the address argument
+   * @param {number} [options.timeout] - The timeout to use for all client requests,
    * in milliseconds. This can be overridden on a per-request basis.
-   * @param {Object} [options.retryPolicy=RetryPolicies.Default] - The logic to
+   * @param {module:swagger-test.RetryPolicies} [options.retryPolicy=RetryPolicies.Default] - The logic to
    * determine which requests to retry, as well as how many times to retry.
-   * @param {function} options.retryPolicy.backoffs
-   * @param {function} options.retryPolicy.retry
    */
   constructor(options) {
     options = options || {};
@@ -111,7 +97,7 @@ class SwaggerTest {
   /**
    * Returns a list of books
    * @param {Object} params
-   * @param {string[]} [params.authors]
+   * @param {string[]} [params.authors] - A list of authors. Must specify at least one and at most two
    * @param {boolean} [params.available=true]
    * @param {string} [params.state=finished]
    * @param {string} [params.published]
@@ -120,6 +106,10 @@ class SwaggerTest {
    * @param {number} [params.maxPages=500.5]
    * @param {number} [params.minPages=5]
    * @param {number} [params.pagesToTime]
+   * @param {object} [options]
+   * @param {number} [options.timeout] - A request specific timeout
+   * @param {external:Span} [options.span] - An OpenTracing span - For example from the parent request
+   * @param {module:swagger-test.RetryPolicies} [options.retryPolicy] - A request specific retryPolicy
    * @param {function} [cb]
    * @returns {Promise}
    * @fulfill {Object[]}
@@ -246,6 +236,10 @@ class SwaggerTest {
   /**
    * Creates a book
    * @param newBook
+   * @param {object} [options]
+   * @param {number} [options.timeout] - A request specific timeout
+   * @param {external:Span} [options.span] - An OpenTracing span - For example from the parent request
+   * @param {module:swagger-test.RetryPolicies} [options.retryPolicy] - A request specific retryPolicy
    * @param {function} [cb]
    * @returns {Promise}
    * @fulfill {Object}
@@ -345,6 +339,10 @@ class SwaggerTest {
    * @param {string} [params.authorID]
    * @param {string} [params.authorization]
    * @param {string} [params.randomBytes]
+   * @param {object} [options]
+   * @param {number} [options.timeout] - A request specific timeout
+   * @param {external:Span} [options.span] - An OpenTracing span - For example from the parent request
+   * @param {module:swagger-test.RetryPolicies} [options.retryPolicy] - A request specific retryPolicy
    * @param {function} [cb]
    * @returns {Promise}
    * @fulfill {Object}
@@ -452,6 +450,10 @@ class SwaggerTest {
   /**
    * Retrieve a book
    * @param {string} id
+   * @param {object} [options]
+   * @param {number} [options.timeout] - A request specific timeout
+   * @param {external:Span} [options.span] - An OpenTracing span - For example from the parent request
+   * @param {module:swagger-test.RetryPolicies} [options.retryPolicy] - A request specific retryPolicy
    * @param {function} [cb]
    * @returns {Promise}
    * @fulfill {Object}
@@ -547,6 +549,10 @@ class SwaggerTest {
   }
 
   /**
+   * @param {object} [options]
+   * @param {number} [options.timeout] - A request specific timeout
+   * @param {external:Span} [options.span] - An OpenTracing span - For example from the parent request
+   * @param {module:swagger-test.RetryPolicies} [options.retryPolicy] - A request specific retryPolicy
    * @param {function} [cb]
    * @returns {Promise}
    * @fulfill {undefined}

--- a/samples/gen-js/types.js
+++ b/samples/gen-js/types.js
@@ -1,5 +1,12 @@
 module.exports.Errors = {};
 
+/**
+ * BadRequest
+ * @extends Error
+ * @memberof module:swagger-test
+ * @alias module:swagger-test.Errors.BadRequest
+ * @property {string} message
+ */
 module.exports.Errors.BadRequest = class extends Error {
   constructor(body) {
     super(body.message);
@@ -8,6 +15,14 @@ module.exports.Errors.BadRequest = class extends Error {
     }
   }
 };
+
+/**
+ * InternalError
+ * @extends Error
+ * @memberof module:swagger-test
+ * @alias module:swagger-test.Errors.InternalError
+ * @property {string} message
+ */
 module.exports.Errors.InternalError = class extends Error {
   constructor(body) {
     super(body.message);
@@ -16,6 +31,14 @@ module.exports.Errors.InternalError = class extends Error {
     }
   }
 };
+
+/**
+ * Unathorized
+ * @extends Error
+ * @memberof module:swagger-test
+ * @alias module:swagger-test.Errors.Unathorized
+ * @property {string} message
+ */
 module.exports.Errors.Unathorized = class extends Error {
   constructor(body) {
     super(body.message);
@@ -24,6 +47,15 @@ module.exports.Errors.Unathorized = class extends Error {
     }
   }
 };
+
+/**
+ * Error
+ * @extends Error
+ * @memberof module:swagger-test
+ * @alias module:swagger-test.Errors.Error
+ * @property {number} code
+ * @property {string} message
+ */
 module.exports.Errors.Error = class extends Error {
   constructor(body) {
     super(body.message);

--- a/samples/swagger.yml
+++ b/samples/swagger.yml
@@ -101,6 +101,7 @@ paths:
           type: array
           items:
             type: string
+          description: "A list of authors. Must specify at least one and at most two"
           maxItems: 2
           minItems: 1
           uniqueItems: true


### PR DESCRIPTION
This adds JSDoc comments to the generated js code, and runs `jsdoc2md` to create a README. You can see an example here: https://github.com/Clever/wag/tree/CREW-95-js-docs/samples/gen-js
