### PR TITLE
Tag spans

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ func main() {
     * **wag**: All `wag`-generated clients take in a context object as the first argument.
       If your handler consumes a `wag`-generated client, then pass the context object to these client methods.
 
+  * By default we tag traces with `http.method`, `span.kind`, `http.url`, `http.status_code`, and `error`. For more information about what these tags mean see: https://github.com/opentracing/opentracing.io/blob/95b966bd6a6b2cf0f231260e3e1fa6206ede2151/_docs/pages/api/data-conventions.md#component-identification
+
 ### Using the Go Client
 Initialize the client with `New`
 ```

--- a/_hardcoded/doer.go
+++ b/_hardcoded/doer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/afex/hystrix-go/hystrix"
 	"github.com/donovanhide/eventsource"
 	opentracing "github.com/opentracing/opentracing-go"
+	tags "github.com/opentracing/opentracing-go/ext"
 	"golang.org/x/net/context/ctxhttp"
 	logger "gopkg.in/Clever/kayvee-go.v5/logger"
 )
@@ -49,6 +50,7 @@ func (d tracingDoer) Do(c *http.Client, r *http.Request) (*http.Response, error)
 	} else {
 		sp = opentracing.StartSpan(opName)
 	}
+	tags.SpanKind.Set(sp, tags.SpanKindRPCClientEnum)
 	if err := sp.Tracer().Inject(sp.Context(),
 		opentracing.HTTPHeaders,
 		opentracing.HTTPHeadersCarrier(r.Header)); err != nil {

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -257,6 +257,7 @@ var methodTmplStr = `
     if (span) {
       opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
       span.logEvent("{{.Method}} {{.Path}}");
+      span.setTag("span.kind", "client")
     }
 
     const requestOptions = {

--- a/samples/gen-go-deprecated/server/router.go
+++ b/samples/gen-go-deprecated/server/router.go
@@ -81,6 +81,8 @@ func NewWithMiddleware(c Controller, addr string, m []func(http.Handler) http.Ha
 
 	r.Methods("GET").Path("/v1/health").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.FromContext(r.Context()).AddContext("op", "health")
+		ctx := middleware.WithTracingOpName(r.Context(), "health")
+		r = r.WithContext(ctx)
 		h.HealthHandler(r.Context(), w, r)
 	})
 

--- a/samples/gen-go-errors/server/router.go
+++ b/samples/gen-go-errors/server/router.go
@@ -81,6 +81,8 @@ func NewWithMiddleware(c Controller, addr string, m []func(http.Handler) http.Ha
 
 	r.Methods("GET").Path("/v1/books/{id}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.FromContext(r.Context()).AddContext("op", "getBook")
+		ctx := middleware.WithTracingOpName(r.Context(), "getBook")
+		r = r.WithContext(ctx)
 		h.GetBookHandler(r.Context(), w, r)
 	})
 

--- a/samples/gen-go-nils/server/router.go
+++ b/samples/gen-go-nils/server/router.go
@@ -81,6 +81,8 @@ func NewWithMiddleware(c Controller, addr string, m []func(http.Handler) http.Ha
 
 	r.Methods("POST").Path("/v1/check/{id}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.FromContext(r.Context()).AddContext("op", "nilCheck")
+		ctx := middleware.WithTracingOpName(r.Context(), "nilCheck")
+		r = r.WithContext(ctx)
 		h.NilCheckHandler(r.Context(), w, r)
 	})
 

--- a/samples/gen-go/server/router.go
+++ b/samples/gen-go/server/router.go
@@ -81,26 +81,36 @@ func NewWithMiddleware(c Controller, addr string, m []func(http.Handler) http.Ha
 
 	r.Methods("GET").Path("/v1/books").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.FromContext(r.Context()).AddContext("op", "getBooks")
+		ctx := middleware.WithTracingOpName(r.Context(), "getBooks")
+		r = r.WithContext(ctx)
 		h.GetBooksHandler(r.Context(), w, r)
 	})
 
 	r.Methods("POST").Path("/v1/books").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.FromContext(r.Context()).AddContext("op", "createBook")
+		ctx := middleware.WithTracingOpName(r.Context(), "createBook")
+		r = r.WithContext(ctx)
 		h.CreateBookHandler(r.Context(), w, r)
 	})
 
 	r.Methods("GET").Path("/v1/books/{book_id}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.FromContext(r.Context()).AddContext("op", "getBookByID")
+		ctx := middleware.WithTracingOpName(r.Context(), "getBookByID")
+		r = r.WithContext(ctx)
 		h.GetBookByIDHandler(r.Context(), w, r)
 	})
 
 	r.Methods("GET").Path("/v1/books2/{id}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.FromContext(r.Context()).AddContext("op", "getBookByID2")
+		ctx := middleware.WithTracingOpName(r.Context(), "getBookByID2")
+		r = r.WithContext(ctx)
 		h.GetBookByID2Handler(r.Context(), w, r)
 	})
 
 	r.Methods("GET").Path("/v1/health/check").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.FromContext(r.Context()).AddContext("op", "healthCheck")
+		ctx := middleware.WithTracingOpName(r.Context(), "healthCheck")
+		r = r.WithContext(ctx)
 		h.HealthCheckHandler(r.Context(), w, r)
 	})
 

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -124,6 +124,8 @@ func NewWithMiddleware(c Controller, addr string, m []func(http.Handler) http.Ha
 	{{range $index, $val := .Functions}}
 	r.Methods("{{$val.Method}}").Path("{{$val.Path}}").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.FromContext(r.Context()).AddContext("op", "{{$val.OpID}}")
+		ctx := middleware.WithTracingOpName(r.Context(), "{{$val.OpID}}")
+		r = r.WithContext(ctx)
 		h.{{$val.HandlerName}}Handler(r.Context(), w, r)
 	})
 	{{end}}


### PR DESCRIPTION
Adding the common tags documented here:
https://github.com/opentracing/opentracing.io/blob/95b966bd6a6b2cf0f231260e3e1fa6206ede2151/_docs/pages/api/data-conventions.md#component-identification

This also tries to associate a clearer operation name with the span. The way we do it is a bit hacky, but since it's fairly hidden behind an interface I think I'm okay with it. Will keep thinking about it.