### PR TITLE
check glide.ymls for correct dependencies

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: fd0551b46ac3509df57305c450bbc71959eb84cc12f6c5bcf15c2e34801291f7
-updated: 2016-12-20T23:06:10.347591586Z
+hash: 3c6513e6191447dad36c16cc341cc0091aaaf34746a4b7178014939153346eac
+updated: 2017-01-06T01:18:57.641912632Z
 imports:
 - name: github.com/afex/hystrix-go
   version: 39520ddd07a9d9a071d615f7476798659f5a3b89
@@ -58,7 +58,7 @@ imports:
   subpackages:
   - generator
 - name: github.com/gogo/protobuf
-  version: 8d70fb3182befc465c4a1eac8ad4d38ff49778e2
+  version: a9cd0c35b97daf74d0ebf3514c5254814b2703b4
   subpackages:
   - proto
 - name: github.com/golang/mock
@@ -213,7 +213,7 @@ imports:
   - go/loader
   - imports
 - name: google.golang.org/grpc
-  version: 09aecb094ef6b9ebe49dd999f52c505beeeb402e
+  version: c8105071640ef29fce843ed96983e864bb18eb0e
   subpackages:
   - codes
   - credentials
@@ -259,7 +259,7 @@ testImports:
   subpackages:
   - difflib
 - name: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
   - require

--- a/glide.yaml
+++ b/glide.yaml
@@ -16,8 +16,10 @@ import:
   subpackages:
   - gomock
 - package: github.com/gorilla/mux
+  # if you change this, please update validation/glide.go
   version: 757bef944d0f21880861c2dd9c871ca543023cba
 - package: github.com/opentracing/opentracing-go
+  # if you change this, please update validation/glide.go
   version: ^1.0.0
 - package: golang.org/x/net
   subpackages:
@@ -41,3 +43,4 @@ import:
 - package: github.com/go-errors/errors
 - package: github.com/afex/hystrix-go
 - package: github.com/donovanhide/eventsource
+- package: gopkg.in/yaml.v2

--- a/main.go
+++ b/main.go
@@ -46,6 +46,12 @@ func main() {
 		log.Fatal("js-path is required")
 	}
 
+	if glideYMLFile, err := os.Open("glide.yml"); err == nil {
+		if err := validation.ValidateGlideYML(glideYMLFile); err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	loads.AddLoader(fmts.YAMLMatcher, fmts.YAMLDoc)
 	doc, err := loads.Spec(*swaggerFile)
 	if err != nil {

--- a/validation/glide.go
+++ b/validation/glide.go
@@ -1,0 +1,72 @@
+package validation
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
+)
+
+// GlideYML unmarshals the parts of a glide.yml file we care about.
+type GlideYML struct {
+	Imports []Import `yaml:"import"`
+}
+
+// Import contained within a glide.yml.
+type Import struct {
+	Package string `yaml:"package"`
+	Version string `yaml:"version"`
+}
+
+// requirements describes dependencies we require wag users to use in their apps.
+var requirements = []Import{
+	{
+		Package: "github.com/lightstep/lightstep-tracer-go",
+		Version: "0d48cd619841b1e1a3cdd20cd6ac97774c0002ce",
+	},
+	{
+		Package: "github.com/opentracing/opentracing-go",
+		Version: "^1.0.0",
+	},
+	{
+		Package: "github.com/opentracing/basictracer-go",
+		Version: "1b32af207119a14b1b231d451df3ed04a72efebf",
+	},
+	{
+		Package: "github.com/gorilla/mux",
+		Version: "757bef944d0f21880861c2dd9c871ca543023cba",
+	},
+}
+
+// ValidateGlideYML looks at a user's glide.yml and makes sure certain dependencies
+// that wag requires are present and locked to the correct version.
+func ValidateGlideYML(glideYMLFile io.Reader) error {
+	var glideYML GlideYML
+	bs, err := ioutil.ReadAll(glideYMLFile)
+	if err != nil {
+		return fmt.Errorf("error reading glide.yml: %s", err)
+	}
+	if err = yaml.Unmarshal(bs, &glideYML); err != nil {
+		return fmt.Errorf("error unmarshalling yaml: %s", err)
+	}
+
+	for _, req := range requirements {
+		if err := validateImports(glideYML.Imports, req); err != nil {
+			return err
+		}
+	}
+
+	return nil
+
+}
+
+func validateImports(imports []Import, requiredImport Import) error {
+	for _, i := range imports {
+		if i.Package == requiredImport.Package &&
+			i.Version == requiredImport.Version {
+			return nil
+		}
+	}
+	return fmt.Errorf("wag requires version %s of %s. Please update your glide.yml and run `glide up`", requiredImport.Version, requiredImport.Package)
+}

--- a/validation/glide_test.go
+++ b/validation/glide_test.go
@@ -1,0 +1,63 @@
+package validation
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type GlideYMLTest struct {
+	YML   string
+	Error error
+}
+
+var glideYMLTests = []GlideYMLTest{
+	{
+		YML: `import:
+- package: github.com/lightstep/lightstep-tracer-go
+  version: 0d48cd619841b1e1a3cdd20cd6ac97774c0002ce
+- package: github.com/opentracing/opentracing-go
+  version: ^1.0.0
+- package: github.com/opentracing/basictracer-go
+  version: 1b32af207119a14b1b231d451df3ed04a72efebf
+- package: github.com/gorilla/mux
+  version: 757bef944d0f21880861c2dd9c871ca543023cba
+`,
+		Error: nil,
+	},
+	{
+		YML: `import:
+- package: github.com/lightstep/lightstep-tracer-go
+  version: incorrect
+- package: github.com/opentracing/opentracing-go
+  version: ^1.0.0
+- package: github.com/opentracing/basictracer-go
+  version: 1b32af207119a14b1b231d451df3ed04a72efebf
+- package: github.com/gorilla/mux
+  version: 757bef944d0f21880861c2dd9c871ca543023cba
+`,
+		Error: errors.New("wag requires version 0d48cd619841b1e1a3cdd20cd6ac97774c0002ce of github.com/lightstep/lightstep-tracer-go. Please update your glide.yml and run `glide up`"),
+	},
+	{
+		YML: `import:
+- package: github.com/lightstep/lightstep-tracer-go
+  version: 0d48cd619841b1e1a3cdd20cd6ac97774c0002ce
+- package: github.com/opentracing/basictracer-go
+  version: 1b32af207119a14b1b231d451df3ed04a72efebf
+- package: github.com/gorilla/mux
+  version: 757bef944d0f21880861c2dd9c871ca543023cba
+`,
+		Error: errors.New("wag requires version ^1.0.0 of github.com/opentracing/opentracing-go. Please update your glide.yml and run `glide up`"),
+	},
+}
+
+func TestGlideYML(t *testing.T) {
+	for _, test := range glideYMLTests {
+		err := ValidateGlideYML(strings.NewReader(test.YML))
+		assert.Equal(t, err, test.Error,
+			fmt.Sprintf("incorrect error returned from input:\n%s", test.YML))
+	}
+}


### PR DESCRIPTION
This adds a check that users have pulled in the correct versions of dependencies that wag requires to function properly.