### PR TITLE
Handle headers correctly

### DIFF
--- a/samples/gen-go-deprecated/server/handlers.go
+++ b/samples/gen-go-deprecated/server/handlers.go
@@ -147,8 +147,8 @@ func newHealthInput(r *http.Request) (*models.HealthInput, error) {
 	}
 
 	if len(sectionStrs) > 0 {
-		sectionStr := sectionStrs[0]
 		var sectionTmp int64
+		sectionStr := sectionStrs[0]
 		sectionTmp, err = swag.ConvertInt64(sectionStr)
 		if err != nil {
 			return nil, err

--- a/samples/gen-go-errors/server/handlers.go
+++ b/samples/gen-go-errors/server/handlers.go
@@ -148,8 +148,8 @@ func newGetBookInput(r *http.Request) (*models.GetBookInput, error) {
 	idStrs := []string{idStr}
 
 	if len(idStrs) > 0 {
-		iDStr := idStrs[0]
 		var iDTmp int64
+		iDStr := idStrs[0]
 		iDTmp, err = swag.ConvertInt64(iDStr)
 		if err != nil {
 			return nil, err

--- a/samples/gen-go-nils/server/handlers.go
+++ b/samples/gen-go-nils/server/handlers.go
@@ -142,8 +142,8 @@ func newNilCheckInput(r *http.Request) (*models.NilCheckInput, error) {
 	idStrs := []string{idStr}
 
 	if len(idStrs) > 0 {
-		iDStr := idStrs[0]
 		var iDTmp string
+		iDStr := idStrs[0]
 		iDTmp, err = iDStr, error(nil)
 		if err != nil {
 			return nil, err
@@ -154,8 +154,8 @@ func newNilCheckInput(r *http.Request) (*models.NilCheckInput, error) {
 	queryStrs := r.URL.Query()["query"]
 
 	if len(queryStrs) > 0 {
-		queryStr := queryStrs[0]
 		var queryTmp string
+		queryStr := queryStrs[0]
 		queryTmp, err = queryStr, error(nil)
 		if err != nil {
 			return nil, err
@@ -163,15 +163,11 @@ func newNilCheckInput(r *http.Request) (*models.NilCheckInput, error) {
 		input.Query = &queryTmp
 	}
 
-	headerStrs := r.Header["header"]
+	headerStrs := r.Header.Get("header")
 
 	if len(headerStrs) > 0 {
-		headerStr := headerStrs[0]
 		var headerTmp string
-		headerTmp, err = headerStr, error(nil)
-		if err != nil {
-			return nil, err
-		}
+		headerTmp = headerStrs
 		input.Header = headerTmp
 	}
 	if array, ok := r.URL.Query()["array"]; ok {

--- a/samples/gen-go/server/handlers.go
+++ b/samples/gen-go/server/handlers.go
@@ -165,8 +165,8 @@ func newGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 		availableStrs = []string{"true"}
 	}
 	if len(availableStrs) > 0 {
-		availableStr := availableStrs[0]
 		var availableTmp bool
+		availableStr := availableStrs[0]
 		availableTmp, err = strconv.ParseBool(availableStr)
 		if err != nil {
 			return nil, err
@@ -180,8 +180,8 @@ func newGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 		stateStrs = []string{"finished"}
 	}
 	if len(stateStrs) > 0 {
-		stateStr := stateStrs[0]
 		var stateTmp string
+		stateStr := stateStrs[0]
 		stateTmp, err = stateStr, error(nil)
 		if err != nil {
 			return nil, err
@@ -192,8 +192,8 @@ func newGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 	publishedStrs := r.URL.Query()["published"]
 
 	if len(publishedStrs) > 0 {
-		publishedStr := publishedStrs[0]
 		var publishedTmp strfmt.Date
+		publishedStr := publishedStrs[0]
 		publishedTmp, err = convertDate(publishedStr)
 		if err != nil {
 			return nil, err
@@ -204,8 +204,8 @@ func newGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 	snake_caseStrs := r.URL.Query()["snake_case"]
 
 	if len(snake_caseStrs) > 0 {
-		snakeCaseStr := snake_caseStrs[0]
 		var snakeCaseTmp string
+		snakeCaseStr := snake_caseStrs[0]
 		snakeCaseTmp, err = snakeCaseStr, error(nil)
 		if err != nil {
 			return nil, err
@@ -216,8 +216,8 @@ func newGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 	completedStrs := r.URL.Query()["completed"]
 
 	if len(completedStrs) > 0 {
-		completedStr := completedStrs[0]
 		var completedTmp strfmt.DateTime
+		completedStr := completedStrs[0]
 		completedTmp, err = convertDateTime(completedStr)
 		if err != nil {
 			return nil, err
@@ -231,8 +231,8 @@ func newGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 		maxPagesStrs = []string{"5.005E+02"}
 	}
 	if len(maxPagesStrs) > 0 {
-		maxPagesStr := maxPagesStrs[0]
 		var maxPagesTmp float64
+		maxPagesStr := maxPagesStrs[0]
 		maxPagesTmp, err = swag.ConvertFloat64(maxPagesStr)
 		if err != nil {
 			return nil, err
@@ -246,8 +246,8 @@ func newGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 		min_pagesStrs = []string{"5"}
 	}
 	if len(min_pagesStrs) > 0 {
-		minPagesStr := min_pagesStrs[0]
 		var minPagesTmp int32
+		minPagesStr := min_pagesStrs[0]
 		minPagesTmp, err = swag.ConvertInt32(minPagesStr)
 		if err != nil {
 			return nil, err
@@ -258,8 +258,8 @@ func newGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 	pagesToTimeStrs := r.URL.Query()["pagesToTime"]
 
 	if len(pagesToTimeStrs) > 0 {
-		pagesToTimeStr := pagesToTimeStrs[0]
 		var pagesToTimeTmp float32
+		pagesToTimeStr := pagesToTimeStrs[0]
 		pagesToTimeTmp, err = swag.ConvertFloat32(pagesToTimeStr)
 		if err != nil {
 			return nil, err
@@ -466,8 +466,8 @@ func newGetBookByIDInput(r *http.Request) (*models.GetBookByIDInput, error) {
 	book_idStrs := []string{book_idStr}
 
 	if len(book_idStrs) > 0 {
-		bookIDStr := book_idStrs[0]
 		var bookIDTmp int64
+		bookIDStr := book_idStrs[0]
 		bookIDTmp, err = swag.ConvertInt64(bookIDStr)
 		if err != nil {
 			return nil, err
@@ -478,8 +478,8 @@ func newGetBookByIDInput(r *http.Request) (*models.GetBookByIDInput, error) {
 	authorIDStrs := r.URL.Query()["authorID"]
 
 	if len(authorIDStrs) > 0 {
-		authorIDStr := authorIDStrs[0]
 		var authorIDTmp string
+		authorIDStr := authorIDStrs[0]
 		authorIDTmp, err = authorIDStr, error(nil)
 		if err != nil {
 			return nil, err
@@ -487,23 +487,19 @@ func newGetBookByIDInput(r *http.Request) (*models.GetBookByIDInput, error) {
 		input.AuthorID = &authorIDTmp
 	}
 
-	authorizationStrs := r.Header["authorization"]
+	authorizationStrs := r.Header.Get("authorization")
 
 	if len(authorizationStrs) > 0 {
-		authorizationStr := authorizationStrs[0]
 		var authorizationTmp string
-		authorizationTmp, err = authorizationStr, error(nil)
-		if err != nil {
-			return nil, err
-		}
+		authorizationTmp = authorizationStrs
 		input.Authorization = authorizationTmp
 	}
 
 	randomBytesStrs := r.URL.Query()["randomBytes"]
 
 	if len(randomBytesStrs) > 0 {
-		randomBytesStr := randomBytesStrs[0]
 		var randomBytesTmp strfmt.Base64
+		randomBytesStr := randomBytesStrs[0]
 		randomBytesTmp, err = convertBase64(randomBytesStr)
 		if err != nil {
 			return nil, err

--- a/samples/gen-js-nils/README.md
+++ b/samples/gen-js-nils/README.md
@@ -34,7 +34,7 @@ Create a new client object.
 | --- | --- | --- | --- |
 | options | <code>Object</code> |  | Options for constructing a client object. |
 | [options.address] | <code>string</code> |  | URL where the server is located. Must provide this or the discovery argument |
-| [options.discovery] | <code>bool</code> |  | Use @clever/discovery to locate the server. Must provide this or the address argument |
+| [options.discovery] | <code>bool</code> |  | Use clever-discovery to locate the server. Must provide this or the address argument |
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_nil-test--NilTest.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 

--- a/samples/gen-js-nils/index.js
+++ b/samples/gen-js-nils/index.js
@@ -1,4 +1,4 @@
-const discovery = require("@clever/discovery");
+const discovery = require("clever-discovery");
 const request = require("request");
 const opentracing = require("opentracing");
 
@@ -83,7 +83,7 @@ class NilTest {
    * @param {Object} options - Options for constructing a client object.
    * @param {string} [options.address] - URL where the server is located. Must provide
    * this or the discovery argument
-   * @param {bool} [options.discovery] - Use @clever/discovery to locate the server. Must provide
+   * @param {bool} [options.discovery] - Use clever-discovery to locate the server. Must provide
    * this or the address argument
    * @param {number} [options.timeout] - The timeout to use for all client requests,
    * in milliseconds. This can be overridden on a per-request basis.

--- a/samples/gen-js-nils/package.json
+++ b/samples/gen-js-nils/package.json
@@ -4,7 +4,7 @@
   "description": "Testing Swagger Codegen",
   "main": "index.js",
   "dependencies": {
-    "@clever/discovery": "0.0.8",
+    "clever-discovery": "0.0.8",
     "opentracing": "^0.11.1",
     "request": "^2.75.0"
   }

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -569,7 +569,7 @@ var paramTemplateStr = `
 		}
 		{{.ParamName}}Strs := []string{ {{.ParamName}}Str }
 	{{- else if eq .ParamType "header" -}}
-		{{.ParamName}}Strs := r.Header["{{.ParamName}}"]
+		{{.ParamName}}Strs := r.Header.Get("{{.ParamName}}")
 		{{if .Required -}}
 			if len({{.ParamName}}Strs) == 0 {
 				return nil, errors.New("parameter must be specified")
@@ -582,12 +582,16 @@ var paramTemplateStr = `
 		}
 	{{- end}}
 	if len({{.ParamName}}Strs) > 0 {
-		{{.VarName}}Str := {{.ParamName}}Strs[0]
-		var {{.VarName}}Tmp {{.TypeName}}
-		{{.VarName}}Tmp, err = {{.TypeCode}}
-		if err != nil {
-			return nil, err
-		}
+			var {{.VarName}}Tmp {{.TypeName}}
+		{{if eq .ParamType "header" -}}
+			{{.VarName}}Tmp = {{.ParamName}}Strs
+		{{- else -}}
+			{{.VarName}}Str := {{.ParamName}}Strs[0]
+			{{.VarName}}Tmp, err = {{.TypeCode}}
+			if err != nil {
+				return nil, err
+			}
+		{{- end}}
 		{{if .PointerInStruct -}}
 			input.{{.CapParamName}} = &{{.VarName}}Tmp
 		{{- else -}}


### PR DESCRIPTION
I _think_ header handling was pretty broken before this change. 

1. Using `r.Header["header_name"]` to get the value of a header is...risky since the case of the keys in that map is unclear. At the very least the first character will be capitalized so if you use `header_name` as the swagger param it won't work (since in the map it'll be `Header_name`). Switch (back) to using `r.Header.Get()`

TBD if/how we want to add some sort sort of test to ensure this doesn't happen going forward. 