### PR TITLE
server: Include param regex in generated gorilla route if specified.

### DIFF
--- a/server/genserver.go
+++ b/server/genserver.go
@@ -163,7 +163,7 @@ func generateRouter(packageName string, s spec.Swagger, paths *spec.Paths) error
 
 			template.Functions = append(template.Functions, routerFunction{
 				Method:      method,
-				Path:        s.BasePath + path,
+				Path:        s.BasePath + gorillaPathFor(op, path),
 				HandlerName: swagger.Capitalize(op.ID),
 				OpID:        op.ID,
 			})
@@ -177,6 +177,18 @@ func generateRouter(packageName string, s spec.Swagger, paths *spec.Paths) error
 	g := swagger.Generator{PackageName: packageName}
 	g.Printf(routerCode)
 	return g.WriteFile("server/router.go")
+}
+
+func gorillaPathFor(op *spec.Operation, path string) string {
+	for _, param := range op.Parameters {
+		if param.In != "path" || param.Pattern == "" {
+			continue
+		}
+		plainName := fmt.Sprintf("{%s}", param.Name)
+		nameWithRegex := fmt.Sprintf("{%s:%s}", param.Name, param.Pattern)
+		path = strings.Replace(path, plainName, nameWithRegex, 1)
+	}
+	return path
 }
 
 type interfaceTemplate struct {


### PR DESCRIPTION
Useful in the case where you have conflicting routes in your configuration yml. E.g., 1. `/a/{x}/b` and 2. `/a/c/{y}`. Route sorting will put 2 before 1, but we can use a regex on the `y` parameter to ensure that the appropriate queries make it to 1.