### PR TITLE
Increase duration error margin in test

### DIFF
--- a/test/client_test.go
+++ b/test/client_test.go
@@ -99,7 +99,7 @@ func TestExponentialClientRetries(t *testing.T) {
 	_, err := c.GetBooks(context.Background(), &models.GetBooksInput{})
 	require.NoError(t, err)
 	require.Equal(t, len(controller.getTimes), 3, "expected three requests")
-	assert.WithinDuration(t, controller.getTimes[1], controller.getTimes[0].Add(100*time.Millisecond), 10*time.Millisecond,
+	assert.WithinDuration(t, controller.getTimes[1], controller.getTimes[0].Add(100*time.Millisecond), 20*time.Millisecond,
 		"expected first backoff to be about 100ms")
 	assert.WithinDuration(t, controller.getTimes[2], controller.getTimes[1].Add(200*time.Millisecond), 20*time.Millisecond,
 		"expected first backoff to be about 200ms")


### PR DESCRIPTION
To handle errors like:
Max difference between 2016-11-10 15:07:43.686317769 -0800 PST and
2016-11-10 15:07:43.676000766 -0800 PST allowed is 10ms, but difference
was 10.317003ms