### PR TITLE
Comment on return types

### DIFF
--- a/samples/deprecated.yml
+++ b/samples/deprecated.yml
@@ -21,12 +21,12 @@ responses:
     schema:
       $ref: "#/definitions/InternalError"
 paths:
-  /books/{id}:
+  /health:
     get:
-      operationId: getBook
+      operationId: health
       parameters:
-        - name: id
-          in: path
+        - name: section
+          in: query
           required: true
           type: integer
       deprecated: true

--- a/samples/gen-go-deprecated/models/inputs.go
+++ b/samples/gen-go-deprecated/models/inputs.go
@@ -14,13 +14,13 @@ var _ = strconv.FormatInt
 var _ = validate.Maximum
 var _ = strfmt.NewFormats
 
-// GetBookInput holds the input parameters for a getBook operation.
-type GetBookInput struct {
-	ID int64
+// HealthInput holds the input parameters for a health operation.
+type HealthInput struct {
+	Section int64
 }
 
-// Validate returns an error if any of the GetBookInput parameters don't satisfy the
+// Validate returns an error if any of the HealthInput parameters don't satisfy the
 // requirements from the swagger yml file.
-func (i GetBookInput) Validate() error {
+func (i HealthInput) Validate() error {
 	return nil
 }

--- a/samples/gen-go-deprecated/server/handlers.go
+++ b/samples/gen-go-deprecated/server/handlers.go
@@ -66,9 +66,9 @@ func jsonMarshalNoError(i interface{}) string {
 	return string(bytes)
 }
 
-// statusCodeForGetBook returns the status code corresponding to the returned
+// statusCodeForHealth returns the status code corresponding to the returned
 // object. It returns -1 if the type doesn't correspond to anything.
-func statusCodeForGetBook(obj interface{}) int {
+func statusCodeForHealth(obj interface{}) int {
 
 	switch obj.(type) {
 
@@ -95,9 +95,9 @@ func statusCodeForGetBook(obj interface{}) int {
 	}
 }
 
-func (h handler) GetBookHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+func (h handler) HealthHandler(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 
-	input, err := newGetBookInput(r)
+	input, err := newHealthInput(r)
 
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
@@ -113,14 +113,14 @@ func (h handler) GetBookHandler(ctx context.Context, w http.ResponseWriter, r *h
 		return
 	}
 
-	err = h.GetBook(ctx, input)
+	err = h.Health(ctx, input)
 
 	if err != nil {
 		logger.FromContext(ctx).AddContext("error", err.Error())
 		if btErr, ok := err.(*errors.Error); ok {
 			logger.FromContext(ctx).AddContext("stacktrace", string(btErr.Stack()))
 		}
-		statusCode := statusCodeForGetBook(err)
+		statusCode := statusCodeForHealth(err)
 		if statusCode == -1 {
 			err = models.InternalError{Message: err.Error()}
 			statusCode = 500
@@ -134,24 +134,24 @@ func (h handler) GetBookHandler(ctx context.Context, w http.ResponseWriter, r *h
 
 }
 
-// newGetBookInput takes in an http.Request an returns the input struct.
-func newGetBookInput(r *http.Request) (*models.GetBookInput, error) {
-	var input models.GetBookInput
+// newHealthInput takes in an http.Request an returns the input struct.
+func newHealthInput(r *http.Request) (*models.HealthInput, error) {
+	var input models.HealthInput
 
 	var err error
 	_ = err
 
-	iDStr := mux.Vars(r)["id"]
-	if len(iDStr) == 0 {
+	sectionStr := r.URL.Query().Get("section")
+	if len(sectionStr) == 0 {
 		return nil, errors.New("Parameter must be specified")
 	}
-	if len(iDStr) != 0 {
-		var iDTmp int64
-		iDTmp, err = swag.ConvertInt64(iDStr)
+	if len(sectionStr) != 0 {
+		var sectionTmp int64
+		sectionTmp, err = swag.ConvertInt64(sectionStr)
 		if err != nil {
 			return nil, err
 		}
-		input.ID = iDTmp
+		input.Section = sectionTmp
 
 	}
 

--- a/samples/gen-go-deprecated/server/interface.go
+++ b/samples/gen-go-deprecated/server/interface.go
@@ -11,6 +11,12 @@ import (
 // Controller defines the interface for the swagger-test service.
 type Controller interface {
 
-	// GetBook makes a GET request to /books/{id}.
+	// GetBook makes a GET request to /books/{id}
+	//
+	// 200: nil
+	// 400: *models.BadRequest
+	// 404: *models.NotFound
+	// 500: *models.InternalError
+	// default: client side HTTP errors, for example: context.DeadlineExceeded.
 	GetBook(ctx context.Context, i *models.GetBookInput) error
 }

--- a/samples/gen-go-deprecated/server/interface.go
+++ b/samples/gen-go-deprecated/server/interface.go
@@ -11,12 +11,12 @@ import (
 // Controller defines the interface for the swagger-test service.
 type Controller interface {
 
-	// GetBook makes a GET request to /books/{id}
+	// Health makes a GET request to /health
 	//
 	// 200: nil
 	// 400: *models.BadRequest
 	// 404: *models.NotFound
 	// 500: *models.InternalError
 	// default: client side HTTP errors, for example: context.DeadlineExceeded.
-	GetBook(ctx context.Context, i *models.GetBookInput) error
+	Health(ctx context.Context, i *models.HealthInput) error
 }

--- a/samples/gen-go-deprecated/server/mock_controller.go
+++ b/samples/gen-go-deprecated/server/mock_controller.go
@@ -30,12 +30,12 @@ func (_m *MockController) EXPECT() *_MockControllerRecorder {
 	return _m.recorder
 }
 
-func (_m *MockController) GetBook(ctx context.Context, i *models.GetBookInput) error {
-	ret := _m.ctrl.Call(_m, "GetBook", ctx, i)
+func (_m *MockController) Health(ctx context.Context, i *models.HealthInput) error {
+	ret := _m.ctrl.Call(_m, "Health", ctx, i)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-func (_mr *_MockControllerRecorder) GetBook(arg0, arg1 interface{}) *gomock.Call {
-	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetBook", arg0, arg1)
+func (_mr *_MockControllerRecorder) Health(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "Health", arg0, arg1)
 }

--- a/samples/gen-go-deprecated/server/router.go
+++ b/samples/gen-go-deprecated/server/router.go
@@ -53,9 +53,9 @@ func New(c Controller, addr string) *Server {
 
 	l := logger.New("swagger-test")
 
-	r.Methods("GET").Path("/v1/books/{id}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger.FromContext(r.Context()).AddContext("op", "getBook")
-		h.GetBookHandler(r.Context(), w, r)
+	r.Methods("GET").Path("/v1/health").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logger.FromContext(r.Context()).AddContext("op", "health")
+		h.HealthHandler(r.Context(), w, r)
 	})
 
 	handler := withMiddleware("swagger-test", r)

--- a/samples/gen-go-errors/client/client.go
+++ b/samples/gen-go-errors/client/client.go
@@ -123,7 +123,13 @@ func (c *WagClient) SetTimeout(timeout time.Duration) {
 	c.defaultTimeout = timeout
 }
 
-// GetBook makes a GET request to /books/{id}.
+// GetBook makes a GET request to /books/{id}
+//
+// 200: nil
+// 400: *models.ExtendedError
+// 404: *models.NotFound
+// 500: *models.InternalError
+// default: client side HTTP errors, for example: context.DeadlineExceeded.
 func (c *WagClient) GetBook(ctx context.Context, i *models.GetBookInput) error {
 	path := c.basePath + "/v1/books/{id}"
 	urlVals := url.Values{}

--- a/samples/gen-go-errors/client/interface.go
+++ b/samples/gen-go-errors/client/interface.go
@@ -11,6 +11,12 @@ import (
 // Client defines the methods available to clients of the swagger-test service.
 type Client interface {
 
-	// GetBook makes a GET request to /books/{id}.
+	// GetBook makes a GET request to /books/{id}
+	//
+	// 200: nil
+	// 400: *models.ExtendedError
+	// 404: *models.NotFound
+	// 500: *models.InternalError
+	// default: client side HTTP errors, for example: context.DeadlineExceeded.
 	GetBook(ctx context.Context, i *models.GetBookInput) error
 }

--- a/samples/gen-go-errors/server/interface.go
+++ b/samples/gen-go-errors/server/interface.go
@@ -11,6 +11,12 @@ import (
 // Controller defines the interface for the swagger-test service.
 type Controller interface {
 
-	// GetBook makes a GET request to /books/{id}.
+	// GetBook makes a GET request to /books/{id}
+	//
+	// 200: nil
+	// 400: *models.ExtendedError
+	// 404: *models.NotFound
+	// 500: *models.InternalError
+	// default: client side HTTP errors, for example: context.DeadlineExceeded.
 	GetBook(ctx context.Context, i *models.GetBookInput) error
 }

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -123,8 +123,12 @@ func (c *WagClient) SetTimeout(timeout time.Duration) {
 	c.defaultTimeout = timeout
 }
 
-// GetBooks makes a GET request to /books.
+// GetBooks makes a GET request to /books
 // Returns a list of books
+// 200: []models.Book
+// 400: *models.BadRequest
+// 500: *models.InternalError
+// default: client side HTTP errors, for example: context.DeadlineExceeded.
 func (c *WagClient) GetBooks(ctx context.Context, i *models.GetBooksInput) ([]models.Book, error) {
 	path := c.basePath + "/v1/books"
 	urlVals := url.Values{}
@@ -217,8 +221,12 @@ func (c *WagClient) GetBooks(ctx context.Context, i *models.GetBooksInput) ([]mo
 	}
 }
 
-// CreateBook makes a POST request to /books.
+// CreateBook makes a POST request to /books
 // Creates a book
+// 200: *models.Book
+// 400: *models.BadRequest
+// 500: *models.InternalError
+// default: client side HTTP errors, for example: context.DeadlineExceeded.
 func (c *WagClient) CreateBook(ctx context.Context, i *models.Book) (*models.Book, error) {
 	path := c.basePath + "/v1/books"
 	urlVals := url.Values{}
@@ -293,8 +301,14 @@ func (c *WagClient) CreateBook(ctx context.Context, i *models.Book) (*models.Boo
 	}
 }
 
-// GetBookByID makes a GET request to /books/{book_id}.
+// GetBookByID makes a GET request to /books/{book_id}
 // Returns a book
+// 200: *models.Book
+// 400: *models.BadRequest
+// 401: *models.Unathorized
+// 404: *models.Error
+// 500: *models.InternalError
+// default: client side HTTP errors, for example: context.DeadlineExceeded.
 func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (*models.Book, error) {
 	path := c.basePath + "/v1/books/{book_id}"
 	urlVals := url.Values{}
@@ -385,8 +399,13 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 	}
 }
 
-// GetBookByID2 makes a GET request to /books2/{id}.
+// GetBookByID2 makes a GET request to /books2/{id}
 // Retrieve a book
+// 200: *models.Book
+// 400: *models.BadRequest
+// 404: *models.Error
+// 500: *models.InternalError
+// default: client side HTTP errors, for example: context.DeadlineExceeded.
 func (c *WagClient) GetBookByID2(ctx context.Context, id string) (*models.Book, error) {
 	path := c.basePath + "/v1/books2/{id}"
 	urlVals := url.Values{}
@@ -459,7 +478,12 @@ func (c *WagClient) GetBookByID2(ctx context.Context, id string) (*models.Book, 
 	}
 }
 
-// HealthCheck makes a GET request to /health/check.
+// HealthCheck makes a GET request to /health/check
+//
+// 200: nil
+// 400: *models.BadRequest
+// 500: *models.InternalError
+// default: client side HTTP errors, for example: context.DeadlineExceeded.
 func (c *WagClient) HealthCheck(ctx context.Context) error {
 	path := c.basePath + "/v1/health/check"
 	urlVals := url.Values{}

--- a/samples/gen-go/client/interface.go
+++ b/samples/gen-go/client/interface.go
@@ -11,22 +11,46 @@ import (
 // Client defines the methods available to clients of the swagger-test service.
 type Client interface {
 
-	// GetBooks makes a GET request to /books.
+	// GetBooks makes a GET request to /books
 	// Returns a list of books
+	// 200: []models.Book
+	// 400: *models.BadRequest
+	// 500: *models.InternalError
+	// default: client side HTTP errors, for example: context.DeadlineExceeded.
 	GetBooks(ctx context.Context, i *models.GetBooksInput) ([]models.Book, error)
 
-	// CreateBook makes a POST request to /books.
+	// CreateBook makes a POST request to /books
 	// Creates a book
+	// 200: *models.Book
+	// 400: *models.BadRequest
+	// 500: *models.InternalError
+	// default: client side HTTP errors, for example: context.DeadlineExceeded.
 	CreateBook(ctx context.Context, i *models.Book) (*models.Book, error)
 
-	// GetBookByID makes a GET request to /books/{book_id}.
+	// GetBookByID makes a GET request to /books/{book_id}
 	// Returns a book
+	// 200: *models.Book
+	// 400: *models.BadRequest
+	// 401: *models.Unathorized
+	// 404: *models.Error
+	// 500: *models.InternalError
+	// default: client side HTTP errors, for example: context.DeadlineExceeded.
 	GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (*models.Book, error)
 
-	// GetBookByID2 makes a GET request to /books2/{id}.
+	// GetBookByID2 makes a GET request to /books2/{id}
 	// Retrieve a book
+	// 200: *models.Book
+	// 400: *models.BadRequest
+	// 404: *models.Error
+	// 500: *models.InternalError
+	// default: client side HTTP errors, for example: context.DeadlineExceeded.
 	GetBookByID2(ctx context.Context, id string) (*models.Book, error)
 
-	// HealthCheck makes a GET request to /health/check.
+	// HealthCheck makes a GET request to /health/check
+	//
+	// 200: nil
+	// 400: *models.BadRequest
+	// 500: *models.InternalError
+	// default: client side HTTP errors, for example: context.DeadlineExceeded.
 	HealthCheck(ctx context.Context) error
 }

--- a/samples/gen-go/server/interface.go
+++ b/samples/gen-go/server/interface.go
@@ -11,22 +11,46 @@ import (
 // Controller defines the interface for the swagger-test service.
 type Controller interface {
 
-	// GetBooks makes a GET request to /books.
+	// GetBooks makes a GET request to /books
 	// Returns a list of books
+	// 200: []models.Book
+	// 400: *models.BadRequest
+	// 500: *models.InternalError
+	// default: client side HTTP errors, for example: context.DeadlineExceeded.
 	GetBooks(ctx context.Context, i *models.GetBooksInput) ([]models.Book, error)
 
-	// CreateBook makes a POST request to /books.
+	// CreateBook makes a POST request to /books
 	// Creates a book
+	// 200: *models.Book
+	// 400: *models.BadRequest
+	// 500: *models.InternalError
+	// default: client side HTTP errors, for example: context.DeadlineExceeded.
 	CreateBook(ctx context.Context, i *models.Book) (*models.Book, error)
 
-	// GetBookByID makes a GET request to /books/{book_id}.
+	// GetBookByID makes a GET request to /books/{book_id}
 	// Returns a book
+	// 200: *models.Book
+	// 400: *models.BadRequest
+	// 401: *models.Unathorized
+	// 404: *models.Error
+	// 500: *models.InternalError
+	// default: client side HTTP errors, for example: context.DeadlineExceeded.
 	GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (*models.Book, error)
 
-	// GetBookByID2 makes a GET request to /books2/{id}.
+	// GetBookByID2 makes a GET request to /books2/{id}
 	// Retrieve a book
+	// 200: *models.Book
+	// 400: *models.BadRequest
+	// 404: *models.Error
+	// 500: *models.InternalError
+	// default: client side HTTP errors, for example: context.DeadlineExceeded.
 	GetBookByID2(ctx context.Context, id string) (*models.Book, error)
 
-	// HealthCheck makes a GET request to /health/check.
+	// HealthCheck makes a GET request to /health/check
+	//
+	// 200: nil
+	// 400: *models.BadRequest
+	// 500: *models.InternalError
+	// default: client side HTTP errors, for example: context.DeadlineExceeded.
 	HealthCheck(ctx context.Context) error
 }


### PR DESCRIPTION
Add a comment on the return types in the Go interfaces. This is both to match the JS behavior and to make it more clear which errors the caller should check for.