### PR TITLE
When creating New go client, trim trailing `/` in basePath

### DIFF
--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -71,6 +71,7 @@ var _ Client = (*WagClient)(nil)
 
 // New creates a new client. The base path and http transport are configurable.
 func New(basePath string) *WagClient {
+	basePath = strings.TrimSuffix(basePath, "/")
 	base := baseDoer{}
 	tracing := tracingDoer{d: base}
 	// For the short-term don't use the default retry policy since its 5 retries can 5X

--- a/samples/gen-go-deprecated/client/client.go
+++ b/samples/gen-go-deprecated/client/client.go
@@ -40,6 +40,7 @@ var _ Client = (*WagClient)(nil)
 
 // New creates a new client. The base path and http transport are configurable.
 func New(basePath string) *WagClient {
+	basePath = strings.TrimSuffix(basePath, "/")
 	base := baseDoer{}
 	tracing := tracingDoer{d: base}
 	// For the short-term don't use the default retry policy since its 5 retries can 5X

--- a/samples/gen-go-errors/client/client.go
+++ b/samples/gen-go-errors/client/client.go
@@ -40,6 +40,7 @@ var _ Client = (*WagClient)(nil)
 
 // New creates a new client. The base path and http transport are configurable.
 func New(basePath string) *WagClient {
+	basePath = strings.TrimSuffix(basePath, "/")
 	base := baseDoer{}
 	tracing := tracingDoer{d: base}
 	// For the short-term don't use the default retry policy since its 5 retries can 5X

--- a/samples/gen-go-nils/client/client.go
+++ b/samples/gen-go-nils/client/client.go
@@ -40,6 +40,7 @@ var _ Client = (*WagClient)(nil)
 
 // New creates a new client. The base path and http transport are configurable.
 func New(basePath string) *WagClient {
+	basePath = strings.TrimSuffix(basePath, "/")
 	base := baseDoer{}
 	tracing := tracingDoer{d: base}
 	// For the short-term don't use the default retry policy since its 5 retries can 5X

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -40,6 +40,7 @@ var _ Client = (*WagClient)(nil)
 
 // New creates a new client. The base path and http transport are configurable.
 func New(basePath string) *WagClient {
+	basePath = strings.TrimSuffix(basePath, "/")
 	base := baseDoer{}
 	tracing := tracingDoer{d: base}
 	// For the short-term don't use the default retry policy since its 5 retries can 5X


### PR DESCRIPTION
This fixes issues with ALBs, which don't treat `//` equivalently to `/`

https://golang.org/pkg/strings/#TrimSuffix