### PR TITLE
Generate different comments for the client and server interface

### DIFF
--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -228,7 +228,7 @@ func generateInterface(packageName string, s *spec.Swagger, serviceName string, 
 				continue
 			}
 
-			interfaceComment, err := swagger.InterfaceComment(method, pathKey, s, pathItemOps[method])
+			interfaceComment, err := swagger.InterfaceComment(method, pathKey, true, s, pathItemOps[method])
 			if err != nil {
 				return err
 			}
@@ -245,7 +245,7 @@ func methodCode(s *spec.Swagger, op *spec.Operation, basePath, method, methodPat
 	var buf bytes.Buffer
 	capOpID := swagger.Capitalize(op.ID)
 
-	interfaceComment, err := swagger.InterfaceComment(method, methodPath, s, op)
+	interfaceComment, err := swagger.InterfaceComment(method, methodPath, true, s, op)
 	if err != nil {
 		return "", err
 	}

--- a/samples/gen-go-deprecated/server/interface.go
+++ b/samples/gen-go-deprecated/server/interface.go
@@ -11,7 +11,7 @@ import (
 // Controller defines the interface for the swagger-test service.
 type Controller interface {
 
-	// Health makes a GET request to /health
+	// Health handles GET requests to /health
 	//
 	// 200: nil
 	// 400: *models.BadRequest

--- a/samples/gen-go-errors/server/interface.go
+++ b/samples/gen-go-errors/server/interface.go
@@ -11,7 +11,7 @@ import (
 // Controller defines the interface for the swagger-test service.
 type Controller interface {
 
-	// GetBook makes a GET request to /books/{id}
+	// GetBook handles GET requests to /books/{id}
 	//
 	// 200: nil
 	// 400: *models.ExtendedError

--- a/samples/gen-go-nils/server/interface.go
+++ b/samples/gen-go-nils/server/interface.go
@@ -11,7 +11,7 @@ import (
 // Controller defines the interface for the nil-test service.
 type Controller interface {
 
-	// NilCheck makes a POST request to /check/{id}
+	// NilCheck handles POST requests to /check/{id}
 	// Nil check tests
 	// 200: nil
 	// 400: *models.BadRequest

--- a/samples/gen-go/server/interface.go
+++ b/samples/gen-go/server/interface.go
@@ -11,7 +11,7 @@ import (
 // Controller defines the interface for the swagger-test service.
 type Controller interface {
 
-	// GetBooks makes a GET request to /books
+	// GetBooks handles GET requests to /books
 	// Returns a list of books
 	// 200: []models.Book
 	// 400: *models.BadRequest
@@ -19,7 +19,7 @@ type Controller interface {
 	// default: client side HTTP errors, for example: context.DeadlineExceeded.
 	GetBooks(ctx context.Context, i *models.GetBooksInput) ([]models.Book, error)
 
-	// CreateBook makes a POST request to /books
+	// CreateBook handles POST requests to /books
 	// Creates a book
 	// 200: *models.Book
 	// 400: *models.BadRequest
@@ -27,7 +27,7 @@ type Controller interface {
 	// default: client side HTTP errors, for example: context.DeadlineExceeded.
 	CreateBook(ctx context.Context, i *models.Book) (*models.Book, error)
 
-	// GetBookByID makes a GET request to /books/{book_id}
+	// GetBookByID handles GET requests to /books/{book_id}
 	// Returns a book
 	// 200: *models.Book
 	// 400: *models.BadRequest
@@ -37,7 +37,7 @@ type Controller interface {
 	// default: client side HTTP errors, for example: context.DeadlineExceeded.
 	GetBookByID(ctx context.Context, i *models.GetBookByIDInput) (*models.Book, error)
 
-	// GetBookByID2 makes a GET request to /books2/{id}
+	// GetBookByID2 handles GET requests to /books2/{id}
 	// Retrieve a book
 	// 200: *models.Book
 	// 400: *models.BadRequest
@@ -46,7 +46,7 @@ type Controller interface {
 	// default: client side HTTP errors, for example: context.DeadlineExceeded.
 	GetBookByID2(ctx context.Context, id string) (*models.Book, error)
 
-	// HealthCheck makes a GET request to /health/check
+	// HealthCheck handles GET requests to /health/check
 	//
 	// 200: nil
 	// 400: *models.BadRequest

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -218,7 +218,7 @@ func generateInterface(packageName string, s *spec.Swagger, serviceName string, 
 		path := paths.Paths[pathKey]
 		pathItemOps := swagger.PathItemOperations(path)
 		for _, method := range swagger.SortedOperationsKeys(pathItemOps) {
-			interfaceComment, err := swagger.InterfaceComment(method, pathKey, s, pathItemOps[method])
+			interfaceComment, err := swagger.InterfaceComment(method, pathKey, false, s, pathItemOps[method])
 			if err != nil {
 				return err
 			}

--- a/swagger/operation.go
+++ b/swagger/operation.go
@@ -36,8 +36,9 @@ func Interface(s *spec.Swagger, op *spec.Operation) string {
 		capOpID, input, *successType)
 }
 
-// InterfaceComment returns the comment for the interface for the operation
-func InterfaceComment(method, path string, s *spec.Swagger, op *spec.Operation) (string, error) {
+// InterfaceComment returns the comment for the interface for the operation. If the client
+// flag is set then it generates the client version. Otherwise it generates the server version.
+func InterfaceComment(method, path string, client bool, s *spec.Swagger, op *spec.Operation) (string, error) {
 
 	statusCodeToType := CodeToTypeMap(s, op, true)
 	for code, typ := range statusCodeToType {
@@ -49,12 +50,14 @@ func InterfaceComment(method, path string, s *spec.Swagger, op *spec.Operation) 
 		OpID             string
 		Method           string
 		Path             string
+		Client           bool
 		Description      string
 		StatusCodeToType map[int]string
 	}{
 		OpID:             Capitalize(op.ID),
 		Method:           method,
 		Path:             path,
+		Client:           client,
 		Description:      op.Description,
 		StatusCodeToType: statusCodeToType,
 	}
@@ -62,7 +65,11 @@ func InterfaceComment(method, path string, s *spec.Swagger, op *spec.Operation) 
 }
 
 var interfaceCommentTmplStr = `
+{{if .Client -}}
 // {{.OpID}} makes a {{.Method}} request to {{.Path}}
+{{- else -}}
+// {{.OpID}} handles {{.Method}} requests to {{.Path}}
+{{- end}}
 // {{.Description}} {{ range $code, $type := .StatusCodeToType }}
 // {{$code}}: {{$type}} {{end}}
 // default: client side HTTP errors, for example: context.DeadlineExceeded.`


### PR DESCRIPTION
Since one makes requests and the other handles them. This was a bit
annoying when creating wag services because I would need to tweak the
server interface comments each time.