### PR TITLE
Change default timeouts

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,3 @@
-v1.5.5
-- Log more frequently to match metrics rolling window
+v1.6.0
+- Added default 5 second timeout for Node
+- Reduce default timeout for Go from 10 to 5 seconds

--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -89,7 +89,7 @@ func New(basePath string) *WagClient {
 		requestDoer: circuit,
 		retryDoer: &retry,
 		circuitDoer: circuit,
-		defaultTimeout: 10 * time.Second,
+		defaultTimeout: 5 * time.Second,
  		transport: &http.Transport{}, 
 		basePath: basePath,
 		logger: logger,

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -211,7 +211,7 @@ class {{.ClassName}} {
    * @param {bool} [options.discovery] - Use clever-discovery to locate the server. Must provide
    * this or the address argument
    * @param {number} [options.timeout] - The timeout to use for all client requests,
-   * in milliseconds. This can be overridden on a per-request basis.
+   * in milliseconds. This can be overridden on a per-request basis. Default is 5000ms.
    * @param {module:{{.ServiceName}}.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
    * @param {module:kayvee.Logger} [options.logger=logger.New("{{.ServiceName}}-wagclient")] - The Kayvee 
@@ -244,6 +244,8 @@ class {{.ClassName}} {
     }
     if (options.timeout) {
       this.timeout = options.timeout;
+    } else {
+      this.timeout = 5000;
     }
     if (options.retryPolicy) {
       this.retryPolicy = options.retryPolicy;

--- a/samples/gen-go-deprecated/client/client.go
+++ b/samples/gen-go-deprecated/client/client.go
@@ -58,7 +58,7 @@ func New(basePath string) *WagClient {
 		requestDoer:    circuit,
 		retryDoer:      &retry,
 		circuitDoer:    circuit,
-		defaultTimeout: 10 * time.Second,
+		defaultTimeout: 5 * time.Second,
 		transport:      &http.Transport{},
 		basePath:       basePath,
 		logger:         logger,

--- a/samples/gen-go-errors/client/client.go
+++ b/samples/gen-go-errors/client/client.go
@@ -58,7 +58,7 @@ func New(basePath string) *WagClient {
 		requestDoer:    circuit,
 		retryDoer:      &retry,
 		circuitDoer:    circuit,
-		defaultTimeout: 10 * time.Second,
+		defaultTimeout: 5 * time.Second,
 		transport:      &http.Transport{},
 		basePath:       basePath,
 		logger:         logger,

--- a/samples/gen-go-nils/client/client.go
+++ b/samples/gen-go-nils/client/client.go
@@ -58,7 +58,7 @@ func New(basePath string) *WagClient {
 		requestDoer:    circuit,
 		retryDoer:      &retry,
 		circuitDoer:    circuit,
-		defaultTimeout: 10 * time.Second,
+		defaultTimeout: 5 * time.Second,
 		transport:      &http.Transport{},
 		basePath:       basePath,
 		logger:         logger,

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -58,7 +58,7 @@ func New(basePath string) *WagClient {
 		requestDoer:    circuit,
 		retryDoer:      &retry,
 		circuitDoer:    circuit,
-		defaultTimeout: 10 * time.Second,
+		defaultTimeout: 5 * time.Second,
 		transport:      &http.Transport{},
 		basePath:       basePath,
 		logger:         logger,

--- a/samples/gen-js-deprecated/README.md
+++ b/samples/gen-js-deprecated/README.md
@@ -52,7 +52,7 @@ Create a new client object.
 | options | <code>Object</code> |  | Options for constructing a client object. |
 | [options.address] | <code>string</code> |  | URL where the server is located. Must provide this or the discovery argument |
 | [options.discovery] | <code>bool</code> |  | Use clever-discovery to locate the server. Must provide this or the address argument |
-| [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. |
+| [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. Default is 5000ms. |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 | [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;swagger-test-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
 | [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |

--- a/samples/gen-js-deprecated/index.js
+++ b/samples/gen-js-deprecated/index.js
@@ -127,7 +127,7 @@ class SwaggerTest {
    * @param {bool} [options.discovery] - Use clever-discovery to locate the server. Must provide
    * this or the address argument
    * @param {number} [options.timeout] - The timeout to use for all client requests,
-   * in milliseconds. This can be overridden on a per-request basis.
+   * in milliseconds. This can be overridden on a per-request basis. Default is 5000ms.
    * @param {module:swagger-test.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
    * @param {module:kayvee.Logger} [options.logger=logger.New("swagger-test-wagclient")] - The Kayvee 
@@ -160,6 +160,8 @@ class SwaggerTest {
     }
     if (options.timeout) {
       this.timeout = options.timeout;
+    } else {
+      this.timeout = 5000;
     }
     if (options.retryPolicy) {
       this.retryPolicy = options.retryPolicy;

--- a/samples/gen-js-errors/README.md
+++ b/samples/gen-js-errors/README.md
@@ -55,7 +55,7 @@ Create a new client object.
 | options | <code>Object</code> |  | Options for constructing a client object. |
 | [options.address] | <code>string</code> |  | URL where the server is located. Must provide this or the discovery argument |
 | [options.discovery] | <code>bool</code> |  | Use clever-discovery to locate the server. Must provide this or the address argument |
-| [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. |
+| [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. Default is 5000ms. |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 | [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;swagger-test-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
 | [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |

--- a/samples/gen-js-errors/index.js
+++ b/samples/gen-js-errors/index.js
@@ -127,7 +127,7 @@ class SwaggerTest {
    * @param {bool} [options.discovery] - Use clever-discovery to locate the server. Must provide
    * this or the address argument
    * @param {number} [options.timeout] - The timeout to use for all client requests,
-   * in milliseconds. This can be overridden on a per-request basis.
+   * in milliseconds. This can be overridden on a per-request basis. Default is 5000ms.
    * @param {module:swagger-test.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
    * @param {module:kayvee.Logger} [options.logger=logger.New("swagger-test-wagclient")] - The Kayvee 
@@ -160,6 +160,8 @@ class SwaggerTest {
     }
     if (options.timeout) {
       this.timeout = options.timeout;
+    } else {
+      this.timeout = 5000;
     }
     if (options.retryPolicy) {
       this.retryPolicy = options.retryPolicy;

--- a/samples/gen-js-nils/README.md
+++ b/samples/gen-js-nils/README.md
@@ -54,7 +54,7 @@ Create a new client object.
 | options | <code>Object</code> |  | Options for constructing a client object. |
 | [options.address] | <code>string</code> |  | URL where the server is located. Must provide this or the discovery argument |
 | [options.discovery] | <code>bool</code> |  | Use clever-discovery to locate the server. Must provide this or the address argument |
-| [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. |
+| [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. Default is 5000ms. |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_nil-test--NilTest.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 | [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;nil-test-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
 | [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |

--- a/samples/gen-js-nils/index.js
+++ b/samples/gen-js-nils/index.js
@@ -127,7 +127,7 @@ class NilTest {
    * @param {bool} [options.discovery] - Use clever-discovery to locate the server. Must provide
    * this or the address argument
    * @param {number} [options.timeout] - The timeout to use for all client requests,
-   * in milliseconds. This can be overridden on a per-request basis.
+   * in milliseconds. This can be overridden on a per-request basis. Default is 5000ms.
    * @param {module:nil-test.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
    * @param {module:kayvee.Logger} [options.logger=logger.New("nil-test-wagclient")] - The Kayvee 
@@ -160,6 +160,8 @@ class NilTest {
     }
     if (options.timeout) {
       this.timeout = options.timeout;
+    } else {
+      this.timeout = 5000;
     }
     if (options.retryPolicy) {
       this.retryPolicy = options.retryPolicy;

--- a/samples/gen-js/README.md
+++ b/samples/gen-js/README.md
@@ -66,7 +66,7 @@ Create a new client object.
 | options | <code>Object</code> |  | Options for constructing a client object. |
 | [options.address] | <code>string</code> |  | URL where the server is located. Must provide this or the discovery argument |
 | [options.discovery] | <code>bool</code> |  | Use clever-discovery to locate the server. Must provide this or the address argument |
-| [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. |
+| [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. Default is 5000ms. |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 | [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;swagger-test-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
 | [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |

--- a/samples/gen-js/index.js
+++ b/samples/gen-js/index.js
@@ -127,7 +127,7 @@ class SwaggerTest {
    * @param {bool} [options.discovery] - Use clever-discovery to locate the server. Must provide
    * this or the address argument
    * @param {number} [options.timeout] - The timeout to use for all client requests,
-   * in milliseconds. This can be overridden on a per-request basis.
+   * in milliseconds. This can be overridden on a per-request basis. Default is 5000ms.
    * @param {module:swagger-test.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
    * @param {module:kayvee.Logger} [options.logger=logger.New("swagger-test-wagclient")] - The Kayvee 
@@ -160,6 +160,8 @@ class SwaggerTest {
     }
     if (options.timeout) {
       this.timeout = options.timeout;
+    } else {
+      this.timeout = 5000;
     }
     if (options.retryPolicy) {
       this.retryPolicy = options.retryPolicy;


### PR DESCRIPTION
Part of this is followup for a few of the recent ALB flares. It seems like our default timeout for Node requests should be 5 seconds, and I think we should try decreasing the Go timeout to 5 seconds too.

This isn't a full solution for Go. Since we reuse the context with the timeout across retries so the retries will fail immediately (I believe - haven't verified). Will follow up with a PR to address that.