### PR TITLE
Add stricter check and clearer error for peer dependency missing

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,9 +46,21 @@ func main() {
 		log.Fatal("js-path is required")
 	}
 
-	if glideYMLFile, err := os.Open("glide.yaml"); err == nil {
-		if err := validation.ValidateGlideYML(glideYMLFile); err != nil {
-			log.Fatal(err)
+	// Check if glide.yaml and glide.lock files are up to date
+	// Ignore validation if the files don't yet exist
+	glideYAMLFile, err := os.Open("glide.yaml")
+	if err == nil {
+		defer glideYAMLFile.Close()
+		if err = validation.ValidateGlideYAML(glideYAMLFile); err != nil {
+			log.Fatal(err.Error())
+		}
+	}
+
+	glideLockFile, err := os.Open("glide.lock")
+	if err == nil {
+		defer glideLockFile.Close()
+		if err = validation.ValidateGlideLock(glideLockFile); err != nil {
+			log.Fatal(err.Error())
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func main() {
 	if err == nil {
 		defer glideYAMLFile.Close()
 		if err = validation.ValidateGlideYAML(glideYAMLFile); err != nil {
-			log.Fatal(err.Error())
+			log.Fatal(err)
 		}
 	}
 
@@ -60,7 +60,7 @@ func main() {
 	if err == nil {
 		defer glideLockFile.Close()
 		if err = validation.ValidateGlideLock(glideLockFile); err != nil {
-			log.Fatal(err.Error())
+			log.Fatal(err)
 		}
 	}
 

--- a/validation/glide.go
+++ b/validation/glide.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 )
@@ -16,6 +17,17 @@ type GlideYML struct {
 // Import contained within a glide.yml.
 type Import struct {
 	Package string `yaml:"package"`
+	Version string `yaml:"version"`
+}
+
+// GlideLock unmarshals the parts of a glide.lock file we care about.
+type GlideLock struct {
+	Imports []LockedVersion `yaml:"imports"`
+}
+
+// LockedVersion contained within a glide.lock.
+type LockedVersion struct {
+	Name    string `yaml:"name"`
 	Version string `yaml:"version"`
 }
 
@@ -43,13 +55,13 @@ var requirements = []Import{
 	},
 }
 
-// ValidateGlideYML looks at a user's glide.yml and makes sure certain dependencies
+// ValidateGlideYAML looks at a user's glide.yml and makes sure certain dependencies
 // that wag requires are present and locked to the correct version.
-func ValidateGlideYML(glideYMLFile io.Reader) error {
+func ValidateGlideYAML(glideYMLFile io.Reader) error {
 	var glideYML GlideYML
 	bs, err := ioutil.ReadAll(glideYMLFile)
 	if err != nil {
-		return fmt.Errorf("error reading glide.yml: %s", err)
+		return fmt.Errorf("error reading glide.yaml: %s", err)
 	}
 	if err = yaml.Unmarshal(bs, &glideYML); err != nil {
 		return fmt.Errorf("error unmarshalling yaml: %s", err)
@@ -62,7 +74,46 @@ func ValidateGlideYML(glideYMLFile io.Reader) error {
 	}
 
 	return nil
+}
 
+// ValidateGlideLock looks at a user's glide.yml and makes sure certain dependencies
+// that wag requires are present and locked to the correct version.
+func ValidateGlideLock(glideLockFile io.Reader) error {
+	var glideLock GlideLock
+	bs, err := ioutil.ReadAll(glideLockFile)
+	if err != nil {
+		return fmt.Errorf("error reading glide.lock: %s", err)
+	}
+	if err = yaml.Unmarshal(bs, &glideLock); err != nil {
+		return fmt.Errorf("error unmarshalling yaml in glide.lock: %s", err)
+	}
+
+	for _, req := range requirements {
+		if err := validateLockedVersion(glideLock.Imports, req); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// PeerDependencyError occurs when glide.yml and/or glide.lock dont have the
+// required dependency versions for wag
+type PeerDependencyError struct {
+	Package string
+	Version string
+	File    string
+}
+
+func (e *PeerDependencyError) Error() string {
+	return fmt.Sprintf("Error: wag peer dependency not met. \n"+
+		"Version %s of %s must be set in glide.yaml and glide.lock.\n"+
+		"Please ensure your glide.yaml file includes\n\n"+
+		"```\n"+
+		"- package: %s\n"+
+		"  version: %s\n"+
+		"```\n\n"+
+		"then run `glide up`.", e.Version, e.Package, e.Package, e.Version)
 }
 
 func validateImports(imports []Import, requiredImport Import) error {
@@ -72,5 +123,17 @@ func validateImports(imports []Import, requiredImport Import) error {
 			return nil
 		}
 	}
-	return fmt.Errorf("wag requires version %s of %s. Please update your glide.yml and run `glide up`", requiredImport.Version, requiredImport.Package)
+	return &PeerDependencyError{Package: requiredImport.Package, Version: requiredImport.Version, File: "glide.yaml"}
+}
+
+func validateLockedVersion(versions []LockedVersion, requiredImport Import) error {
+	for _, v := range versions {
+		// If we've specified locking to a semantic version like "^1.0.0", we can't easily determine
+		// if the locked version satisfies that. We accept any version as long as the package is present.
+		if (v.Name == requiredImport.Package && strings.HasPrefix(requiredImport.Version, "^")) ||
+			(v.Name == requiredImport.Package && v.Version == requiredImport.Version) {
+			return nil
+		}
+	}
+	return &PeerDependencyError{Package: requiredImport.Package, Version: requiredImport.Version, File: "glide.lock"}
 }

--- a/validation/glide_test.go
+++ b/validation/glide_test.go
@@ -1,22 +1,22 @@
 package validation
 
 import (
-	"errors"
-	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-type GlideYMLTest struct {
-	YML   string
+type GlideTest struct {
+	Title string
+	Input string
 	Error error
 }
 
-var glideYMLTests = []GlideYMLTest{
+var glideYAMLTests = []GlideTest{
 	{
-		YML: `import:
+		Title: "Success glide.yaml is up to date",
+		Input: `import:
 - package: github.com/lightstep/lightstep-tracer-go
   version: 0d48cd619841b1e1a3cdd20cd6ac97774c0002ce
 - package: github.com/opentracing/opentracing-go
@@ -31,7 +31,8 @@ var glideYMLTests = []GlideYMLTest{
 		Error: nil,
 	},
 	{
-		YML: `import:
+		Title: "Error if glide.yaml out of date for one or more deps (lightstep-tracer-go)",
+		Input: `import:
 - package: github.com/lightstep/lightstep-tracer-go
   version: incorrect
 - package: github.com/opentracing/opentracing-go
@@ -40,26 +41,122 @@ var glideYMLTests = []GlideYMLTest{
   version: 1b32af207119a14b1b231d451df3ed04a72efebf
 - package: github.com/gorilla/mux
   version: 757bef944d0f21880861c2dd9c871ca543023cba
+- name: github.com/golang/mock
+  version: 13f360950a79f5864a972c786a10a50e44b69541
 `,
-		Error: errors.New("wag requires version 0d48cd619841b1e1a3cdd20cd6ac97774c0002ce of github.com/lightstep/lightstep-tracer-go. Please update your glide.yml and run `glide up`"),
+		Error: &PeerDependencyError{Package: "github.com/lightstep/lightstep-tracer-go", Version: "0d48cd619841b1e1a3cdd20cd6ac97774c0002ce", File: "glide.yaml"},
 	},
 	{
-		YML: `import:
+		Title: "Error if an item is missing altogether from glide.yaml (opentracing-go)",
+		Input: `import:
 - package: github.com/lightstep/lightstep-tracer-go
   version: 0d48cd619841b1e1a3cdd20cd6ac97774c0002ce
 - package: github.com/opentracing/basictracer-go
   version: 1b32af207119a14b1b231d451df3ed04a72efebf
 - package: github.com/gorilla/mux
   version: 757bef944d0f21880861c2dd9c871ca543023cba
+- package: github.com/golang/mock
+  version: 13f360950a79f5864a972c786a10a50e44b69541
 `,
-		Error: errors.New("wag requires version ^1.0.0 of github.com/opentracing/opentracing-go. Please update your glide.yml and run `glide up`"),
+		Error: &PeerDependencyError{Package: "github.com/opentracing/opentracing-go", Version: "^1.0.0", File: "glide.yaml"},
 	},
 }
 
-func TestGlideYML(t *testing.T) {
-	for _, test := range glideYMLTests {
-		err := ValidateGlideYML(strings.NewReader(test.YML))
-		assert.Equal(t, err, test.Error,
-			fmt.Sprintf("incorrect error returned from input:\n%s", test.YML))
+var glideLockTests = []GlideTest{
+	{
+		Title: "Success if glide.lock is fully up to date",
+		Input: `hash: fakehashfakehash2ab3a7fc19967467d0350d521f2efc13979838813aabe77b
+updated: 2017-10-18T18:42:39.792248183Z
+imports:
+- name: github.com/lightstep/lightstep-tracer-go
+  version: 0d48cd619841b1e1a3cdd20cd6ac97774c0002ce
+- name: github.com/opentracing/opentracing-go
+  version: ^1.0.0
+- name: github.com/opentracing/basictracer-go
+  version: 1b32af207119a14b1b231d451df3ed04a72efebf
+- name: github.com/gorilla/mux
+  version: 757bef944d0f21880861c2dd9c871ca543023cba
+- name: github.com/golang/mock
+  version: 13f360950a79f5864a972c786a10a50e44b69541
+`,
+		Error: nil,
+	},
+	{
+		Title: "glide.lock up-to-date does not exact match semver versions, since it can't easily determine if semver == commit hash",
+		Input: `hash: fakehashfakehash2ab3a7fc19967467d0350d521f2efc13979838813aabe77b
+updated: 2017-10-18T18:42:39.792248183Z
+imports:
+- name: github.com/lightstep/lightstep-tracer-go
+  version: 0d48cd619841b1e1a3cdd20cd6ac97774c0002ce
+- name: github.com/opentracing/opentracing-go
+  version: some-unknown-version
+- name: github.com/opentracing/basictracer-go
+  version: 1b32af207119a14b1b231d451df3ed04a72efebf
+- name: github.com/gorilla/mux
+  version: 757bef944d0f21880861c2dd9c871ca543023cba
+- name: github.com/golang/mock
+  version: 13f360950a79f5864a972c786a10a50e44b69541
+`,
+		Error: nil,
+	},
+	{
+		Title: "Error if glide.lock out of date for one or more deps (lightstep-tracer-go)",
+		Input: `hash: fakehashfakehash2ab3a7fc19967467d0350d521f2efc13979838813aabe77b
+updated: 2017-10-18T18:42:39.792248183Z
+imports:
+- name: github.com/lightstep/lightstep-tracer-go
+  version: incorrect
+- name: github.com/opentracing/opentracing-go
+  version: ^1.0.0
+- name: github.com/opentracing/basictracer-go
+  version: 1b32af207119a14b1b231d451df3ed04a72efebf
+- name: github.com/gorilla/mux
+  version: 757bef944d0f21880861c2dd9c871ca543023cba
+- name: github.com/golang/mock
+  version: 13f360950a79f5864a972c786a10a50e44b69541
+`,
+		Error: &PeerDependencyError{Package: "github.com/lightstep/lightstep-tracer-go", Version: "0d48cd619841b1e1a3cdd20cd6ac97774c0002ce", File: "glide.lock"},
+	},
+	{
+		Title: "Error if an item is missing altogether from glide.lock (opentracing-go)",
+		Input: `hash: fakehashfakehash2ab3a7fc19967467d0350d521f2efc13979838813aabe77b
+updated: 2017-10-18T18:42:39.792248183Z
+imports:
+- name: github.com/lightstep/lightstep-tracer-go
+  version: 0d48cd619841b1e1a3cdd20cd6ac97774c0002ce
+- name: github.com/opentracing/basictracer-go
+  version: 1b32af207119a14b1b231d451df3ed04a72efebf
+- name: github.com/gorilla/mux
+  version: 757bef944d0f21880861c2dd9c871ca543023cba
+- name: github.com/golang/mock
+  version: 13f360950a79f5864a972c786a10a50e44b69541
+`,
+		Error: &PeerDependencyError{Package: "github.com/opentracing/opentracing-go", Version: "^1.0.0", File: "glide.lock"},
+	},
+}
+
+func TestValidateglideYAML(t *testing.T) {
+	for _, test := range glideYAMLTests {
+		t.Log(test.Title)
+		err := ValidateGlideYAML(strings.NewReader(test.Input))
+		if test.Error != nil {
+			assert.Error(t, err)
+			assert.Equal(t, test.Error, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}
+
+func TestValidateGlideLock(t *testing.T) {
+	for _, test := range glideLockTests {
+		t.Log(test.Title)
+		err := ValidateGlideLock(strings.NewReader(test.Input))
+		if test.Error != nil {
+			assert.Error(t, err)
+			assert.Equal(t, test.Error, err)
+		} else {
+			assert.NoError(t, err)
+		}
 	}
 }

--- a/validation/glide_test.go
+++ b/validation/glide_test.go
@@ -41,10 +41,14 @@ var glideYAMLTests = []GlideTest{
   version: 1b32af207119a14b1b231d451df3ed04a72efebf
 - package: github.com/gorilla/mux
   version: 757bef944d0f21880861c2dd9c871ca543023cba
-- name: github.com/golang/mock
+- package: github.com/golang/mock
   version: 13f360950a79f5864a972c786a10a50e44b69541
 `,
-		Error: &PeerDependencyError{Package: "github.com/lightstep/lightstep-tracer-go", Version: "0d48cd619841b1e1a3cdd20cd6ac97774c0002ce", File: "glide.yaml"},
+		Error: &ListOfPeerDependencyError{
+			Errors: []*PeerDependencyError{
+				&PeerDependencyError{Package: "github.com/lightstep/lightstep-tracer-go", Version: "0d48cd619841b1e1a3cdd20cd6ac97774c0002ce", File: "glide.yaml"},
+			},
+		},
 	},
 	{
 		Title: "Error if an item is missing altogether from glide.yaml (opentracing-go)",
@@ -58,7 +62,11 @@ var glideYAMLTests = []GlideTest{
 - package: github.com/golang/mock
   version: 13f360950a79f5864a972c786a10a50e44b69541
 `,
-		Error: &PeerDependencyError{Package: "github.com/opentracing/opentracing-go", Version: "^1.0.0", File: "glide.yaml"},
+		Error: &ListOfPeerDependencyError{
+			Errors: []*PeerDependencyError{
+				&PeerDependencyError{Package: "github.com/opentracing/opentracing-go", Version: "^1.0.0", File: "glide.yaml"},
+			},
+		},
 	},
 }
 
@@ -115,7 +123,11 @@ imports:
 - name: github.com/golang/mock
   version: 13f360950a79f5864a972c786a10a50e44b69541
 `,
-		Error: &PeerDependencyError{Package: "github.com/lightstep/lightstep-tracer-go", Version: "0d48cd619841b1e1a3cdd20cd6ac97774c0002ce", File: "glide.lock"},
+		Error: &ListOfPeerDependencyError{
+			Errors: []*PeerDependencyError{
+				&PeerDependencyError{Package: "github.com/lightstep/lightstep-tracer-go", Version: "0d48cd619841b1e1a3cdd20cd6ac97774c0002ce", File: "glide.lock"},
+			},
+		},
 	},
 	{
 		Title: "Error if an item is missing altogether from glide.lock (opentracing-go)",
@@ -131,20 +143,25 @@ imports:
 - name: github.com/golang/mock
   version: 13f360950a79f5864a972c786a10a50e44b69541
 `,
-		Error: &PeerDependencyError{Package: "github.com/opentracing/opentracing-go", Version: "^1.0.0", File: "glide.lock"},
+		Error: &ListOfPeerDependencyError{
+			Errors: []*PeerDependencyError{
+				&PeerDependencyError{Package: "github.com/opentracing/opentracing-go", Version: "^1.0.0", File: "glide.lock"},
+			},
+		},
 	},
 }
 
-func TestValidateglideYAML(t *testing.T) {
+func TestValidateGlideYAML(t *testing.T) {
 	for _, test := range glideYAMLTests {
-		t.Log(test.Title)
-		err := ValidateGlideYAML(strings.NewReader(test.Input))
-		if test.Error != nil {
-			assert.Error(t, err)
-			assert.Equal(t, test.Error, err)
-		} else {
-			assert.NoError(t, err)
-		}
+		t.Run(test.Title, func(t *testing.T) {
+			err := ValidateGlideYAML(strings.NewReader(test.Input))
+			if test.Error != nil {
+				assert.Error(t, err)
+				assert.Equal(t, test.Error, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRA-2622

Now checks if both glide.yaml and glide.lock are valid.
Also adds more detailed error message.

**Before:**

![image](https://user-images.githubusercontent.com/102242/32070262-aa6e194e-ba40-11e7-9cb4-607d34cd2c10.png)

**After:**

![image](https://user-images.githubusercontent.com/102242/32070182-61efc014-ba40-11e7-86cb-304c32437690.png)

Does not yet roll up all errors at once.
