### PR TITLE
Refactor code generation

### DIFF
--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -303,9 +303,9 @@ func paramToTemplate(s *spec.Swagger, param *spec.Parameter, op *spec.Operation)
 		ErrorMessage: errorMessage(s, op),
 	}
 	if singleStringPathParameter {
-		t.Name = op.Parameters[0].Name
+		t.Name = param.Name
 		t.ToStringCode = singleParamName
-		t.AccessString = op.Parameters[0].Name
+		t.AccessString = param.Name
 	}
 	return t
 }

--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -281,6 +281,10 @@ func methodCode(s *spec.Swagger, op *spec.Operation, basePath, method, methodPat
 
 }
 
+// paramToTemplate converts a spec.Parameter into the a struct with the information needed to
+// template code that uses that parameter. For example, it figures out what the access string for
+// the parameter should be (e.g. either "i.$FIELD" or just $FIELD) and whether the field should be
+// used as a pointer or not.
 func paramToTemplate(s *spec.Swagger, param *spec.Parameter, op *spec.Operation) paramTemplate {
 
 	singleStringPathParameter, singleParamName := swagger.SingleStringPathParameter(op)
@@ -302,8 +306,9 @@ func paramToTemplate(s *spec.Swagger, param *spec.Parameter, op *spec.Operation)
 		Pointer:      pointer,
 		ErrorMessage: errorMessage(s, op),
 	}
+	// If this is a single parameter then use $FIELD rather than i.$FIELD in both the toString
+	// and accessing code.
 	if singleStringPathParameter {
-		t.Name = param.Name
 		t.ToStringCode = singleParamName
 		t.AccessString = param.Name
 	}

