### PR TITLE
Nested schema error

### DIFF
--- a/validation/validation.go
+++ b/validation/validation.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/Clever/wag/swagger"
 	swaggererrors "github.com/go-openapi/errors"
@@ -48,7 +49,7 @@ func validateOp(path, method string, op *spec.Operation) error {
 			method, path)
 	}
 
-	if err := validateResponses(op); err != nil {
+	if err := validateResponses(path, method, op); err != nil {
 		return err
 	}
 
@@ -59,14 +60,23 @@ func validateOp(path, method string, op *spec.Operation) error {
 	return nil
 }
 
-func validateResponses(op *spec.Operation) error {
+func validateResponses(path, method string, op *spec.Operation) error {
 
 	for _, statusCode := range swagger.SortedStatusCodeKeys(op.Responses.StatusCodeResponses) {
 		if statusCode < 200 || statusCode > 599 {
-			return fmt.Errorf("Response map key must be an integer between 200 and 599 or "+
-				"the string 'default'. Was %d", statusCode)
+			return fmt.Errorf("response map key must be an integer between 200 and 599 or "+
+				"the string 'default'. Was %d for %s %s", statusCode, path, method)
 		}
-		_, err := swagger.TypeFromSchema(op.Responses.StatusCodeResponses[statusCode].Schema, false)
+		response := op.Responses.StatusCodeResponses[statusCode]
+		refStr := response.Ref.String()
+		if refStr != "" && strings.HasPrefix(refStr, "#/definitions") {
+			return fmt.Errorf("responses with references should nest the ref in a schema. "+
+				"responses.%d.$ref = '%s' for %s %s should be "+
+				"responses.%d.schema.$ref = '%s'",
+				statusCode, refStr, path, method, statusCode, refStr)
+		}
+
+		_, err := swagger.TypeFromSchema(response.Schema, false)
 		if err != nil {
 			return err
 		}

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -48,6 +48,19 @@ func validateOp(path, method string, op *spec.Operation) error {
 			method, path)
 	}
 
+	if err := validateResponses(op); err != nil {
+		return err
+	}
+
+	if err := validateParams(path, method, op); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateResponses(op *spec.Operation) error {
+
 	for _, statusCode := range swagger.SortedStatusCodeKeys(op.Responses.StatusCodeResponses) {
 		if statusCode < 200 || statusCode > 599 {
 			return fmt.Errorf("Response map key must be an integer between 200 and 599 or "+
@@ -58,6 +71,10 @@ func validateOp(path, method string, op *spec.Operation) error {
 			return err
 		}
 	}
+	return nil
+}
+
+func validateParams(path, method string, op *spec.Operation) error {
 
 	for _, param := range op.Parameters {
 
@@ -105,7 +122,6 @@ func validateOp(path, method string, op *spec.Operation) error {
 			}
 		}
 	}
-
 	return nil
 }
 

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -3,8 +3,10 @@ package validation
 import (
 	"testing"
 
+	"github.com/go-openapi/jsonreference"
 	"github.com/go-openapi/spec"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateOpID(t *testing.T) {
@@ -27,4 +29,22 @@ func TestValidatePathParams(t *testing.T) {
 	err := validateOp("/books", "GET", &op)
 	assert.Error(t, err)
 	assert.Equal(t, "paramName for GET /books is a path parameter so it must be required", err.Error())
+}
+
+func TestValidateRawRef(t *testing.T) {
+	op := spec.Operation{}
+	op.Responses = &spec.Responses{}
+	op.Responses.StatusCodeResponses = make(map[int]spec.Response)
+
+	response := spec.Response{}
+	jsonref, err := jsonreference.New("#/definitions/testref")
+	require.NoError(t, err)
+	response.Ref = spec.Ref{Ref: jsonref}
+
+	op.Responses.StatusCodeResponses[200] = response
+	err = validateResponses("path", "method", &op)
+	require.Error(t, err)
+	assert.Equal(t, "responses with references should nest the ref in a schema. "+
+		"responses.200.$ref = '#/definitions/testref' for path method should be "+
+		"responses.200.schema.$ref = '#/definitions/testref'", err.Error())
 }


### PR DESCRIPTION
If you don't nest a reference in a schema you get a go-openapi error. This has confused a few people so let's give a clearer error message.

cc @drhurd 