### PR TITLE
validation: Clarity around response type validation.

### DIFF
--- a/swagger/types.go
+++ b/swagger/types.go
@@ -28,13 +28,13 @@ func TypeFromSchema(schema *spec.Schema, includeModels bool) (string, error) {
 	} else {
 		schemaType := schema.Type
 		if len(schemaType) != 1 || schemaType[0] != "array" {
-			return "", fmt.Errorf("Cannot define complex data types inline. They must be defined in" +
-				"the #/definitions section of the swagger yaml")
+			return "", fmt.Errorf("Cannot define complex data types inline. They must be defined in " +
+				"the #/definitions section of the swagger yaml.")
 		}
 		items := schema.Items
-		if items == nil || items.Schema == nil {
-			return "", fmt.Errorf("Cannot define complex data types inline. They must be defined in" +
-				"the #/definitions section of the swagger yaml")
+		if items == nil || items.Schema == nil || items.Schema.Ref.String() == "" {
+			return "", fmt.Errorf("Cannot define complex data types inline. They must be defined in " +
+				"the #/definitions section of the swagger yaml.")
 		}
 		def, err := defFromRef(items.Schema.Ref.String())
 		if err != nil {

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -78,7 +78,7 @@ func validateResponses(path, method string, op *spec.Operation) error {
 
 		_, err := swagger.TypeFromSchema(response.Schema, false)
 		if err != nil {
-			return err
+			return fmt.Errorf("responses.%d for %s %s: %s", statusCode, method, path, err.Error())
 		}
 	}
 	return nil


### PR DESCRIPTION
Previously, swagger ymls with operations like:

```yml
/strings:
  get:
    operationId: getStrings
    responses:
      200:
        description: Some strings
        schema:
          type: array
          items:
            type: string
```

would return an error stating: `schema.$ref has undefined reference type "". Must start with #/definitions or #/responses.`.

Now, it returns the clearer error: `responses.200 for GET /strings: Cannot define complex data types inline. They must be defined in the #/definitions section of the swagger yaml.`