--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -422,9 +422,7 @@ var bodyParamStr = `
 	{{end}}
 	var err error
 	body, err = json.Marshal({{.AccessString}})
-	if err != nil {
-		{{.ErrorMessage}}	
-	}
+	{{.ErrorMessage}}	
 	{{if .Pointer}}
 	}
 	{{end}}

--- a/models/genmodels.go
+++ b/models/genmodels.go
@@ -140,7 +140,7 @@ func printInputValidation(g *swagger.Generator, op *spec.Operation) error {
 			g.Printf("\t}\n\n")
 		}
 
-		validations, err := swagger.ParamToValidationCode(param)
+		validations, err := swagger.ParamToValidationCode(param, op)
 		if err != nil {
 			return err
 		}

--- a/models/genmodels.go
+++ b/models/genmodels.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/Clever/go-utils/stringset"
 	"github.com/Clever/wag/swagger"
-	"github.com/Clever/wag/utils"
+	"github.com/Clever/wag/templates"
 
 	"github.com/go-swagger/go-swagger/generator"
 )
@@ -134,39 +134,28 @@ func printInputValidation(g *swagger.Generator, op *spec.Operation) error {
 	}
 
 	for _, param := range op.Parameters {
-		if param.In == "body" {
-			g.Printf("\tif err := i.%s.Validate(nil); err != nil {\n", swagger.StructParamName(param))
-			g.Printf("\t\treturn err\n")
-			g.Printf("\t}\n\n")
-		}
-
-		validations, err := swagger.ParamToValidationCode(param, op)
-		if err != nil {
-			return err
-		}
 		_, pointer, err := swagger.ParamToType(param)
 		if err != nil {
 			return err
 		}
-		for _, validation := range validations {
-			if param.In == "header" {
-				g.Printf("\tif len(i.%s) > 0 {\n", swagger.StructParamName(param))
-				g.Printf(errCheck(validation))
-				g.Printf("\t}\n")
-			} else if !pointer && param.Type != "array" {
-				if singleStringPathParameter {
-					// replace i.<Param> with <param>
-					validation = strings.Replace(validation,
-						fmt.Sprintf("i.%s", utils.CamelCase(param.Name, true)),
-						paramName, -1)
-				}
-				g.Printf(errCheck(validation))
-			} else {
-				g.Printf("\tif i.%s != nil {\n", swagger.StructParamName(param))
-				g.Printf(errCheck(validation))
-				g.Printf("\t}\n")
-			}
+		validations, err := swagger.ParamToValidationCode(param, op)
+		if err != nil {
+			return err
 		}
+		t := validateTemplate{
+			Type:         param.In,
+			AccessString: "i." + swagger.StructParamName(param),
+			Pointer:      pointer || param.Type == "array",
+			Validations:  validations,
+		}
+		if single, _ := swagger.SingleStringPathParameter(op); single {
+			t.AccessString = param.Name
+		}
+		str, err := templates.WriteTemplate(validationStr, t)
+		if err != nil {
+			return err
+		}
+		g.Printf(str)
 	}
 	g.Printf("\treturn nil\n")
 	g.Printf("}\n\n")
@@ -174,14 +163,44 @@ func printInputValidation(g *swagger.Generator, op *spec.Operation) error {
 	return nil
 }
 
-// errCheck returns an if err := ifCondition; err != nil { return err } function
-func errCheck(ifCondition string) string {
-	return fmt.Sprintf(
-		`	if err := %s; err != nil {
+type validateTemplate struct {
+	Type         string
+	AccessString string
+	Pointer      bool
+	Validations  []string
+}
+
+//
+
+var validationStr = `
+	{{if eq .Type "body" -}}
+	if err := {{.AccessString}}.Validate(nil); err != nil {
 		return err
 	}
-`, ifCondition)
-}
+	{{- end -}}
+	{{- $type := .Type -}}
+	{{- $accessString := .AccessString -}}
+	{{- $pointer := .Pointer -}}
+	{{- range $i, $validation := .Validations -}}
+		{{- if eq $type "header" -}}
+		if len({{$accessString}}) > 0 {
+			if err := {{$validation}}; err != nil {
+				return err
+			}
+		}
+		{{else -}}
+		{{- if $pointer}}
+		if {{$accessString}} != nil {
+		{{- end -}}
+		if err := {{$validation}}; err != nil {
+			return err
+		}
+		{{if $pointer -}}
+		}
+		{{- end -}}
+		{{end -}}
+	{{- end }}
+`
 
 func generateOutputs(packageName string, s spec.Swagger) error {
 	g := swagger.Generator{PackageName: packageName}

--- a/samples/gen-go-deprecated/models/inputs.go
+++ b/samples/gen-go-deprecated/models/inputs.go
@@ -22,5 +22,6 @@ type HealthInput struct {
 // Validate returns an error if any of the HealthInput parameters don't satisfy the
 // requirements from the swagger yml file.
 func (i HealthInput) Validate() error {
+
 	return nil
 }

--- a/samples/gen-go-errors/models/inputs.go
+++ b/samples/gen-go-errors/models/inputs.go
@@ -22,8 +22,10 @@ type GetBookInput struct {
 // Validate returns an error if any of the GetBookInput parameters don't satisfy the
 // requirements from the swagger yml file.
 func (i GetBookInput) Validate() error {
+
 	if err := validate.MaximumInt("id", "path", i.ID, int64(4000), false); err != nil {
 		return err
 	}
+
 	return nil
 }

--- a/samples/gen-go-nils/client/client.go
+++ b/samples/gen-go-nils/client/client.go
@@ -161,12 +161,9 @@ func (c *WagClient) NilCheck(ctx context.Context, i *models.NilCheckInput) error
 
 		var err error
 		body, err = json.Marshal(i.Body)
+
 		if err != nil {
-
-			if err != nil {
-				return err
-			}
-
+			return err
 		}
 
 	}

--- a/samples/gen-go-nils/client/client.go
+++ b/samples/gen-go-nils/client/client.go
@@ -161,9 +161,12 @@ func (c *WagClient) NilCheck(ctx context.Context, i *models.NilCheckInput) error
 
 		var err error
 		body, err = json.Marshal(i.Body)
-
 		if err != nil {
-			return err
+
+			if err != nil {
+				return err
+			}
+
 		}
 
 	}

--- a/samples/gen-go-nils/client/client.go
+++ b/samples/gen-go-nils/client/client.go
@@ -147,9 +147,11 @@ func (c *WagClient) NilCheck(ctx context.Context, i *models.NilCheckInput) error
 	var body []byte
 
 	path = strings.Replace(path, "{id}", i.ID, -1)
+
 	if i.Query != nil {
 		urlVals.Add("query", *i.Query)
 	}
+
 	for _, v := range i.Array {
 		urlVals.Add("array", v)
 	}

--- a/samples/gen-go-nils/models/inputs.go
+++ b/samples/gen-go-nils/models/inputs.go
@@ -26,9 +26,9 @@ type NilCheckInput struct {
 // Validate returns an error if any of the NilCheckInput parameters don't satisfy the
 // requirements from the swagger yml file.
 func (i NilCheckInput) Validate() error {
+
 	if err := i.Body.Validate(nil); err != nil {
 		return err
 	}
-
 	return nil
 }

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -257,12 +257,9 @@ func (c *WagClient) CreateBook(ctx context.Context, i *models.Book) (*models.Boo
 
 		var err error
 		body, err = json.Marshal(i)
+
 		if err != nil {
-
-			if err != nil {
-				return nil, err
-			}
-
+			return nil, err
 		}
 
 	}

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -257,9 +257,12 @@ func (c *WagClient) CreateBook(ctx context.Context, i *models.Book) (*models.Boo
 
 		var err error
 		body, err = json.Marshal(i)
-
 		if err != nil {
-			return nil, err
+
+			if err != nil {
+				return nil, err
+			}
+
 		}
 
 	}

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -149,30 +149,39 @@ func (c *WagClient) GetBooks(ctx context.Context, i *models.GetBooksInput) ([]mo
 	for _, v := range i.Authors {
 		urlVals.Add("authors", v)
 	}
+
 	if i.Available != nil {
 		urlVals.Add("available", strconv.FormatBool(*i.Available))
 	}
+
 	if i.State != nil {
 		urlVals.Add("state", *i.State)
 	}
+
 	if i.Published != nil {
 		urlVals.Add("published", (*i.Published).String())
 	}
+
 	if i.SnakeCase != nil {
 		urlVals.Add("snake_case", *i.SnakeCase)
 	}
+
 	if i.Completed != nil {
 		urlVals.Add("completed", (*i.Completed).String())
 	}
+
 	if i.MaxPages != nil {
 		urlVals.Add("maxPages", strconv.FormatFloat(*i.MaxPages, 'E', -1, 64))
 	}
+
 	if i.MinPages != nil {
 		urlVals.Add("min_pages", strconv.FormatInt(int64(*i.MinPages), 10))
 	}
+
 	if i.PagesToTime != nil {
 		urlVals.Add("pagesToTime", strconv.FormatFloat(float64(*i.PagesToTime), 'E', -1, 32))
 	}
+
 	path = path + "?" + urlVals.Encode()
 
 	client := &http.Client{Transport: c.transport}
@@ -325,12 +334,15 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 	var body []byte
 
 	path = strings.Replace(path, "{book_id}", strconv.FormatInt(i.BookID, 10), -1)
+
 	if i.AuthorID != nil {
 		urlVals.Add("authorID", *i.AuthorID)
 	}
+
 	if i.RandomBytes != nil {
 		urlVals.Add("randomBytes", string(*i.RandomBytes))
 	}
+
 	path = path + "?" + urlVals.Encode()
 
 	client := &http.Client{Transport: c.transport}

--- a/samples/gen-go/models/inputs.go
+++ b/samples/gen-go/models/inputs.go
@@ -30,6 +30,7 @@ type GetBooksInput struct {
 // Validate returns an error if any of the GetBooksInput parameters don't satisfy the
 // requirements from the swagger yml file.
 func (i GetBooksInput) Validate() error {
+
 	if i.Authors != nil {
 		if err := validate.MaxItems("authors", "query", int64(len(i.Authors)), 2); err != nil {
 			return err
@@ -45,26 +46,31 @@ func (i GetBooksInput) Validate() error {
 			return err
 		}
 	}
+
 	if i.State != nil {
 		if err := validate.Enum("state", "query", *i.State, []interface{}{"finished", "inprogress"}); err != nil {
 			return err
 		}
 	}
+
 	if i.Published != nil {
 		if err := validate.FormatOf("published", "query", "date", (*i.Published).String(), strfmt.Default); err != nil {
 			return err
 		}
 	}
+
 	if i.SnakeCase != nil {
 		if err := validate.MaxLength("snake_case", "query", string(*i.SnakeCase), 5); err != nil {
 			return err
 		}
 	}
+
 	if i.Completed != nil {
 		if err := validate.FormatOf("completed", "query", "date-time", (*i.Completed).String(), strfmt.Default); err != nil {
 			return err
 		}
 	}
+
 	if i.MaxPages != nil {
 		if err := validate.Maximum("maxPages", "query", float64(*i.MaxPages), 1000.000000, false); err != nil {
 			return err
@@ -80,6 +86,7 @@ func (i GetBooksInput) Validate() error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -94,6 +101,7 @@ type GetBookByIDInput struct {
 // Validate returns an error if any of the GetBookByIDInput parameters don't satisfy the
 // requirements from the swagger yml file.
 func (i GetBookByIDInput) Validate() error {
+
 	if err := validate.MaximumInt("book_id", "path", i.BookID, int64(10000000), false); err != nil {
 		return err
 	}
@@ -103,11 +111,13 @@ func (i GetBookByIDInput) Validate() error {
 	if err := validate.MultipleOf("book_id", "path", float64(i.BookID), 2.000000); err != nil {
 		return err
 	}
+
 	if i.AuthorID != nil {
 		if err := validate.FormatOf("authorID", "query", "mongo-id", *i.AuthorID, strfmt.Default); err != nil {
 			return err
 		}
 	}
+
 	if len(i.Authorization) > 0 {
 		if err := validate.MaxLength("authorization", "header", string(i.Authorization), 24); err != nil {
 			return err
@@ -123,6 +133,7 @@ func (i GetBookByIDInput) Validate() error {
 			return err
 		}
 	}
+
 	if i.RandomBytes != nil {
 		if err := validate.FormatOf("randomBytes", "query", "byte", string(*i.RandomBytes), strfmt.Default); err != nil {
 			return err
@@ -139,9 +150,11 @@ type GetBookByID2Input struct {
 // ValidateGetBookByID2Input returns an error if the input parameter doesn't
 // satisfy the requirements in the swagger yml file.
 func ValidateGetBookByID2Input(id string) error {
+
 	if err := validate.Pattern("id", "path", string(id), "^[0-9a-f]{24}$"); err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -514,7 +514,7 @@ func generateNewInput(op *spec.Operation) (string, error) {
 				buf.WriteString(fmt.Sprintf("\tif %s, ok := r.URL.Query()[\"%s\"]; ok {\n\t\tinput.%s = %s\n\t}\n",
 					paramVarName, param.Name, camelParamName, paramVarName))
 			} else {
-				typeCode, err := swagger.StringToTypeCode(fmt.Sprintf("%sStr", paramVarName), param)
+				typeCode, err := swagger.StringToTypeCode(fmt.Sprintf("%sStr", paramVarName), param, op)
 				if err != nil {
 					return "", err
 				}

--- a/swagger/parameter.go
+++ b/swagger/parameter.go
@@ -23,9 +23,9 @@ import (
 // ParamToStringCode returns a function that converts a Parameter into the code to convert
 // it into a string (for serialization). For example, a integer named 'Size' becomes
 // `strconv.FormatInt(i.Size, 10)`
-func ParamToStringCode(param spec.Parameter) string {
+func ParamToStringCode(param spec.Parameter, op *spec.Operation) string {
 
-	valToSet := accessString(param)
+	valToSet := accessString(param, op)
 	switch param.Type {
 	case "string":
 		switch param.Format {
@@ -159,7 +159,7 @@ func convertDate(input string) (strfmt.Date, error) {
 // StringToTypeCode returns the code to convert a string into the type. For example,
 // for an int64 it generates swag.ConvertFloat64(sizeStr). It returns an array because sometimes
 // this takes multiple lines of code
-func StringToTypeCode(strField string, param spec.Parameter) (string, error) {
+func StringToTypeCode(strField string, param spec.Parameter, op *spec.Operation) (string, error) {
 
 	switch param.Type {
 	case "integer":
@@ -201,24 +201,24 @@ func StringToTypeCode(strField string, param spec.Parameter) (string, error) {
 
 // ParamToValidationCode takes in a param and returns a list of parameter validation
 // functions, each of which have a single return value, error
-func ParamToValidationCode(param spec.Parameter) ([]string, error) {
+func ParamToValidationCode(param spec.Parameter, op *spec.Operation) ([]string, error) {
 	var validations []string
 	if param.Type == "string" {
 		if param.MaxLength != nil {
 			validations = append(validations, fmt.Sprintf("validate.MaxLength(\"%s\", \"%s\", string(%s), %d)",
-				param.Name, param.In, accessString(param), *param.MaxLength))
+				param.Name, param.In, accessString(param, op), *param.MaxLength))
 		}
 		if param.MinLength != nil {
 			validations = append(validations, fmt.Sprintf("validate.MinLength(\"%s\", \"%s\", string(%s), %d)",
-				param.Name, param.In, accessString(param), *param.MaxLength))
+				param.Name, param.In, accessString(param, op), *param.MaxLength))
 		}
 		if param.Pattern != "" {
 			validations = append(validations, fmt.Sprintf("validate.Pattern(\"%s\", \"%s\", string(%s), \"%s\")",
-				param.Name, param.In, accessString(param), param.Pattern))
+				param.Name, param.In, accessString(param, op), param.Pattern))
 		}
 		if param.Format != "" {
 			validations = append(validations, fmt.Sprintf("validate.FormatOf(\"%s\", \"%s\", \"%s\", %s, strfmt.Default)",
-				param.Name, param.In, param.Format, ParamToStringCode(param)))
+				param.Name, param.In, param.Format, ParamToStringCode(param, op)))
 		}
 		if len(param.Enum) != 0 {
 			strEnum := []string{}
@@ -226,46 +226,46 @@ func ParamToValidationCode(param spec.Parameter) ([]string, error) {
 				strEnum = append(strEnum, enum.(string))
 			}
 			validations = append(validations, fmt.Sprintf("validate.Enum(\"%s\", \"%s\", %s, %s)",
-				param.Name, param.In, accessString(param), fmt.Sprintf("[]interface{}{\"%s\"}", strings.Join(strEnum, "\",\""))))
+				param.Name, param.In, accessString(param, op), fmt.Sprintf("[]interface{}{\"%s\"}", strings.Join(strEnum, "\",\""))))
 		}
 	} else if param.Type == "integer" {
 		if param.Maximum != nil {
 			validations = append(validations, fmt.Sprintf("validate.MaximumInt(\"%s\", \"%s\", %s, int64(%d), %t)",
-				param.Name, param.In, accessString(param), int64(*param.Maximum), param.ExclusiveMaximum))
+				param.Name, param.In, accessString(param, op), int64(*param.Maximum), param.ExclusiveMaximum))
 		}
 		if param.Minimum != nil {
 			validations = append(validations, fmt.Sprintf("validate.MinimumInt(\"%s\", \"%s\", %s, int64(%d), %t)",
-				param.Name, param.In, accessString(param), int64(*param.Minimum), param.ExclusiveMinimum))
+				param.Name, param.In, accessString(param, op), int64(*param.Minimum), param.ExclusiveMinimum))
 		}
 		if param.MultipleOf != nil {
 			validations = append(validations, fmt.Sprintf("validate.MultipleOf(\"%s\", \"%s\", float64(%s), %f)",
-				param.Name, param.In, accessString(param), *param.MultipleOf))
+				param.Name, param.In, accessString(param, op), *param.MultipleOf))
 		}
 	} else if param.Type == "number" {
 		if param.Maximum != nil {
 			validations = append(validations, fmt.Sprintf("validate.Maximum(\"%s\", \"%s\",  float64(%s), %f, %t)",
-				param.Name, param.In, accessString(param), *param.Maximum, param.ExclusiveMaximum))
+				param.Name, param.In, accessString(param, op), *param.Maximum, param.ExclusiveMaximum))
 		}
 		if param.Minimum != nil {
 			validations = append(validations, fmt.Sprintf("validate.Minimum(\"%s\", \"%s\", float64(%s), %f, %t)",
-				param.Name, param.In, accessString(param), *param.Minimum, param.ExclusiveMinimum))
+				param.Name, param.In, accessString(param, op), *param.Minimum, param.ExclusiveMinimum))
 		}
 		if param.MultipleOf != nil {
 			validations = append(validations, fmt.Sprintf("validate.MultipleOf(\"%s\", \"%s\", float64(%s), %f)",
-				param.Name, param.In, accessString(param), *param.MultipleOf))
+				param.Name, param.In, accessString(param, op), *param.MultipleOf))
 		}
 	} else if param.Type == "array" {
 		if param.MaxItems != nil {
 			validations = append(validations, fmt.Sprintf("validate.MaxItems(\"%s\", \"%s\", int64(len(%s)), %d)",
-				param.Name, param.In, accessString(param), *param.MaxItems))
+				param.Name, param.In, accessString(param, op), *param.MaxItems))
 		}
 		if param.MinItems != nil {
 			validations = append(validations, fmt.Sprintf("validate.MinItems(\"%s\", \"%s\", int64(len(%s)), %d)",
-				param.Name, param.In, accessString(param), *param.MinItems))
+				param.Name, param.In, accessString(param, op), *param.MinItems))
 		}
 		if param.UniqueItems {
 			validations = append(validations, fmt.Sprintf("validate.UniqueItems(\"%s\", \"%s\", %s)",
-				param.Name, param.In, accessString(param)))
+				param.Name, param.In, accessString(param, op)))
 		}
 	}
 	return validations, nil
@@ -273,7 +273,7 @@ func ParamToValidationCode(param spec.Parameter) ([]string, error) {
 
 // accessString returns a string with the access of a variable in the struct named 'i'. For example:
 // *i.Length
-func accessString(param spec.Parameter) string {
+func accessString(param spec.Parameter, op *spec.Operation) string {
 	_, makePointer, err := ParamToType(param)
 	if err != nil {
 		panic(fmt.Sprintf("unexpected error building parameter: %s", err))
@@ -281,6 +281,11 @@ func accessString(param spec.Parameter) string {
 	pointer := ""
 	if makePointer {
 		pointer = "*"
+	}
+
+	single, _ := SingleStringPathParameter(op)
+	if single {
+		return fmt.Sprintf("%s%s", pointer, param.Name)
 	}
 	return fmt.Sprintf("%si.%s", pointer, utils.CamelCase(param.Name, true))
 }


### PR DESCRIPTION
This change will make it easier to support arbitrary single parameter methods.

For the most part it tries to move all the `if` and `printf` statements into templates so that they're easier to read. It also replaces things like `i.%s` with `{{.AccessString}}`

I do this for both the model and client generation. The server generation was fairly close to a good place already.

Did this separately so we could make sure the refactor kept the generated code the same (except for whitespace)