### PR TITLE
Error in client for empty path parameters

### DIFF
--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -323,8 +323,10 @@ func buildRequestCode(s *spec.Swagger, op *spec.Operation, method string) string
 		t := paramToTemplate(s, &param, op)
 		if param.In == "path" {
 			pt := pathParamTemplate{
+				Name:         param.Name,
 				PathName:     "{" + t.Name + "}",
 				ToStringCode: t.ToStringCode,
+				ErrorMessage: errorMessage(s, op),
 			}
 			str, err := templates.WriteTemplate(pathParamStr, pt)
 			if err != nil {
@@ -388,11 +390,19 @@ type paramTemplate struct {
 // pathParamTemplate is a seperate template because I couldn't find a non-annoying
 // way to encode {".Name"} in the template
 type pathParamTemplate struct {
+	Name         string
 	PathName     string
 	ToStringCode string
+	ErrorMessage string
 }
 
-var pathParamStr = `path = strings.Replace(path, "{{.PathName}}", {{.ToStringCode}}, -1)
+var pathParamStr = `
+	path{{.Name}} := {{.ToStringCode}}
+	if path{{.Name}} == "" {
+		err := fmt.Errorf("path parameters cannot be empty")
+		{{- .ErrorMessage}}
+	}
+	path = strings.Replace(path, "{{.PathName}}", path{{.Name}}, -1)
 `
 
 var queryParamStr = `

--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -399,7 +399,7 @@ type pathParamTemplate struct {
 var pathParamStr = `
 	path{{.Name}} := {{.ToStringCode}}
 	if path{{.Name}} == "" {
-		err := fmt.Errorf("path parameters cannot be empty")
+		err := fmt.Errorf("{{.Name}} cannot be empty because it's a path parameter")
 		{{- .ErrorMessage}}
 	}
 	path = strings.Replace(path, "{{.PathName}}", path{{.Name}}, -1)

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -245,8 +245,8 @@ var methodTmplStr = `
 
     const headers = {};
     {{- range $param := .PathParams}}
-    if (params.{{$param.JSName}} == "") {
-      cb(new Error("Path parameters must be non-empty"))
+    if (!params.{{$param.JSName}}) {
+      cb(new Error("{{$param.JSName}} must be non-empty because it's a path parameter"))
     }
     {{- end -}}
     {{- range $param := .HeaderParams}}

--- a/samples/gen-go-errors/client/client.go
+++ b/samples/gen-go-errors/client/client.go
@@ -149,7 +149,7 @@ func (c *WagClient) GetBook(ctx context.Context, i *models.GetBookInput) error {
 
 	pathid := strconv.FormatInt(i.ID, 10)
 	if pathid == "" {
-		err := fmt.Errorf("path parameters cannot be empty")
+		err := fmt.Errorf("id cannot be empty because it's a path parameter")
 
 		if err != nil {
 			return err

--- a/samples/gen-go-errors/client/client.go
+++ b/samples/gen-go-errors/client/client.go
@@ -147,7 +147,16 @@ func (c *WagClient) GetBook(ctx context.Context, i *models.GetBookInput) error {
 	urlVals := url.Values{}
 	var body []byte
 
-	path = strings.Replace(path, "{id}", strconv.FormatInt(i.ID, 10), -1)
+	pathid := strconv.FormatInt(i.ID, 10)
+	if pathid == "" {
+		err := fmt.Errorf("path parameters cannot be empty")
+
+		if err != nil {
+			return err
+		}
+
+	}
+	path = strings.Replace(path, "{id}", pathid, -1)
 	path = path + "?" + urlVals.Encode()
 
 	client := &http.Client{Transport: c.transport}

--- a/samples/gen-go-nils/client/client.go
+++ b/samples/gen-go-nils/client/client.go
@@ -148,7 +148,7 @@ func (c *WagClient) NilCheck(ctx context.Context, i *models.NilCheckInput) error
 
 	pathid := i.ID
 	if pathid == "" {
-		err := fmt.Errorf("path parameters cannot be empty")
+		err := fmt.Errorf("id cannot be empty because it's a path parameter")
 
 		if err != nil {
 			return err

--- a/samples/gen-go-nils/client/client.go
+++ b/samples/gen-go-nils/client/client.go
@@ -146,7 +146,16 @@ func (c *WagClient) NilCheck(ctx context.Context, i *models.NilCheckInput) error
 	urlVals := url.Values{}
 	var body []byte
 
-	path = strings.Replace(path, "{id}", i.ID, -1)
+	pathid := i.ID
+	if pathid == "" {
+		err := fmt.Errorf("path parameters cannot be empty")
+
+		if err != nil {
+			return err
+		}
+
+	}
+	path = strings.Replace(path, "{id}", pathid, -1)
 
 	if i.Query != nil {
 		urlVals.Add("query", *i.Query)

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -335,7 +335,7 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 
 	pathbook_id := strconv.FormatInt(i.BookID, 10)
 	if pathbook_id == "" {
-		err := fmt.Errorf("path parameters cannot be empty")
+		err := fmt.Errorf("book_id cannot be empty because it's a path parameter")
 
 		if err != nil {
 			return nil, err
@@ -442,7 +442,7 @@ func (c *WagClient) GetBookByID2(ctx context.Context, id string) (*models.Book, 
 
 	pathid := id
 	if pathid == "" {
-		err := fmt.Errorf("path parameters cannot be empty")
+		err := fmt.Errorf("id cannot be empty because it's a path parameter")
 
 		if err != nil {
 			return nil, err

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -333,7 +333,16 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 	urlVals := url.Values{}
 	var body []byte
 
-	path = strings.Replace(path, "{book_id}", strconv.FormatInt(i.BookID, 10), -1)
+	pathbook_id := strconv.FormatInt(i.BookID, 10)
+	if pathbook_id == "" {
+		err := fmt.Errorf("path parameters cannot be empty")
+
+		if err != nil {
+			return nil, err
+		}
+
+	}
+	path = strings.Replace(path, "{book_id}", pathbook_id, -1)
 
 	if i.AuthorID != nil {
 		urlVals.Add("authorID", *i.AuthorID)
@@ -431,7 +440,16 @@ func (c *WagClient) GetBookByID2(ctx context.Context, id string) (*models.Book, 
 	urlVals := url.Values{}
 	var body []byte
 
-	path = strings.Replace(path, "{id}", id, -1)
+	pathid := id
+	if pathid == "" {
+		err := fmt.Errorf("path parameters cannot be empty")
+
+		if err != nil {
+			return nil, err
+		}
+
+	}
+	path = strings.Replace(path, "{id}", pathid, -1)
 	path = path + "?" + urlVals.Encode()
 
 	client := &http.Client{Transport: c.transport}

--- a/samples/gen-js-errors/index.js
+++ b/samples/gen-js-errors/index.js
@@ -143,8 +143,8 @@ class SwaggerTest {
     const span = options.span;
 
     const headers = {};
-    if (params.id == "") {
-      cb(new Error("Path parameters must be non-empty"))
+    if (!params.id) {
+      cb(new Error("id must be non-empty because it's a path parameter"))
     }
 
     const query = {};

--- a/samples/gen-js-errors/index.js
+++ b/samples/gen-js-errors/index.js
@@ -143,6 +143,9 @@ class SwaggerTest {
     const span = options.span;
 
     const headers = {};
+    if (params.id == "") {
+      cb(new Error("Path parameters must be non-empty"))
+    }
 
     const query = {};
 

--- a/samples/gen-js-nils/index.js
+++ b/samples/gen-js-nils/index.js
@@ -145,8 +145,8 @@ class NilTest {
     const span = options.span;
 
     const headers = {};
-    if (params.id == "") {
-      cb(new Error("Path parameters must be non-empty"))
+    if (!params.id) {
+      cb(new Error("id must be non-empty because it's a path parameter"))
     }
     headers["header"] = params.header;
 

--- a/samples/gen-js-nils/index.js
+++ b/samples/gen-js-nils/index.js
@@ -145,6 +145,9 @@ class NilTest {
     const span = options.span;
 
     const headers = {};
+    if (params.id == "") {
+      cb(new Error("Path parameters must be non-empty"))
+    }
     headers["header"] = params.header;
 
     const query = {};

--- a/samples/gen-js/index.js
+++ b/samples/gen-js/index.js
@@ -386,6 +386,9 @@ class SwaggerTest {
     const span = options.span;
 
     const headers = {};
+    if (params.bookID == "") {
+      cb(new Error("Path parameters must be non-empty"))
+    }
     headers["authorization"] = params.authorization;
 
     const query = {};
@@ -500,6 +503,9 @@ class SwaggerTest {
     const span = options.span;
 
     const headers = {};
+    if (params.id == "") {
+      cb(new Error("Path parameters must be non-empty"))
+    }
 
     const query = {};
 

--- a/samples/gen-js/index.js
+++ b/samples/gen-js/index.js
@@ -386,8 +386,8 @@ class SwaggerTest {
     const span = options.span;
 
     const headers = {};
-    if (params.bookID == "") {
-      cb(new Error("Path parameters must be non-empty"))
+    if (!params.bookID) {
+      cb(new Error("bookID must be non-empty because it's a path parameter"))
     }
     headers["authorization"] = params.authorization;
 
@@ -503,8 +503,8 @@ class SwaggerTest {
     const span = options.span;
 
     const headers = {};
-    if (params.id == "") {
-      cb(new Error("Path parameters must be non-empty"))
+    if (!params.id) {
+      cb(new Error("id must be non-empty because it's a path parameter"))
     }
 
     const query = {};

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -143,6 +143,14 @@ func TestNonGetRetries(t *testing.T) {
 	assert.Equal(t, 1, controller.postCount)
 }
 
+func TestErrorOnMissingPathParams(t *testing.T) {
+	// Should fail client side
+	c := client.New("badUrl")
+	_, err := c.GetBookByID2(context.Background(), "")
+	require.Error(t, err)
+	assert.Equal(t, "path parameters cannot be empty", err.Error())
+}
+
 func TestNetworkErrorRetries(t *testing.T) {
 	c := client.New("https://thisshouldnotresolve1234567890.com/")
 	_, err := c.CreateBook(context.Background(), &models.Book{})

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -148,7 +148,7 @@ func TestErrorOnMissingPathParams(t *testing.T) {
 	c := client.New("badUrl")
 	_, err := c.GetBookByID2(context.Background(), "")
 	require.Error(t, err)
-	assert.Equal(t, "path parameters cannot be empty", err.Error())
+	assert.Equal(t, "id cannot be empty because it's a path parameter", err.Error())
 }
 
 func TestNetworkErrorRetries(t *testing.T) {

--- a/test/js/operations.js
+++ b/test/js/operations.js
@@ -32,7 +32,7 @@ describe("operations", function() {
       bookID: "",
     };
     c.getBookByID(params, function(err, resp) {
-      assert.equal(err.toString(), "Error: Path parameters must be non-empty")
+      assert.equal(err.toString(), "Error: bookID must be non-empty because it's a path parameter")
       done()
     });
   });

--- a/test/js/operations.js
+++ b/test/js/operations.js
@@ -26,6 +26,17 @@ describe("operations", function() {
     });
   });
 
+  it("error on empty path param", function(done) {
+    const c = new Client({address: mockAddress});
+    const params = {
+      bookID: "",
+    };
+    c.getBookByID(params, function(err, resp) {
+      assert.equal(err.toString(), "Error: Path parameters must be non-empty")
+      done()
+    });
+  });
+
   it("return a error in failure cases", function(done) {
     const c = new Client({address: mockAddress});
     const scope = nock(mockAddress)


### PR DESCRIPTION
Because if the path parameters are empty then we can't construct the URL.