### PR TITLE
doer: update hystrix event log title

### DIFF
--- a/_hardcoded/doer.go
+++ b/_hardcoded/doer.go
@@ -212,7 +212,9 @@ type HystrixSSEEvent struct {
 }
 
 func logEvent(l logger.KayveeLogger, e HystrixSSEEvent) {
-	l.InfoD(e.Name, map[string]interface{}{
+	l.InfoD("hystrix-sse-event", map[string]interface{}{
+		"type":                            e.Type,
+		"name":                            e.Name,
 		"requestCount":                    e.RequestCount,
 		"errorCount":                      e.ErrorCount,
 		"errorPercentage":                 e.ErrorPercentage,


### PR DESCRIPTION
we want log titles to have simple, constant values, so they can easily
be matched and routed.

I've also added name and type to the metadata, so we can choose to route
those to backends like SignalFX, as needed.