### PR TITLE
allow setting transport

### DIFF
--- a/samples/gen-go-blog/client/client.go
+++ b/samples/gen-go-blog/client/client.go
@@ -26,7 +26,7 @@ var _ = bytes.Compare
 type WagClient struct {
 	basePath    string
 	requestDoer doer
-	transport   *http.Transport
+	transport   http.RoundTripper
 	timeout     time.Duration
 	// Keep the retry doer around so that we can set the number of retries
 	retryDoer *retryDoer
@@ -140,6 +140,11 @@ func (c *WagClient) SetCircuitBreakerSettings(settings CircuitBreakerSettings) {
 // with a timeout use context.WithTimeout as described here: https://godoc.org/golang.org/x/net/context#WithTimeout.
 func (c *WagClient) SetTimeout(timeout time.Duration) {
 	c.defaultTimeout = timeout
+}
+
+// SetTransport sets the http transport used by the client.
+func (c *WagClient) SetTransport(t http.RoundTripper) {
+	c.transport = t
 }
 
 // GetSectionsForStudent makes a GET request to /students/{student_id}/sections

--- a/samples/gen-go-db/client/client.go
+++ b/samples/gen-go-db/client/client.go
@@ -26,7 +26,7 @@ var _ = bytes.Compare
 type WagClient struct {
 	basePath    string
 	requestDoer doer
-	transport   *http.Transport
+	transport   http.RoundTripper
 	timeout     time.Duration
 	// Keep the retry doer around so that we can set the number of retries
 	retryDoer *retryDoer
@@ -140,6 +140,11 @@ func (c *WagClient) SetCircuitBreakerSettings(settings CircuitBreakerSettings) {
 // with a timeout use context.WithTimeout as described here: https://godoc.org/golang.org/x/net/context#WithTimeout.
 func (c *WagClient) SetTimeout(timeout time.Duration) {
 	c.defaultTimeout = timeout
+}
+
+// SetTransport sets the http transport used by the client.
+func (c *WagClient) SetTransport(t http.RoundTripper) {
+	c.transport = t
 }
 
 // HealthCheck makes a GET request to /health/check

--- a/samples/gen-go-deprecated/client/client.go
+++ b/samples/gen-go-deprecated/client/client.go
@@ -26,7 +26,7 @@ var _ = bytes.Compare
 type WagClient struct {
 	basePath    string
 	requestDoer doer
-	transport   *http.Transport
+	transport   http.RoundTripper
 	timeout     time.Duration
 	// Keep the retry doer around so that we can set the number of retries
 	retryDoer *retryDoer
@@ -140,6 +140,11 @@ func (c *WagClient) SetCircuitBreakerSettings(settings CircuitBreakerSettings) {
 // with a timeout use context.WithTimeout as described here: https://godoc.org/golang.org/x/net/context#WithTimeout.
 func (c *WagClient) SetTimeout(timeout time.Duration) {
 	c.defaultTimeout = timeout
+}
+
+// SetTransport sets the http transport used by the client.
+func (c *WagClient) SetTransport(t http.RoundTripper) {
+	c.transport = t
 }
 
 func shortHash(s string) string {

--- a/samples/gen-go-errors/client/client.go
+++ b/samples/gen-go-errors/client/client.go
@@ -26,7 +26,7 @@ var _ = bytes.Compare
 type WagClient struct {
 	basePath    string
 	requestDoer doer
-	transport   *http.Transport
+	transport   http.RoundTripper
 	timeout     time.Duration
 	// Keep the retry doer around so that we can set the number of retries
 	retryDoer *retryDoer
@@ -140,6 +140,11 @@ func (c *WagClient) SetCircuitBreakerSettings(settings CircuitBreakerSettings) {
 // with a timeout use context.WithTimeout as described here: https://godoc.org/golang.org/x/net/context#WithTimeout.
 func (c *WagClient) SetTimeout(timeout time.Duration) {
 	c.defaultTimeout = timeout
+}
+
+// SetTransport sets the http transport used by the client.
+func (c *WagClient) SetTransport(t http.RoundTripper) {
+	c.transport = t
 }
 
 // GetBook makes a GET request to /books/{id}

--- a/samples/gen-go-nils/client/client.go
+++ b/samples/gen-go-nils/client/client.go
@@ -26,7 +26,7 @@ var _ = bytes.Compare
 type WagClient struct {
 	basePath    string
 	requestDoer doer
-	transport   *http.Transport
+	transport   http.RoundTripper
 	timeout     time.Duration
 	// Keep the retry doer around so that we can set the number of retries
 	retryDoer *retryDoer
@@ -140,6 +140,11 @@ func (c *WagClient) SetCircuitBreakerSettings(settings CircuitBreakerSettings) {
 // with a timeout use context.WithTimeout as described here: https://godoc.org/golang.org/x/net/context#WithTimeout.
 func (c *WagClient) SetTimeout(timeout time.Duration) {
 	c.defaultTimeout = timeout
+}
+
+// SetTransport sets the http transport used by the client.
+func (c *WagClient) SetTransport(t http.RoundTripper) {
+	c.transport = t
 }
 
 // NilCheck makes a POST request to /check/{id}

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -26,7 +26,7 @@ var _ = bytes.Compare
 type WagClient struct {
 	basePath    string
 	requestDoer doer
-	transport   *http.Transport
+	transport   http.RoundTripper
 	timeout     time.Duration
 	// Keep the retry doer around so that we can set the number of retries
 	retryDoer *retryDoer
@@ -140,6 +140,11 @@ func (c *WagClient) SetCircuitBreakerSettings(settings CircuitBreakerSettings) {
 // with a timeout use context.WithTimeout as described here: https://godoc.org/golang.org/x/net/context#WithTimeout.
 func (c *WagClient) SetTimeout(timeout time.Duration) {
 	c.defaultTimeout = timeout
+}
+
+// SetTransport sets the http transport used by the client.
+func (c *WagClient) SetTransport(t http.RoundTripper) {
+	c.transport = t
 }
 
 // GetAuthors makes a GET request to /authors


### PR DESCRIPTION
For swagger APIs that are not of wag's creation, sometimes overriding this transport is necessary. E.g., when communicating with the MongoDB Atlas API we need to use Digest Authentication: https://github.com/Clever/custom-cf-resources/blob/master/cmd/atlas/main.go#L41-L50

This PR ports the patch to the wag client used in that code ^ https://github.com/Clever/custom-cf-resources/blob/master/cmd/atlas/wag-client.patch