### PR TITLE
add circuit breaking to JS client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ $(GOPATH)/src/github.com/golang/mock:
 $(MOCKGEN): $(GOPATH)/src/github.com/golang/mock
 	go build -o $(GOPATH)/bin/mockgen github.com/golang/mock/mockgen
 
-
 build: hardcoded/hardcoded.go
 	go build -o bin/wag
 

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -188,8 +188,7 @@ const defaultCircuitOptions = {
   requestVolumeThreshold: 20,
   sleepWindow:            5000,
   errorPercentThreshold:  90,
-  logIntervalMs:          30000,
-  logger: () => { /* TODO remove this and use kayvee logger from mohit's PR */ },
+  logIntervalMs:          30000
 };
 
 /**
@@ -270,7 +269,7 @@ class {{.ClassName}} {
       context(this).
       build();
 
-    setInterval(() => this._logCircuitState(circuitOptions.logger), circuitOptions.logIntervalMs);
+    setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
   }
 
   _hystrixCommandErrorHandler(err) {
@@ -290,7 +289,7 @@ class {{.ClassName}} {
     const metrics = this._hystrixCommand.metrics;
     const healthCounts = metrics.getHealthCounts()
     const circuitBreaker = this._hystrixCommand.circuitBreaker;
-    logger({
+    this.logger.infoD("{{.ServiceName}}", {
       "requestCount":                    healthCounts.totalCount,
       "errorCount":                      healthCounts.errorCount,
       "errorPercentage":                 healthCounts.errorPercentage,

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -182,7 +182,7 @@ function responseLog(logger, req, res, err) {
  * @alias module:{{.ServiceName}}.DefaultCircuitOptions
  */
 const defaultCircuitOptions = {
-  debug:                  true,
+  forceClosed:            true,
   requestVolumeThreshold: 20,
   maxConcurrentRequests:  100,
   requestVolumeThreshold: 20,
@@ -217,7 +217,7 @@ class {{.ClassName}} {
    * @param {module:kayvee.Logger} [options.logger=logger.New("{{.ServiceName}}-wagclient")] - The Kayvee 
    * logger to use in the client.
    * @param {Object} [options.circuit] - Options for constructing the client's circuit breaker.
-   * @param {bool} [options.circuit.debug] - When set to true will not circuit break. Default: true.
+   * @param {bool} [options.circuit.forceClosed] - When set to true the circuit will always be closed. Default: true.
    * @param {number} [options.circuit.maxConcurrentRequests] - the maximum number of concurrent requests
    * the client can make at the same time. Default: 100.
    * @param {number} [options.circuit.requestVolumeThreshold] - The minimum number of requests needed
@@ -257,7 +257,7 @@ class {{.ClassName}} {
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
     this._hystrixCommand = commandFactory.getOrCreate("{{.ServiceName}}").
       errorHandler(this._hystrixCommandErrorHandler).
-      circuitBreakerForceClosed(circuitOptions.debug).
+      circuitBreakerForceClosed(circuitOptions.forceClosed).
       requestVolumeRejectionThreshold(circuitOptions.maxConcurrentRequests).
       circuitBreakerRequestVolumeThreshold(circuitOptions.requestVolumeThreshold).
       circuitBreakerSleepWindowInMilliseconds(circuitOptions.sleepWindow).

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -87,6 +87,8 @@ const discovery = require("clever-discovery");
 const kayvee = require("kayvee");
 const request = require("request");
 const opentracing = require("opentracing");
+const {commandFactory} = require("hystrixjs");
+const RollingNumberEvent = require("hystrixjs/lib/metrics/RollingNumberEvent");
 
 /**
  * @external Span
@@ -176,6 +178,21 @@ function responseLog(logger, req, res, err) {
 }
 
 /**
+ * Default circuit breaker options.
+ * @alias module:{{.ServiceName}}.DefaultCircuitOptions
+ */
+const defaultCircuitOptions = {
+  debug:                  true,
+  requestVolumeThreshold: 20,
+  maxConcurrentRequests:  100,
+  requestVolumeThreshold: 20,
+  sleepWindow:            5000,
+  errorPercentThreshold:  90,
+  logIntervalMs:          30000,
+  logger: () => { /* TODO remove this and use kayvee logger from mohit's PR */ },
+};
+
+/**
  * {{.ServiceName}} client library.
  * @module {{.ServiceName}}
  * @typicalname {{.ClassName}}
@@ -200,6 +217,17 @@ class {{.ClassName}} {
    * determine which requests to retry, as well as how many times to retry.
    * @param {module:kayvee.Logger} [options.logger=logger.New("{{.ServiceName}}-wagclient")] - The Kayvee 
    * logger to use in the client.
+   * @param {Object} [options.circuit] - Options for constructing the client's circuit breaker.
+   * @param {bool} [options.circuit.debug] - When set to true will not circuit break. Default: true.
+   * @param {number} [options.circuit.maxConcurrentRequests] - the maximum number of concurrent requests
+   * the client can make at the same time. Default: 100.
+   * @param {number} [options.circuit.requestVolumeThreshold] - The minimum number of requests needed
+   * before a circuit can be tripped due to health. Default: 20.
+   * @param {number} [options.circuit.sleepWindow] - how long, in milliseconds, to wait after a circuit opens
+   * before testing for recovery. Default: 5000.
+   * @param {number} [options.circuit.errorPercentThreshold] - the threshold to place on the rolling error
+   * rate. Once the error rate exceeds this percentage, the circuit opens.
+   * Default: 90.
    */
   constructor(options) {
     options = options || {};
@@ -226,6 +254,45 @@ class {{.ClassName}} {
     } else {
       this.logger =  new kayvee.logger("{{.ServiceName}}-wagclient");
     }
+
+    const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
+    this._hystrixCommand = commandFactory.getOrCreate("{{.ServiceName}}").
+      circuitBreakerForceClosed(circuitOptions.debug).
+      requestVolumeRejectionThreshold(circuitOptions.maxConcurrentRequests).
+      circuitBreakerRequestVolumeThreshold(circuitOptions.requestVolumeThreshold).
+      circuitBreakerSleepWindowInMilliseconds(circuitOptions.sleepWindow).
+      circuitBreakerErrorThresholdPercentage(circuitOptions.errorPercentThreshold).
+      timeout(0).
+      statisticalWindowLength(10000).
+      statisticalWindowNumberOfBuckets(10).
+      run(this._hystrixCommandRun).
+      context(this).
+      build();
+
+    setInterval(() => this._logCircuitState(circuitOptions.logger), circuitOptions.logIntervalMs);
+  }
+
+  _hystrixCommandRun(method, args) {
+    return method.apply(this, args);
+  }
+
+  _logCircuitState(logger) {
+    // code below heavily borrows from hystrix's internal HystrixSSEStream.js logic
+    const metrics = this._hystrixCommand.metrics;
+    const healthCounts = metrics.getHealthCounts()
+    const circuitBreaker = this._hystrixCommand.circuitBreaker;
+    logger({
+      "requestCount":                    healthCounts.totalCount,
+      "errorCount":                      healthCounts.errorCount,
+      "errorPercentage":                 healthCounts.errorPercentage,
+      "isCircuitBreakerOpen":            circuitBreaker.isOpen(),
+      "rollingCountFailure":             metrics.getRollingCount(RollingNumberEvent.FAILURE),
+      "rollingCountShortCircuited":      metrics.getRollingCount(RollingNumberEvent.SHORT_CIRCUITED),
+      "rollingCountSuccess":             metrics.getRollingCount(RollingNumberEvent.SUCCESS),
+      "rollingCountTimeout":             metrics.getRollingCount(RollingNumberEvent.TIMEOUT),
+      "currentConcurrentExecutionCount": metrics.getCurrentExecutionCount(),
+      "latencyTotalMean":                metrics.getExecutionTime("mean") || 0,
+    });
   }
 {{range $methodCode := .Methods}}{{$methodCode}}{{end}}};
 
@@ -246,6 +313,8 @@ module.exports.RetryPolicies = {
  * @alias module:{{.ServiceName}}.Errors
  */
 module.exports.Errors = Errors;
+
+module.exports.DefaultCircuitOptions = defaultCircuitOptions;
 `
 
 var packageJSONTmplStr = `{
@@ -258,7 +327,9 @@ var packageJSONTmplStr = `{
     "clever-discovery": "0.0.8",
     "opentracing": "^0.11.1",
     "request": "^2.75.0",
-	"kayvee": "^3.8.2"
+    "kayvee": "^3.8.2",
+    "hystrixjs": "^0.2.0",
+    "rxjs": "^5.4.1"
   }
 }
 `
@@ -439,9 +510,9 @@ var methodTmplStr = `
     {{- if .IterMethod}}
 
     return {
-      map: (f, cb) => it(f, true, cb),
-      toArray: cb => it(x => x, true, cb),
-      forEach: (f, cb) => it(f, false, cb),
+      map: (f, cb) => this._hystrixCommand.execute(it, [f, true, cb]),
+      toArray: cb => this._hystrixCommand.execute(it, [x => x, true, cb]),
+      forEach: (f, cb) => this._hystrixCommand.execute(it, [f, false, cb]),
     };
     {{- end}}
   }
@@ -466,7 +537,14 @@ var singleParamMethodDefinitionTemplateString = `/**{{if .Description}}
    * @reject {module:{{$ServiceName}}.Errors.{{$response.Name}}}{{end}}{{end}}
    * @reject {Error}{{end}}
    */
-  {{.MethodName}}({{range $param := .Params}}{{$param.JSName}}, {{end}}options{{if not .IterMethod}}, cb{{end}}) {
+  {{- if .IterMethod}}
+  {{.MethodName}}({{range $param := .Params}}{{$param.JSName}}, {{end}}options) {
+  {{- else}}
+  {{.MethodName}}({{range $param := .Params}}{{$param.JSName}}, {{end}}options, cb) {
+    return this._hystrixCommand.execute(this._{{.MethodName}}, arguments);
+  }
+  _{{.MethodName}}({{range $param := .Params}}{{$param.JSName}}, {{end}}options, cb) {
+  {{- end}}
     const params = {};{{range $param := .Params}}
     params["{{$param.JSName}}"] = {{$param.JSName}};{{end}}
 `
@@ -491,7 +569,14 @@ var pluralParamMethodDefinitionTemplateString = `/**{{if .Description}}
    * @reject {module:{{$ServiceName}}.Errors.{{$response.Name}}}{{end}}{{end}}
    * @reject {Error}{{end}}
    */
-  {{.MethodName}}(params, options{{if not .IterMethod}}, cb{{end}}) {`
+  {{- if .IterMethod}}
+  {{.MethodName}}(params, options) {
+  {{- else}}
+  {{.MethodName}}(params, options, cb) {
+    return this._hystrixCommand.execute(this._{{.MethodName}}, arguments);
+  }
+  _{{.MethodName}}(params, options, cb) {
+  {{- end}}`
 
 type paramMapping struct {
 	JSName      string

--- a/samples/gen-js-deprecated/README.md
+++ b/samples/gen-js-deprecated/README.md
@@ -33,6 +33,7 @@ swagger-test client library.
             * [.BadRequest](#module_swagger-test--SwaggerTest.Errors.BadRequest) ⇐ <code>Error</code>
             * [.NotFound](#module_swagger-test--SwaggerTest.Errors.NotFound) ⇐ <code>Error</code>
             * [.InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError) ⇐ <code>Error</code>
+        * [.DefaultCircuitOptions](#module_swagger-test--SwaggerTest.DefaultCircuitOptions)
 
 <a name="exp_module_swagger-test--SwaggerTest"></a>
 
@@ -54,6 +55,12 @@ Create a new client object.
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 | [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;swagger-test-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
+| [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |
+| [options.circuit.forceClosed] | <code>bool</code> |  | When set to true the circuit will always be closed. Default: true. |
+| [options.circuit.maxConcurrentRequests] | <code>number</code> |  | the maximum number of concurrent requests the client can make at the same time. Default: 100. |
+| [options.circuit.requestVolumeThreshold] | <code>number</code> |  | The minimum number of requests needed before a circuit can be tripped due to health. Default: 20. |
+| [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
+| [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
 
 <a name="module_swagger-test--SwaggerTest.RetryPolicies"></a>
 
@@ -136,6 +143,12 @@ InternalError
 | --- | --- |
 | message | <code>string</code> | 
 
+<a name="module_swagger-test--SwaggerTest.DefaultCircuitOptions"></a>
+
+#### SwaggerTest.DefaultCircuitOptions
+Default circuit breaker options.
+
+**Kind**: static constant of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
 <a name="responseLog"></a>
 
 ## responseLog()

--- a/samples/gen-js-deprecated/index.js
+++ b/samples/gen-js-deprecated/index.js
@@ -3,6 +3,8 @@ const discovery = require("clever-discovery");
 const kayvee = require("kayvee");
 const request = require("request");
 const opentracing = require("opentracing");
+const {commandFactory} = require("hystrixjs");
+const RollingNumberEvent = require("hystrixjs/lib/metrics/RollingNumberEvent");
 
 /**
  * @external Span
@@ -92,6 +94,20 @@ function responseLog(logger, req, res, err) {
 }
 
 /**
+ * Default circuit breaker options.
+ * @alias module:swagger-test.DefaultCircuitOptions
+ */
+const defaultCircuitOptions = {
+  forceClosed:            true,
+  requestVolumeThreshold: 20,
+  maxConcurrentRequests:  100,
+  requestVolumeThreshold: 20,
+  sleepWindow:            5000,
+  errorPercentThreshold:  90,
+  logIntervalMs:          30000
+};
+
+/**
  * swagger-test client library.
  * @module swagger-test
  * @typicalname SwaggerTest
@@ -116,6 +132,17 @@ class SwaggerTest {
    * determine which requests to retry, as well as how many times to retry.
    * @param {module:kayvee.Logger} [options.logger=logger.New("swagger-test-wagclient")] - The Kayvee 
    * logger to use in the client.
+   * @param {Object} [options.circuit] - Options for constructing the client's circuit breaker.
+   * @param {bool} [options.circuit.forceClosed] - When set to true the circuit will always be closed. Default: true.
+   * @param {number} [options.circuit.maxConcurrentRequests] - the maximum number of concurrent requests
+   * the client can make at the same time. Default: 100.
+   * @param {number} [options.circuit.requestVolumeThreshold] - The minimum number of requests needed
+   * before a circuit can be tripped due to health. Default: 20.
+   * @param {number} [options.circuit.sleepWindow] - how long, in milliseconds, to wait after a circuit opens
+   * before testing for recovery. Default: 5000.
+   * @param {number} [options.circuit.errorPercentThreshold] - the threshold to place on the rolling error
+   * rate. Once the error rate exceeds this percentage, the circuit opens.
+   * Default: 90.
    */
   constructor(options) {
     options = options || {};
@@ -142,6 +169,54 @@ class SwaggerTest {
     } else {
       this.logger =  new kayvee.logger("swagger-test-wagclient");
     }
+
+    const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
+    this._hystrixCommand = commandFactory.getOrCreate("swagger-test").
+      errorHandler(this._hystrixCommandErrorHandler).
+      circuitBreakerForceClosed(circuitOptions.forceClosed).
+      requestVolumeRejectionThreshold(circuitOptions.maxConcurrentRequests).
+      circuitBreakerRequestVolumeThreshold(circuitOptions.requestVolumeThreshold).
+      circuitBreakerSleepWindowInMilliseconds(circuitOptions.sleepWindow).
+      circuitBreakerErrorThresholdPercentage(circuitOptions.errorPercentThreshold).
+      timeout(0).
+      statisticalWindowLength(10000).
+      statisticalWindowNumberOfBuckets(10).
+      run(this._hystrixCommandRun).
+      context(this).
+      build();
+
+    setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+  }
+
+  _hystrixCommandErrorHandler(err) {
+    // to avoid counting 4XXs as errors, only count an error if it comes from the request library
+    if (err._fromRequest === true) {
+      return err;
+    }
+    return false;
+  }
+
+  _hystrixCommandRun(method, args) {
+    return method.apply(this, args);
+  }
+
+  _logCircuitState(logger) {
+    // code below heavily borrows from hystrix's internal HystrixSSEStream.js logic
+    const metrics = this._hystrixCommand.metrics;
+    const healthCounts = metrics.getHealthCounts()
+    const circuitBreaker = this._hystrixCommand.circuitBreaker;
+    this.logger.infoD("swagger-test", {
+      "requestCount":                    healthCounts.totalCount,
+      "errorCount":                      healthCounts.errorCount,
+      "errorPercentage":                 healthCounts.errorPercentage,
+      "isCircuitBreakerOpen":            circuitBreaker.isOpen(),
+      "rollingCountFailure":             metrics.getRollingCount(RollingNumberEvent.FAILURE),
+      "rollingCountShortCircuited":      metrics.getRollingCount(RollingNumberEvent.SHORT_CIRCUITED),
+      "rollingCountSuccess":             metrics.getRollingCount(RollingNumberEvent.SUCCESS),
+      "rollingCountTimeout":             metrics.getRollingCount(RollingNumberEvent.TIMEOUT),
+      "currentConcurrentExecutionCount": metrics.getCurrentExecutionCount(),
+      "latencyTotalMean":                metrics.getExecutionTime("mean") || 0,
+    });
   }
 };
 
@@ -162,3 +237,5 @@ module.exports.RetryPolicies = {
  * @alias module:swagger-test.Errors
  */
 module.exports.Errors = Errors;
+
+module.exports.DefaultCircuitOptions = defaultCircuitOptions;

--- a/samples/gen-js-deprecated/package.json
+++ b/samples/gen-js-deprecated/package.json
@@ -8,6 +8,8 @@
     "clever-discovery": "0.0.8",
     "opentracing": "^0.11.1",
     "request": "^2.75.0",
-	"kayvee": "^3.8.2"
+    "kayvee": "^3.8.2",
+    "hystrixjs": "^0.2.0",
+    "rxjs": "^5.4.1"
   }
 }

--- a/samples/gen-js-errors/README.md
+++ b/samples/gen-js-errors/README.md
@@ -36,6 +36,7 @@ swagger-test client library.
                 * [.ExtendedError](#module_swagger-test--SwaggerTest.Errors.ExtendedError) ⇐ <code>Error</code>
                 * [.NotFound](#module_swagger-test--SwaggerTest.Errors.NotFound) ⇐ <code>Error</code>
                 * [.InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError) ⇐ <code>Error</code>
+            * [.DefaultCircuitOptions](#module_swagger-test--SwaggerTest.DefaultCircuitOptions)
 
 <a name="exp_module_swagger-test--SwaggerTest"></a>
 
@@ -57,6 +58,12 @@ Create a new client object.
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 | [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;swagger-test-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
+| [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |
+| [options.circuit.forceClosed] | <code>bool</code> |  | When set to true the circuit will always be closed. Default: true. |
+| [options.circuit.maxConcurrentRequests] | <code>number</code> |  | the maximum number of concurrent requests the client can make at the same time. Default: 100. |
+| [options.circuit.requestVolumeThreshold] | <code>number</code> |  | The minimum number of requests needed before a circuit can be tripped due to health. Default: 20. |
+| [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
+| [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
 
 <a name="module_swagger-test--SwaggerTest+getBook"></a>
 
@@ -160,6 +167,12 @@ InternalError
 | code | <code>number</code> | 
 | message | <code>string</code> | 
 
+<a name="module_swagger-test--SwaggerTest.DefaultCircuitOptions"></a>
+
+#### SwaggerTest.DefaultCircuitOptions
+Default circuit breaker options.
+
+**Kind**: static constant of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
 <a name="responseLog"></a>
 
 ## responseLog()

--- a/samples/gen-js-errors/package.json
+++ b/samples/gen-js-errors/package.json
@@ -8,6 +8,8 @@
     "clever-discovery": "0.0.8",
     "opentracing": "^0.11.1",
     "request": "^2.75.0",
-	"kayvee": "^3.8.2"
+    "kayvee": "^3.8.2",
+    "hystrixjs": "^0.2.0",
+    "rxjs": "^5.4.1"
   }
 }

--- a/samples/gen-js-nils/README.md
+++ b/samples/gen-js-nils/README.md
@@ -35,6 +35,7 @@ nil-test client library.
             * [.Errors](#module_nil-test--NilTest.Errors)
                 * [.BadRequest](#module_nil-test--NilTest.Errors.BadRequest) ⇐ <code>Error</code>
                 * [.InternalError](#module_nil-test--NilTest.Errors.InternalError) ⇐ <code>Error</code>
+            * [.DefaultCircuitOptions](#module_nil-test--NilTest.DefaultCircuitOptions)
 
 <a name="exp_module_nil-test--NilTest"></a>
 
@@ -56,6 +57,12 @@ Create a new client object.
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_nil-test--NilTest.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 | [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;nil-test-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
+| [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |
+| [options.circuit.forceClosed] | <code>bool</code> |  | When set to true the circuit will always be closed. Default: true. |
+| [options.circuit.maxConcurrentRequests] | <code>number</code> |  | the maximum number of concurrent requests the client can make at the same time. Default: 100. |
+| [options.circuit.requestVolumeThreshold] | <code>number</code> |  | The minimum number of requests needed before a circuit can be tripped due to health. Default: 20. |
+| [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
+| [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
 
 <a name="module_nil-test--NilTest+nilCheck"></a>
 
@@ -149,6 +156,12 @@ InternalError
 | --- | --- |
 | message | <code>string</code> | 
 
+<a name="module_nil-test--NilTest.DefaultCircuitOptions"></a>
+
+#### NilTest.DefaultCircuitOptions
+Default circuit breaker options.
+
+**Kind**: static constant of <code>[NilTest](#exp_module_nil-test--NilTest)</code>  
 <a name="responseLog"></a>
 
 ## responseLog()

--- a/samples/gen-js-nils/index.js
+++ b/samples/gen-js-nils/index.js
@@ -3,6 +3,8 @@ const discovery = require("clever-discovery");
 const kayvee = require("kayvee");
 const request = require("request");
 const opentracing = require("opentracing");
+const {commandFactory} = require("hystrixjs");
+const RollingNumberEvent = require("hystrixjs/lib/metrics/RollingNumberEvent");
 
 /**
  * @external Span
@@ -92,6 +94,20 @@ function responseLog(logger, req, res, err) {
 }
 
 /**
+ * Default circuit breaker options.
+ * @alias module:nil-test.DefaultCircuitOptions
+ */
+const defaultCircuitOptions = {
+  forceClosed:            true,
+  requestVolumeThreshold: 20,
+  maxConcurrentRequests:  100,
+  requestVolumeThreshold: 20,
+  sleepWindow:            5000,
+  errorPercentThreshold:  90,
+  logIntervalMs:          30000
+};
+
+/**
  * nil-test client library.
  * @module nil-test
  * @typicalname NilTest
@@ -116,6 +132,17 @@ class NilTest {
    * determine which requests to retry, as well as how many times to retry.
    * @param {module:kayvee.Logger} [options.logger=logger.New("nil-test-wagclient")] - The Kayvee 
    * logger to use in the client.
+   * @param {Object} [options.circuit] - Options for constructing the client's circuit breaker.
+   * @param {bool} [options.circuit.forceClosed] - When set to true the circuit will always be closed. Default: true.
+   * @param {number} [options.circuit.maxConcurrentRequests] - the maximum number of concurrent requests
+   * the client can make at the same time. Default: 100.
+   * @param {number} [options.circuit.requestVolumeThreshold] - The minimum number of requests needed
+   * before a circuit can be tripped due to health. Default: 20.
+   * @param {number} [options.circuit.sleepWindow] - how long, in milliseconds, to wait after a circuit opens
+   * before testing for recovery. Default: 5000.
+   * @param {number} [options.circuit.errorPercentThreshold] - the threshold to place on the rolling error
+   * rate. Once the error rate exceeds this percentage, the circuit opens.
+   * Default: 90.
    */
   constructor(options) {
     options = options || {};
@@ -142,6 +169,54 @@ class NilTest {
     } else {
       this.logger =  new kayvee.logger("nil-test-wagclient");
     }
+
+    const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
+    this._hystrixCommand = commandFactory.getOrCreate("nil-test").
+      errorHandler(this._hystrixCommandErrorHandler).
+      circuitBreakerForceClosed(circuitOptions.forceClosed).
+      requestVolumeRejectionThreshold(circuitOptions.maxConcurrentRequests).
+      circuitBreakerRequestVolumeThreshold(circuitOptions.requestVolumeThreshold).
+      circuitBreakerSleepWindowInMilliseconds(circuitOptions.sleepWindow).
+      circuitBreakerErrorThresholdPercentage(circuitOptions.errorPercentThreshold).
+      timeout(0).
+      statisticalWindowLength(10000).
+      statisticalWindowNumberOfBuckets(10).
+      run(this._hystrixCommandRun).
+      context(this).
+      build();
+
+    setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+  }
+
+  _hystrixCommandErrorHandler(err) {
+    // to avoid counting 4XXs as errors, only count an error if it comes from the request library
+    if (err._fromRequest === true) {
+      return err;
+    }
+    return false;
+  }
+
+  _hystrixCommandRun(method, args) {
+    return method.apply(this, args);
+  }
+
+  _logCircuitState(logger) {
+    // code below heavily borrows from hystrix's internal HystrixSSEStream.js logic
+    const metrics = this._hystrixCommand.metrics;
+    const healthCounts = metrics.getHealthCounts()
+    const circuitBreaker = this._hystrixCommand.circuitBreaker;
+    this.logger.infoD("nil-test", {
+      "requestCount":                    healthCounts.totalCount,
+      "errorCount":                      healthCounts.errorCount,
+      "errorPercentage":                 healthCounts.errorPercentage,
+      "isCircuitBreakerOpen":            circuitBreaker.isOpen(),
+      "rollingCountFailure":             metrics.getRollingCount(RollingNumberEvent.FAILURE),
+      "rollingCountShortCircuited":      metrics.getRollingCount(RollingNumberEvent.SHORT_CIRCUITED),
+      "rollingCountSuccess":             metrics.getRollingCount(RollingNumberEvent.SUCCESS),
+      "rollingCountTimeout":             metrics.getRollingCount(RollingNumberEvent.TIMEOUT),
+      "currentConcurrentExecutionCount": metrics.getCurrentExecutionCount(),
+      "latencyTotalMean":                metrics.getExecutionTime("mean") || 0,
+    });
   }
 
   /**
@@ -164,6 +239,9 @@ class NilTest {
    * @reject {Error}
    */
   nilCheck(params, options, cb) {
+    return this._hystrixCommand.execute(this._nilCheck, arguments);
+  }
+  _nilCheck(params, options, cb) {
     if (!cb && typeof options === "function") {
       cb = options;
       options = undefined;
@@ -241,6 +319,7 @@ class NilTest {
             return;
           }
           if (err) {
+            err._fromRequest = true;
             responseLog(logger, requestOptions, response, err)
             rejecter(err);
             return;
@@ -292,3 +371,5 @@ module.exports.RetryPolicies = {
  * @alias module:nil-test.Errors
  */
 module.exports.Errors = Errors;
+
+module.exports.DefaultCircuitOptions = defaultCircuitOptions;

--- a/samples/gen-js-nils/package.json
+++ b/samples/gen-js-nils/package.json
@@ -8,6 +8,8 @@
     "clever-discovery": "0.0.8",
     "opentracing": "^0.11.1",
     "request": "^2.75.0",
-	"kayvee": "^3.8.2"
+    "kayvee": "^3.8.2",
+    "hystrixjs": "^0.2.0",
+    "rxjs": "^5.4.1"
   }
 }

--- a/samples/gen-js/README.md
+++ b/samples/gen-js/README.md
@@ -47,6 +47,7 @@ swagger-test client library.
                 * [.InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError) ⇐ <code>Error</code>
                 * [.Unathorized](#module_swagger-test--SwaggerTest.Errors.Unathorized) ⇐ <code>Error</code>
                 * [.Error](#module_swagger-test--SwaggerTest.Errors.Error) ⇐ <code>Error</code>
+            * [.DefaultCircuitOptions](#module_swagger-test--SwaggerTest.DefaultCircuitOptions)
 
 <a name="exp_module_swagger-test--SwaggerTest"></a>
 
@@ -68,6 +69,12 @@ Create a new client object.
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 | [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;swagger-test-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
+| [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |
+| [options.circuit.forceClosed] | <code>bool</code> |  | When set to true the circuit will always be closed. Default: true. |
+| [options.circuit.maxConcurrentRequests] | <code>number</code> |  | the maximum number of concurrent requests the client can make at the same time. Default: 100. |
+| [options.circuit.requestVolumeThreshold] | <code>number</code> |  | The minimum number of requests needed before a circuit can be tripped due to health. Default: 20. |
+| [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
+| [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
 
 <a name="module_swagger-test--SwaggerTest+getAuthors"></a>
 
@@ -410,6 +417,12 @@ Error
 | code | <code>number</code> | 
 | message | <code>string</code> | 
 
+<a name="module_swagger-test--SwaggerTest.DefaultCircuitOptions"></a>
+
+#### SwaggerTest.DefaultCircuitOptions
+Default circuit breaker options.
+
+**Kind**: static constant of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
 <a name="responseLog"></a>
 
 ## responseLog()

--- a/samples/gen-js/package.json
+++ b/samples/gen-js/package.json
@@ -8,6 +8,8 @@
     "clever-discovery": "0.0.8",
     "opentracing": "^0.11.1",
     "request": "^2.75.0",
-	"kayvee": "^3.8.2"
+    "kayvee": "^3.8.2",
+    "hystrixjs": "^0.2.0",
+    "rxjs": "^5.4.1"
   }
 }

--- a/test/js/circuit_breaker.ts
+++ b/test/js/circuit_breaker.ts
@@ -108,17 +108,20 @@ describe("circuit", function() {
     let loggerCalls = 0;
     const c = new Client({
       address: mockAddress,
-      circuit: {
-        debug: true,
-        requestVolumeThreshold: 20,
-        logIntervalMs: 1000,
-        logger: (data) => {
+      logger: {
+        errorD: (title, data) => {},
+        infoD: (title, data) => {
           loggerCalls++;
           if (loggerCalls == 1) {
             assert.equal(data.errorCount, 20, "expected log to show 20 errors");
             assert.equal(data.errorPercentage, 100, "expected error percent to be 100");
           }
         },
+      },
+      circuit: {
+        debug: true,
+        requestVolumeThreshold: 20,
+        logIntervalMs: 1000,
       },
     });
     for (let i = 0; i < 20; i++) {
@@ -142,17 +145,20 @@ describe("circuit", function() {
     const c = new Client({
       address: mockAddress,
       retryPolicy: RetryPolicies.None,
-      circuit: {
-        debug: true,
-        requestVolumeThreshold: 20,
-        logIntervalMs: 1000,
-        logger: (data) => {
+      logger: {
+        errorD: (title, data) => {},
+        infoD: (title, data) => {
           loggerCalls++;
           if (loggerCalls == 1) {
             assert.equal(data.errorCount, 0, "expected log to show 0 errors");
             assert.equal(data.errorPercentage, 0, "expected error percent to be 0");
           }
         },
+      },
+      circuit: {
+        debug: true,
+        requestVolumeThreshold: 20,
+        logIntervalMs: 1000,
       },
     });
     for (let i = 0; i < 20; i++) {

--- a/test/js/circuit_breaker.ts
+++ b/test/js/circuit_breaker.ts
@@ -24,7 +24,7 @@ describe("circuit", function() {
     const c = new Client({
       address: mockAddress,
       circuit: {
-        debug: false,
+        forceClosed: false,
         requestVolumeThreshold: 20,
         sleepWindow: 500,
       },
@@ -82,11 +82,11 @@ describe("circuit", function() {
     }
   });
 
-  it("doesn't do anything if debug is set to true", async () => {
+  it("doesn't do anything if forceClosed is set to true", async () => {
     const c = new Client({
       address: mockAddress,
       circuit: {
-        debug: true,
+        forceClosed: true,
         requestVolumeThreshold: 20
       },
     });
@@ -119,7 +119,7 @@ describe("circuit", function() {
         },
       },
       circuit: {
-        debug: true,
+        forceClosed: true,
         requestVolumeThreshold: 20,
         logIntervalMs: 1000,
       },
@@ -156,7 +156,7 @@ describe("circuit", function() {
         },
       },
       circuit: {
-        debug: true,
+        forceClosed: true,
         requestVolumeThreshold: 20,
         logIntervalMs: 1000,
       },

--- a/test/js/circuit_breaker.ts
+++ b/test/js/circuit_breaker.ts
@@ -1,0 +1,139 @@
+const assert = require("assert");
+const nock = require("nock");
+
+const Client = require("swagger-test");
+
+const mockAddress = "http://localhost:8000";
+
+const {commandFactory,metricsFactory,circuitFactory} = require("hystrixjs");
+
+async function sleep(ms) { return new Promise((resolve) => {
+  setTimeout(resolve, ms);
+});};
+
+describe("circuit", function() {
+  beforeEach(() => {
+    metricsFactory.resetCache();
+    circuitFactory.resetCache();
+    commandFactory.resetCache();
+    nock.cleanAll();
+  });
+  
+  it("opens when the number of failures exceeds requestVolumeThreshold, and closes if sees success after sleep window", async () => {
+    const c = new Client({
+      address: mockAddress,
+      circuit: {
+        debug: false,
+        requestVolumeThreshold: 20,
+        sleepWindow: 500,
+      },
+    });
+
+    // trip the circuit
+    for (let i = 0; i < 20; i++) {
+      const scope = nock(mockAddress).
+        get("/v1/authors").
+        replyWithError('something awful happened');
+      try {
+        const resp = await c.getAuthors({});
+      } catch (err) {
+        assert.equal(err.message, "something awful happened");
+      }
+      assert(scope.isDone(), "nock scope should be done");
+    }
+
+    // see circuit open
+    let scope = nock(mockAddress).
+      get("/v1/authors").
+      replyWithError('something awful happened');
+    try {
+      const resp = await c.getAuthors({});
+      throw new Error("got resp, should have gotten circuit open error");
+    } catch (err) {
+      assert.equal(err.message, "OpenCircuitError");
+      assert.equal(scope.isDone(), false, "nock should not have gotten hit");
+    }
+    nock.cleanAll();
+
+    // circuit should let something through after the sleep window
+    await sleep(750);
+    scope = nock(mockAddress).
+      get("/v1/authors").
+      reply(200);
+    try {
+      const resp = await c.getAuthors({});
+    } catch (err) {
+      assert.fail(`Circuit should have let a test request through, instead got error: ${err}`);
+    }
+    assert.equal(scope.isDone(), true, "nock should have gotten hit");
+
+    // circuit should now be closed and letting requests through
+    for (let i = 0; i < 20; i++) {
+      const scope = nock(mockAddress).
+        get("/v1/authors").
+        reply(200);
+      try {
+        const resp = await c.getAuthors({});
+      } catch (err) {
+        assert.fail(`Circuit should be closed and letting requests through, but instead we got error: ${err}`);
+      }
+      assert(scope.isDone(), "nock scope should be done");
+    }
+  });
+
+  it("doesn't do anything if debug is set to true", async () => {
+    const c = new Client({
+      address: mockAddress,
+      circuit: {
+        debug: true,
+        requestVolumeThreshold: 20
+      },
+    });
+    for (let i = 0; i < 40; i++) {
+      const scope = nock(mockAddress).
+        get("/v1/authors").
+        replyWithError('something awful happened');
+      try {
+        const resp = await c.getAuthors({});
+        throw new Error("got resp, should have gotten error");
+      } catch (err) {
+        assert.equal(err.message, "something awful happened");
+      }
+      assert(scope.isDone(), "nock scope should be done");
+    }
+  });
+
+  it("logs state of the circuit", async () => {
+    let loggerCalls = 0;
+    const c = new Client({
+      address: mockAddress,
+      circuit: {
+        debug: true,
+        requestVolumeThreshold: 20,
+        logIntervalMs: 1000,
+        logger: (data) => {
+          loggerCalls++;
+          if (loggerCalls == 1) {
+            assert.equal(data.errorCount, 20, "expected log to show 20 errors");
+            assert.equal(data.errorPercentage, 100, "expected error percent to be 100");
+          }
+        },
+      },
+    });
+    for (let i = 0; i < 20; i++) {
+      const scope = nock(mockAddress).
+        get("/v1/authors").
+        replyWithError('something awful happened');
+      try {
+        const resp = await c.getAuthors({});
+        throw new Error("got resp, should have gotten error");
+      } catch (err) {
+        assert.equal(err.message, "something awful happened");
+      }
+      assert(scope.isDone(), "nock scope should be done");
+    }
+    await sleep(1500);
+    assert.equal(loggerCalls, 1);
+  });
+});
+

--- a/test/js/package.json
+++ b/test/js/package.json
@@ -8,6 +8,7 @@
   "devDependencies": {
     "@types/mocha": "^2.2.39",
     "@types/node": "^7.0.5",
+    "hystrixjs": "^0.2.0",
     "mocha": "^3.1.2",
     "nock": "^9.0.2",
     "ts-node": "^3.1.0",

--- a/test/js/retries.js
+++ b/test/js/retries.js
@@ -5,9 +5,18 @@ const util = require("util");
 const Client = require("swagger-test");
 const {RetryPolicies} = Client;
 
+const {commandFactory,metricsFactory,circuitFactory} = require("hystrixjs");
+
 const mockAddress = "http://localhost:8000";
 
 describe("retries", function() {
+  beforeEach(() => {
+    metricsFactory.resetCache();
+    circuitFactory.resetCache();
+    commandFactory.resetCache();
+    nock.cleanAll();
+  });
+
   it("performs exponential retries when set backoff by default", function(done) {
     const client = new Client({
       address: mockAddress,


### PR DESCRIPTION
We have circuit breaking in the Go client, but not in the JS client. This PR adds circuit breaking to the js client.

I tried to make this as similar as possible to how the go client does it:
- It exposes the same settings (w/ same defaults) as the Go client circuit breaker
- It periodically logs circuit state

