### PR TITLE
Explicitly error on nested object definitions

### DIFF
--- a/validation/validation.go
+++ b/validation/validation.go
@@ -139,6 +139,8 @@ func validateDefinitions(definitions map[string]spec.Schema) error {
 	for name, def := range definitions {
 		for _, subDef := range def.Properties {
 			if len(subDef.Type) == 1 && subDef.Type[0] == "object" {
+				// We throw an error here because nested objects generate a compiler error in
+				// the go-swagger model code.
 				return fmt.Errorf("%s cannot have nested object types", name)
 			}
 		}

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -135,6 +135,17 @@ func validateParams(path, method string, op *spec.Operation) error {
 	return nil
 }
 
+func validateDefinitions(definitions map[string]spec.Schema) error {
+	for name, def := range definitions {
+		for _, subDef := range def.Properties {
+			if len(subDef.Type) == 1 && subDef.Type[0] == "object" {
+				return fmt.Errorf("%s cannot have nested object types", name)
+			}
+		}
+	}
+	return nil
+}
+
 // Validate returns an error if the swagger file is invalid or uses fields
 // we don't support. Note that this isn't a comprehensive check for all things
 // we don't support, so this may not return an error, but the Swagger file might
@@ -204,7 +215,7 @@ func Validate(d loads.Document) error {
 		}
 	}
 
-	return nil
+	return validateDefinitions(s.Definitions)
 }
 
 func sliceContains(slice []string, key string) bool {

--- a/validation/validation_test.go
+++ b/validation/validation_test.go
@@ -48,3 +48,18 @@ func TestValidateRawRef(t *testing.T) {
 		"responses.200.$ref = '#/definitions/testref' for path method should be "+
 		"responses.200.schema.$ref = '#/definitions/testref'", err.Error())
 }
+
+func TestNestedTypes(t *testing.T) {
+	nestedSchema := spec.Schema{}
+	nestedSchema.Type = spec.StringOrArray([]string{"object"})
+	schema := spec.Schema{}
+	schema.Properties = make(map[string]spec.Schema)
+	schema.Properties["nested"] = nestedSchema
+
+	definitions := spec.Definitions{}
+	definitions["badNested"] = schema
+
+	err := validateDefinitions(definitions)
+	require.Error(t, err)
+	assert.Equal(t, "badNested cannot have nested object types", err.Error())
+}


### PR DESCRIPTION
definitions:
  Foo:
    type: object
    properties:
      bar:
        type: object
        properties:
          baz:
           type: string

Generates an error:
gen-go/models/foo.go:44: m.Bar.Validate undefined (type *FooBar has no
field or method Validate)

This appears to be a bug in the way go-swagger generates validation
code. Let's make it clearer to uses what's going on by explicitly
disallowing this.