### PR TITLE
Use kayveelogger for setlogger

### DIFF
--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -117,7 +117,7 @@ func (c *WagClient) SetCircuitBreakerDebug(b bool) {
 	c.circuitDoer.debug = b
 }
 
-// SetLogge  allows for setting a custom logger
+// SetLogger allows for setting a custom logger
 func (c *WagClient) SetLogger(logger logger.KayveeLogger) {
 	c.logger = logger
 	c.circuitDoer.logger = logger

--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -117,8 +117,8 @@ func (c *WagClient) SetCircuitBreakerDebug(b bool) {
 	c.circuitDoer.debug = b
 }
 
-// SetLogger allows for setting a custom logger
-func (c *WagClient) SetLogger(logger *logger.Logger) {
+// SetLogge  allows for setting a custom logger
+func (c *WagClient) SetLogger(logger logger.KayveeLogger) {
 	c.logger = logger
 	c.circuitDoer.logger = logger
 }

--- a/samples/gen-go-deprecated/client/client.go
+++ b/samples/gen-go-deprecated/client/client.go
@@ -83,8 +83,8 @@ func (c *WagClient) SetCircuitBreakerDebug(b bool) {
 	c.circuitDoer.debug = b
 }
 
-// SetLogger allows for setting a custom logger
-func (c *WagClient) SetLogger(logger *logger.Logger) {
+// SetLogge  allows for setting a custom logger
+func (c *WagClient) SetLogger(logger logger.KayveeLogger) {
 	c.logger = logger
 	c.circuitDoer.logger = logger
 }

--- a/samples/gen-go-deprecated/client/client.go
+++ b/samples/gen-go-deprecated/client/client.go
@@ -83,7 +83,7 @@ func (c *WagClient) SetCircuitBreakerDebug(b bool) {
 	c.circuitDoer.debug = b
 }
 
-// SetLogge  allows for setting a custom logger
+// SetLogger allows for setting a custom logger
 func (c *WagClient) SetLogger(logger logger.KayveeLogger) {
 	c.logger = logger
 	c.circuitDoer.logger = logger

--- a/samples/gen-go-errors/client/client.go
+++ b/samples/gen-go-errors/client/client.go
@@ -83,8 +83,8 @@ func (c *WagClient) SetCircuitBreakerDebug(b bool) {
 	c.circuitDoer.debug = b
 }
 
-// SetLogger allows for setting a custom logger
-func (c *WagClient) SetLogger(logger *logger.Logger) {
+// SetLogge  allows for setting a custom logger
+func (c *WagClient) SetLogger(logger logger.KayveeLogger) {
 	c.logger = logger
 	c.circuitDoer.logger = logger
 }

--- a/samples/gen-go-errors/client/client.go
+++ b/samples/gen-go-errors/client/client.go
@@ -83,7 +83,7 @@ func (c *WagClient) SetCircuitBreakerDebug(b bool) {
 	c.circuitDoer.debug = b
 }
 
-// SetLogge  allows for setting a custom logger
+// SetLogger allows for setting a custom logger
 func (c *WagClient) SetLogger(logger logger.KayveeLogger) {
 	c.logger = logger
 	c.circuitDoer.logger = logger

--- a/samples/gen-go-nils/client/client.go
+++ b/samples/gen-go-nils/client/client.go
@@ -83,8 +83,8 @@ func (c *WagClient) SetCircuitBreakerDebug(b bool) {
 	c.circuitDoer.debug = b
 }
 
-// SetLogger allows for setting a custom logger
-func (c *WagClient) SetLogger(logger *logger.Logger) {
+// SetLogge  allows for setting a custom logger
+func (c *WagClient) SetLogger(logger logger.KayveeLogger) {
 	c.logger = logger
 	c.circuitDoer.logger = logger
 }

--- a/samples/gen-go-nils/client/client.go
+++ b/samples/gen-go-nils/client/client.go
@@ -83,7 +83,7 @@ func (c *WagClient) SetCircuitBreakerDebug(b bool) {
 	c.circuitDoer.debug = b
 }
 
-// SetLogge  allows for setting a custom logger
+// SetLogger allows for setting a custom logger
 func (c *WagClient) SetLogger(logger logger.KayveeLogger) {
 	c.logger = logger
 	c.circuitDoer.logger = logger

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -83,8 +83,8 @@ func (c *WagClient) SetCircuitBreakerDebug(b bool) {
 	c.circuitDoer.debug = b
 }
 
-// SetLogger allows for setting a custom logger
-func (c *WagClient) SetLogger(logger *logger.Logger) {
+// SetLogge  allows for setting a custom logger
+func (c *WagClient) SetLogger(logger logger.KayveeLogger) {
 	c.logger = logger
 	c.circuitDoer.logger = logger
 }

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -83,7 +83,7 @@ func (c *WagClient) SetCircuitBreakerDebug(b bool) {
 	c.circuitDoer.debug = b
 }
 
-// SetLogge  allows for setting a custom logger
+// SetLogger allows for setting a custom logger
 func (c *WagClient) SetLogger(logger logger.KayveeLogger) {
 	c.logger = logger
 	c.circuitDoer.logger = logger

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/Clever/wag/samples/gen-go/client"
 	"github.com/Clever/wag/samples/gen-go/models"
 	"github.com/Clever/wag/samples/gen-go/server"
+	kayvee "gopkg.in/Clever/kayvee-go.v6/logger"
+
 	"github.com/afex/hystrix-go/hystrix"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -492,6 +494,9 @@ func TestIteratorHeaders(t *testing.T) {
 	testServer := httptest.NewServer(s.Handler)
 	defer testServer.Close()
 	c := client.New(testServer.URL)
+
+	t.Log("Ensure client.SetLogger works")
+	c.SetLogger(kayvee.New("test-custom-logger"))
 
 	book1ID := int64(1)
 	book1Name := "Test"


### PR DESCRIPTION
Clients generated with the latest version of wag does not support `SetLogger` properly since `kayvee.New()` now returns `kayvee.KayveeLogger` interface.

`client.SetLogger(*kayvee.Logger)` was using a struct as opposed to the interface `kayvee.KayveeLogger`. Fix and add test to ensure the right `version`/`interface` is being passed to the client.