### PR TITLE
Fix params with dashes

### DIFF
--- a/samples/gen-go-errors/server/handlers.go
+++ b/samples/gen-go-errors/server/handlers.go
@@ -148,13 +148,13 @@ func newGetBookInput(r *http.Request) (*models.GetBookInput, error) {
 	idStrs := []string{idStr}
 
 	if len(idStrs) > 0 {
-		var iDTmp int64
-		iDStr := idStrs[0]
-		iDTmp, err = swag.ConvertInt64(iDStr)
+		var idTmp int64
+		idStr := idStrs[0]
+		idTmp, err = swag.ConvertInt64(idStr)
 		if err != nil {
 			return nil, err
 		}
-		input.ID = iDTmp
+		input.ID = idTmp
 	}
 
 	return &input, nil

--- a/samples/gen-go-nils/server/handlers.go
+++ b/samples/gen-go-nils/server/handlers.go
@@ -142,13 +142,13 @@ func newNilCheckInput(r *http.Request) (*models.NilCheckInput, error) {
 	idStrs := []string{idStr}
 
 	if len(idStrs) > 0 {
-		var iDTmp string
-		iDStr := idStrs[0]
-		iDTmp, err = iDStr, error(nil)
+		var idTmp string
+		idStr := idStrs[0]
+		idTmp, err = idStr, error(nil)
 		if err != nil {
 			return nil, err
 		}
-		input.ID = iDTmp
+		input.ID = idTmp
 	}
 
 	queryStrs := r.URL.Query()["query"]

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -363,6 +363,8 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 
 	req.Header.Set("authorization", i.Authorization)
 
+	req.Header.Set("X-Dont-Rate-Limit-Me-Bro", i.XDontRateLimitMeBro)
+
 	// Add the opname for doers like tracing
 	ctx = context.WithValue(ctx, opNameCtx{}, "getBookByID")
 	req = req.WithContext(ctx)

--- a/samples/gen-go/models/inputs.go
+++ b/samples/gen-go/models/inputs.go
@@ -92,10 +92,11 @@ func (i GetBooksInput) Validate() error {
 
 // GetBookByIDInput holds the input parameters for a getBookByID operation.
 type GetBookByIDInput struct {
-	BookID        int64
-	AuthorID      *string
-	Authorization string
-	RandomBytes   *strfmt.Base64
+	BookID              int64
+	AuthorID            *string
+	Authorization       string
+	XDontRateLimitMeBro string
+	RandomBytes         *strfmt.Base64
 }
 
 // Validate returns an error if any of the GetBookByIDInput parameters don't satisfy the

--- a/samples/gen-go/server/handlers.go
+++ b/samples/gen-go/server/handlers.go
@@ -201,11 +201,11 @@ func newGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 		input.Published = &publishedTmp
 	}
 
-	snake_caseStrs := r.URL.Query()["snake_case"]
+	snakeCaseStrs := r.URL.Query()["snake_case"]
 
-	if len(snake_caseStrs) > 0 {
+	if len(snakeCaseStrs) > 0 {
 		var snakeCaseTmp string
-		snakeCaseStr := snake_caseStrs[0]
+		snakeCaseStr := snakeCaseStrs[0]
 		snakeCaseTmp, err = snakeCaseStr, error(nil)
 		if err != nil {
 			return nil, err
@@ -240,14 +240,14 @@ func newGetBooksInput(r *http.Request) (*models.GetBooksInput, error) {
 		input.MaxPages = &maxPagesTmp
 	}
 
-	min_pagesStrs := r.URL.Query()["min_pages"]
+	minPagesStrs := r.URL.Query()["min_pages"]
 
-	if len(min_pagesStrs) == 0 {
-		min_pagesStrs = []string{"5"}
+	if len(minPagesStrs) == 0 {
+		minPagesStrs = []string{"5"}
 	}
-	if len(min_pagesStrs) > 0 {
+	if len(minPagesStrs) > 0 {
 		var minPagesTmp int32
-		minPagesStr := min_pagesStrs[0]
+		minPagesStr := minPagesStrs[0]
 		minPagesTmp, err = swag.ConvertInt32(minPagesStr)
 		if err != nil {
 			return nil, err
@@ -459,15 +459,15 @@ func newGetBookByIDInput(r *http.Request) (*models.GetBookByIDInput, error) {
 	var err error
 	_ = err
 
-	book_idStr := mux.Vars(r)["book_id"]
-	if len(book_idStr) == 0 {
+	bookIDStr := mux.Vars(r)["book_id"]
+	if len(bookIDStr) == 0 {
 		return nil, errors.New("parameter must be specified")
 	}
-	book_idStrs := []string{book_idStr}
+	bookIDStrs := []string{bookIDStr}
 
-	if len(book_idStrs) > 0 {
+	if len(bookIDStrs) > 0 {
 		var bookIDTmp int64
-		bookIDStr := book_idStrs[0]
+		bookIDStr := bookIDStrs[0]
 		bookIDTmp, err = swag.ConvertInt64(bookIDStr)
 		if err != nil {
 			return nil, err
@@ -493,6 +493,14 @@ func newGetBookByIDInput(r *http.Request) (*models.GetBookByIDInput, error) {
 		var authorizationTmp string
 		authorizationTmp = authorizationStrs
 		input.Authorization = authorizationTmp
+	}
+
+	xDontRateLimitMeBroStrs := r.Header.Get("X-Dont-Rate-Limit-Me-Bro")
+
+	if len(xDontRateLimitMeBroStrs) > 0 {
+		var xDontRateLimitMeBroTmp string
+		xDontRateLimitMeBroTmp = xDontRateLimitMeBroStrs
+		input.XDontRateLimitMeBro = xDontRateLimitMeBroTmp
 	}
 
 	randomBytesStrs := r.URL.Query()["randomBytes"]

--- a/samples/gen-js/README.md
+++ b/samples/gen-js/README.md
@@ -112,6 +112,7 @@ Returns a book
 | params.bookID | <code>number</code> |  |
 | [params.authorID] | <code>string</code> |  |
 | [params.authorization] | <code>string</code> |  |
+| [params.XDontRateLimitMeBro] | <code>string</code> |  |
 | [params.randomBytes] | <code>string</code> |  |
 | [options] | <code>object</code> |  |
 | [options.timeout] | <code>number</code> | A request specific timeout |

--- a/samples/gen-js/index.js
+++ b/samples/gen-js/index.js
@@ -362,6 +362,7 @@ class SwaggerTest {
    * @param {number} params.bookID
    * @param {string} [params.authorID]
    * @param {string} [params.authorization]
+   * @param {string} [params.XDontRateLimitMeBro]
    * @param {string} [params.randomBytes]
    * @param {object} [options]
    * @param {number} [options.timeout] - A request specific timeout
@@ -410,6 +411,7 @@ class SwaggerTest {
         return
       }
       headers["authorization"] = params.authorization;
+      headers["X-Dont-Rate-Limit-Me-Bro"] = params.XDontRateLimitMeBro;
 
       const query = {};
       if (typeof params.authorID !== "undefined") {

--- a/samples/swagger.yml
+++ b/samples/swagger.yml
@@ -53,6 +53,9 @@ paths:
           minLength: 1
           maxLength: 24
           pattern: "[0-9a-f]+"
+        - name: X-Dont-Rate-Limit-Me-Bro
+          in: header
+          type: string
         - name: randomBytes
           in: query
           type: string


### PR DESCRIPTION
Dashes were included in variable names in the generated handler code for parameters that had dashes, which doesn't make syntastic sense.