### PR TITLE
allow optional keepAlive for node clients

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-v1.9.0
-- Allow setting http Transport
+v1.10.0
+- Allow setting keepalive in node clients

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -212,6 +212,8 @@ class {{.ClassName}} {
    * this or the address argument
    * @param {number} [options.timeout] - The timeout to use for all client requests,
    * in milliseconds. This can be overridden on a per-request basis. Default is 5000ms.
+   * @param {bool} [options.keepalive] - Set keepalive to true for client requests. This sets the
+   * forever: true attribute in request. Defaults to false
    * @param {module:{{.ServiceName}}.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
    * @param {module:kayvee.Logger} [options.logger=logger.New("{{.ServiceName}}-wagclient")] - The Kayvee 
@@ -241,6 +243,11 @@ class {{.ClassName}} {
       this.address = options.address;
     } else {
       throw new Error("Cannot initialize {{.ServiceName}} without discovery or address");
+    }
+    if (options.keepalive) {
+      this.keepalive = options.keepalive
+    } else {
+      this.keepalive = false;
     }
     if (options.timeout) {
       this.timeout = options.timeout;
@@ -336,7 +343,7 @@ var packageJSONTmplStr = `{
     "async": "^2.1.4",
     "clever-discovery": "0.0.8",
     "opentracing": "^0.11.1",
-    "request": "^2.75.0",
+    "request": "^2.87.0",
     "kayvee": "^3.8.2",
     "hystrixjs": "^0.2.0",
     "rxjs": "^5.4.1"
@@ -406,7 +413,7 @@ var methodTmplStr = `
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "{{.Method}}",
         uri: this.address + "{{.PathCode}}",
         json: true,
@@ -415,6 +422,9 @@ var methodTmplStr = `
         qs: query,
         useQuerystring: true,
       };
+	  if (this.keepalive) {
+		requestOptions.forever = true;
+	  }
   {{ if ne .BodyParam ""}}
       requestOptions.body = params.{{.BodyParam}};
   {{ end }}

--- a/hardcoded/hardcoded.go
+++ b/hardcoded/hardcoded.go
@@ -215,7 +215,7 @@ var _bindata = map[string]*asset{
 			"\xff",
 		size: 10896,
 		mode: 0664,
-		time: time.Unix(1524593583, 423895781),
+		time: time.Unix(1531951245, 349127592),
 	},
 	"../_hardcoded/middleware.go": &asset{
 		name: "middleware.go",
@@ -288,7 +288,7 @@ var _bindata = map[string]*asset{
 			"\x1a\xbe\x96\x1d\x92\x46\xd8\x7a\x8f\xd2\xf1\x82\xfe\x7f\x00\x00\x00\xff\xff",
 		size: 3827,
 		mode: 0664,
-		time: time.Unix(1524593583, 431895771),
+		time: time.Unix(1490986499, 479020008),
 	},
 }
 

--- a/samples/gen-js-blog/README.md
+++ b/samples/gen-js-blog/README.md
@@ -55,6 +55,7 @@ Create a new client object.
 | [options.address] | <code>string</code> |  | URL where the server is located. Must provide this or the discovery argument |
 | [options.discovery] | <code>bool</code> |  | Use clever-discovery to locate the server. Must provide this or the address argument |
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. Default is 5000ms. |
+| [options.keepalive] | <code>bool</code> |  | Set keepalive to true for client requests. This sets the forever: true attribute in request. Defaults to false |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_blog--Blog.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 | [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;blog-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
 | [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |

--- a/samples/gen-js-blog/index.js
+++ b/samples/gen-js-blog/index.js
@@ -128,6 +128,8 @@ class Blog {
    * this or the address argument
    * @param {number} [options.timeout] - The timeout to use for all client requests,
    * in milliseconds. This can be overridden on a per-request basis. Default is 5000ms.
+   * @param {bool} [options.keepalive] - Set keepalive to true for client requests. This sets the
+   * forever: true attribute in request. Defaults to false
    * @param {module:blog.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
    * @param {module:kayvee.Logger} [options.logger=logger.New("blog-wagclient")] - The Kayvee 
@@ -157,6 +159,11 @@ class Blog {
       this.address = options.address;
     } else {
       throw new Error("Cannot initialize blog without discovery or address");
+    }
+    if (options.keepalive) {
+      this.keepalive = options.keepalive
+    } else {
+      this.keepalive = false;
     }
     if (options.timeout) {
       this.timeout = options.timeout;
@@ -283,7 +290,7 @@ class Blog {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "GET",
         uri: this.address + "/students/" + params.studentID + "/sections",
         json: true,
@@ -292,6 +299,9 @@ class Blog {
         qs: query,
         useQuerystring: true,
       };
+	  if (this.keepalive) {
+		requestOptions.forever = true;
+	  }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;

--- a/samples/gen-js-blog/package.json
+++ b/samples/gen-js-blog/package.json
@@ -7,7 +7,7 @@
     "async": "^2.1.4",
     "clever-discovery": "0.0.8",
     "opentracing": "^0.11.1",
-    "request": "^2.75.0",
+    "request": "^2.87.0",
     "kayvee": "^3.8.2",
     "hystrixjs": "^0.2.0",
     "rxjs": "^5.4.1"

--- a/samples/gen-js-db/README.md
+++ b/samples/gen-js-db/README.md
@@ -55,6 +55,7 @@ Create a new client object.
 | [options.address] | <code>string</code> |  | URL where the server is located. Must provide this or the discovery argument |
 | [options.discovery] | <code>bool</code> |  | Use clever-discovery to locate the server. Must provide this or the address argument |
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. Default is 5000ms. |
+| [options.keepalive] | <code>bool</code> |  | Set keepalive to true for client requests. This sets the forever: true attribute in request. Defaults to false |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 | [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;swagger-test-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
 | [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |

--- a/samples/gen-js-db/index.js
+++ b/samples/gen-js-db/index.js
@@ -128,6 +128,8 @@ class SwaggerTest {
    * this or the address argument
    * @param {number} [options.timeout] - The timeout to use for all client requests,
    * in milliseconds. This can be overridden on a per-request basis. Default is 5000ms.
+   * @param {bool} [options.keepalive] - Set keepalive to true for client requests. This sets the
+   * forever: true attribute in request. Defaults to false
    * @param {module:swagger-test.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
    * @param {module:kayvee.Logger} [options.logger=logger.New("swagger-test-wagclient")] - The Kayvee 
@@ -157,6 +159,11 @@ class SwaggerTest {
       this.address = options.address;
     } else {
       throw new Error("Cannot initialize swagger-test without discovery or address");
+    }
+    if (options.keepalive) {
+      this.keepalive = options.keepalive
+    } else {
+      this.keepalive = false;
     }
     if (options.timeout) {
       this.timeout = options.timeout;
@@ -276,7 +283,7 @@ class SwaggerTest {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "GET",
         uri: this.address + "/v1/health/check",
         json: true,
@@ -285,6 +292,9 @@ class SwaggerTest {
         qs: query,
         useQuerystring: true,
       };
+	  if (this.keepalive) {
+		requestOptions.forever = true;
+	  }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;

--- a/samples/gen-js-db/package.json
+++ b/samples/gen-js-db/package.json
@@ -7,7 +7,7 @@
     "async": "^2.1.4",
     "clever-discovery": "0.0.8",
     "opentracing": "^0.11.1",
-    "request": "^2.75.0",
+    "request": "^2.87.0",
     "kayvee": "^3.8.2",
     "hystrixjs": "^0.2.0",
     "rxjs": "^5.4.1"

--- a/samples/gen-js-deprecated/README.md
+++ b/samples/gen-js-deprecated/README.md
@@ -53,6 +53,7 @@ Create a new client object.
 | [options.address] | <code>string</code> |  | URL where the server is located. Must provide this or the discovery argument |
 | [options.discovery] | <code>bool</code> |  | Use clever-discovery to locate the server. Must provide this or the address argument |
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. Default is 5000ms. |
+| [options.keepalive] | <code>bool</code> |  | Set keepalive to true for client requests. This sets the forever: true attribute in request. Defaults to false |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 | [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;swagger-test-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
 | [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |

--- a/samples/gen-js-deprecated/index.js
+++ b/samples/gen-js-deprecated/index.js
@@ -128,6 +128,8 @@ class SwaggerTest {
    * this or the address argument
    * @param {number} [options.timeout] - The timeout to use for all client requests,
    * in milliseconds. This can be overridden on a per-request basis. Default is 5000ms.
+   * @param {bool} [options.keepalive] - Set keepalive to true for client requests. This sets the
+   * forever: true attribute in request. Defaults to false
    * @param {module:swagger-test.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
    * @param {module:kayvee.Logger} [options.logger=logger.New("swagger-test-wagclient")] - The Kayvee 
@@ -157,6 +159,11 @@ class SwaggerTest {
       this.address = options.address;
     } else {
       throw new Error("Cannot initialize swagger-test without discovery or address");
+    }
+    if (options.keepalive) {
+      this.keepalive = options.keepalive
+    } else {
+      this.keepalive = false;
     }
     if (options.timeout) {
       this.timeout = options.timeout;

--- a/samples/gen-js-deprecated/package.json
+++ b/samples/gen-js-deprecated/package.json
@@ -7,7 +7,7 @@
     "async": "^2.1.4",
     "clever-discovery": "0.0.8",
     "opentracing": "^0.11.1",
-    "request": "^2.75.0",
+    "request": "^2.87.0",
     "kayvee": "^3.8.2",
     "hystrixjs": "^0.2.0",
     "rxjs": "^5.4.1"

--- a/samples/gen-js-errors/README.md
+++ b/samples/gen-js-errors/README.md
@@ -56,6 +56,7 @@ Create a new client object.
 | [options.address] | <code>string</code> |  | URL where the server is located. Must provide this or the discovery argument |
 | [options.discovery] | <code>bool</code> |  | Use clever-discovery to locate the server. Must provide this or the address argument |
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. Default is 5000ms. |
+| [options.keepalive] | <code>bool</code> |  | Set keepalive to true for client requests. This sets the forever: true attribute in request. Defaults to false |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 | [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;swagger-test-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
 | [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |

--- a/samples/gen-js-errors/index.js
+++ b/samples/gen-js-errors/index.js
@@ -128,6 +128,8 @@ class SwaggerTest {
    * this or the address argument
    * @param {number} [options.timeout] - The timeout to use for all client requests,
    * in milliseconds. This can be overridden on a per-request basis. Default is 5000ms.
+   * @param {bool} [options.keepalive] - Set keepalive to true for client requests. This sets the
+   * forever: true attribute in request. Defaults to false
    * @param {module:swagger-test.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
    * @param {module:kayvee.Logger} [options.logger=logger.New("swagger-test-wagclient")] - The Kayvee 
@@ -157,6 +159,11 @@ class SwaggerTest {
       this.address = options.address;
     } else {
       throw new Error("Cannot initialize swagger-test without discovery or address");
+    }
+    if (options.keepalive) {
+      this.keepalive = options.keepalive
+    } else {
+      this.keepalive = false;
     }
     if (options.timeout) {
       this.timeout = options.timeout;
@@ -283,7 +290,7 @@ class SwaggerTest {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "GET",
         uri: this.address + "/v1/books/" + params.id + "",
         json: true,
@@ -292,6 +299,9 @@ class SwaggerTest {
         qs: query,
         useQuerystring: true,
       };
+	  if (this.keepalive) {
+		requestOptions.forever = true;
+	  }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;

--- a/samples/gen-js-errors/package.json
+++ b/samples/gen-js-errors/package.json
@@ -7,7 +7,7 @@
     "async": "^2.1.4",
     "clever-discovery": "0.0.8",
     "opentracing": "^0.11.1",
-    "request": "^2.75.0",
+    "request": "^2.87.0",
     "kayvee": "^3.8.2",
     "hystrixjs": "^0.2.0",
     "rxjs": "^5.4.1"

--- a/samples/gen-js-nils/README.md
+++ b/samples/gen-js-nils/README.md
@@ -55,6 +55,7 @@ Create a new client object.
 | [options.address] | <code>string</code> |  | URL where the server is located. Must provide this or the discovery argument |
 | [options.discovery] | <code>bool</code> |  | Use clever-discovery to locate the server. Must provide this or the address argument |
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. Default is 5000ms. |
+| [options.keepalive] | <code>bool</code> |  | Set keepalive to true for client requests. This sets the forever: true attribute in request. Defaults to false |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_nil-test--NilTest.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 | [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;nil-test-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
 | [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |

--- a/samples/gen-js-nils/index.js
+++ b/samples/gen-js-nils/index.js
@@ -128,6 +128,8 @@ class NilTest {
    * this or the address argument
    * @param {number} [options.timeout] - The timeout to use for all client requests,
    * in milliseconds. This can be overridden on a per-request basis. Default is 5000ms.
+   * @param {bool} [options.keepalive] - Set keepalive to true for client requests. This sets the
+   * forever: true attribute in request. Defaults to false
    * @param {module:nil-test.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
    * @param {module:kayvee.Logger} [options.logger=logger.New("nil-test-wagclient")] - The Kayvee 
@@ -157,6 +159,11 @@ class NilTest {
       this.address = options.address;
     } else {
       throw new Error("Cannot initialize nil-test without discovery or address");
+    }
+    if (options.keepalive) {
+      this.keepalive = options.keepalive
+    } else {
+      this.keepalive = false;
     }
     if (options.timeout) {
       this.timeout = options.timeout;
@@ -294,7 +301,7 @@ class NilTest {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "POST",
         uri: this.address + "/v1/check/" + params.id + "",
         json: true,
@@ -303,6 +310,9 @@ class NilTest {
         qs: query,
         useQuerystring: true,
       };
+	  if (this.keepalive) {
+		requestOptions.forever = true;
+	  }
   
       requestOptions.body = params.body;
   

--- a/samples/gen-js-nils/package.json
+++ b/samples/gen-js-nils/package.json
@@ -7,7 +7,7 @@
     "async": "^2.1.4",
     "clever-discovery": "0.0.8",
     "opentracing": "^0.11.1",
-    "request": "^2.75.0",
+    "request": "^2.87.0",
     "kayvee": "^3.8.2",
     "hystrixjs": "^0.2.0",
     "rxjs": "^5.4.1"

--- a/samples/gen-js/README.md
+++ b/samples/gen-js/README.md
@@ -67,6 +67,7 @@ Create a new client object.
 | [options.address] | <code>string</code> |  | URL where the server is located. Must provide this or the discovery argument |
 | [options.discovery] | <code>bool</code> |  | Use clever-discovery to locate the server. Must provide this or the address argument |
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. Default is 5000ms. |
+| [options.keepalive] | <code>bool</code> |  | Set keepalive to true for client requests. This sets the forever: true attribute in request. Defaults to false |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
 | [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;swagger-test-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
 | [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |

--- a/samples/gen-js/index.js
+++ b/samples/gen-js/index.js
@@ -128,6 +128,8 @@ class SwaggerTest {
    * this or the address argument
    * @param {number} [options.timeout] - The timeout to use for all client requests,
    * in milliseconds. This can be overridden on a per-request basis. Default is 5000ms.
+   * @param {bool} [options.keepalive] - Set keepalive to true for client requests. This sets the
+   * forever: true attribute in request. Defaults to false
    * @param {module:swagger-test.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
    * @param {module:kayvee.Logger} [options.logger=logger.New("swagger-test-wagclient")] - The Kayvee 
@@ -157,6 +159,11 @@ class SwaggerTest {
       this.address = options.address;
     } else {
       throw new Error("Cannot initialize swagger-test without discovery or address");
+    }
+    if (options.keepalive) {
+      this.keepalive = options.keepalive
+    } else {
+      this.keepalive = false;
     }
     if (options.timeout) {
       this.timeout = options.timeout;
@@ -286,7 +293,7 @@ class SwaggerTest {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "GET",
         uri: this.address + "/v1/authors",
         json: true,
@@ -295,6 +302,9 @@ class SwaggerTest {
         qs: query,
         useQuerystring: true,
       };
+	  if (this.keepalive) {
+		requestOptions.forever = true;
+	  }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;
@@ -400,7 +410,7 @@ class SwaggerTest {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "GET",
         uri: this.address + "/v1/authors",
         json: true,
@@ -409,6 +419,9 @@ class SwaggerTest {
         qs: query,
         useQuerystring: true,
       };
+	  if (this.keepalive) {
+		requestOptions.forever = true;
+	  }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;
@@ -564,7 +577,7 @@ class SwaggerTest {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "PUT",
         uri: this.address + "/v1/authors",
         json: true,
@@ -573,6 +586,9 @@ class SwaggerTest {
         qs: query,
         useQuerystring: true,
       };
+	  if (this.keepalive) {
+		requestOptions.forever = true;
+	  }
   
       requestOptions.body = params.favoriteBooks;
   
@@ -681,7 +697,7 @@ class SwaggerTest {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "PUT",
         uri: this.address + "/v1/authors",
         json: true,
@@ -690,6 +706,9 @@ class SwaggerTest {
         qs: query,
         useQuerystring: true,
       };
+	  if (this.keepalive) {
+		requestOptions.forever = true;
+	  }
   
       requestOptions.body = params.favoriteBooks;
   
@@ -888,7 +907,7 @@ class SwaggerTest {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "GET",
         uri: this.address + "/v1/books",
         json: true,
@@ -897,6 +916,9 @@ class SwaggerTest {
         qs: query,
         useQuerystring: true,
       };
+	  if (this.keepalive) {
+		requestOptions.forever = true;
+	  }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;
@@ -1044,7 +1066,7 @@ class SwaggerTest {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "GET",
         uri: this.address + "/v1/books",
         json: true,
@@ -1053,6 +1075,9 @@ class SwaggerTest {
         qs: query,
         useQuerystring: true,
       };
+	  if (this.keepalive) {
+		requestOptions.forever = true;
+	  }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;
@@ -1200,7 +1225,7 @@ class SwaggerTest {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "POST",
         uri: this.address + "/v1/books",
         json: true,
@@ -1209,6 +1234,9 @@ class SwaggerTest {
         qs: query,
         useQuerystring: true,
       };
+	  if (this.keepalive) {
+		requestOptions.forever = true;
+	  }
   
       requestOptions.body = params.newBook;
   
@@ -1319,7 +1347,7 @@ class SwaggerTest {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "PUT",
         uri: this.address + "/v1/books",
         json: true,
@@ -1328,6 +1356,9 @@ class SwaggerTest {
         qs: query,
         useQuerystring: true,
       };
+	  if (this.keepalive) {
+		requestOptions.forever = true;
+	  }
   
       requestOptions.body = params.newBook;
   
@@ -1456,7 +1487,7 @@ class SwaggerTest {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "GET",
         uri: this.address + "/v1/books/" + params.bookID + "",
         json: true,
@@ -1465,6 +1496,9 @@ class SwaggerTest {
         qs: query,
         useQuerystring: true,
       };
+	  if (this.keepalive) {
+		requestOptions.forever = true;
+	  }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;
@@ -1590,7 +1624,7 @@ class SwaggerTest {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "GET",
         uri: this.address + "/v1/books2/" + params.id + "",
         json: true,
@@ -1599,6 +1633,9 @@ class SwaggerTest {
         qs: query,
         useQuerystring: true,
       };
+	  if (this.keepalive) {
+		requestOptions.forever = true;
+	  }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;
@@ -1710,7 +1747,7 @@ class SwaggerTest {
         span.setTag("span.kind", "client");
       }
 
-      const requestOptions = {
+	  const requestOptions = {
         method: "GET",
         uri: this.address + "/v1/health/check",
         json: true,
@@ -1719,6 +1756,9 @@ class SwaggerTest {
         qs: query,
         useQuerystring: true,
       };
+	  if (this.keepalive) {
+		requestOptions.forever = true;
+	  }
   
 
       const retryPolicy = options.retryPolicy || this.retryPolicy || singleRetryPolicy;

--- a/samples/gen-js/package.json
+++ b/samples/gen-js/package.json
@@ -7,7 +7,7 @@
     "async": "^2.1.4",
     "clever-discovery": "0.0.8",
     "opentracing": "^0.11.1",
-    "request": "^2.75.0",
+    "request": "^2.87.0",
     "kayvee": "^3.8.2",
     "hystrixjs": "^0.2.0",
     "rxjs": "^5.4.1"

--- a/server/gendb/bindata.go
+++ b/server/gendb/bindata.go
@@ -6,12 +6,12 @@
 //  asset-dir: true
 //  restore: true
 // sources:
-//  /home/ubuntu/go/src/github.com/Clever/wag/server/gendb/dynamodb-local.sh.tmpl
-//  /home/ubuntu/go/src/github.com/Clever/wag/server/gendb/dynamodb.go.tmpl
-//  /home/ubuntu/go/src/github.com/Clever/wag/server/gendb/dynamodb_test.go.tmpl
-//  /home/ubuntu/go/src/github.com/Clever/wag/server/gendb/interface.go.tmpl
-//  /home/ubuntu/go/src/github.com/Clever/wag/server/gendb/table.go.tmpl
-//  /home/ubuntu/go/src/github.com/Clever/wag/server/gendb/tests.go.tmpl
+//  /home/mohit/gocode/src/github.com/Clever/wag/server/gendb/dynamodb-local.sh.tmpl
+//  /home/mohit/gocode/src/github.com/Clever/wag/server/gendb/dynamodb.go.tmpl
+//  /home/mohit/gocode/src/github.com/Clever/wag/server/gendb/dynamodb_test.go.tmpl
+//  /home/mohit/gocode/src/github.com/Clever/wag/server/gendb/interface.go.tmpl
+//  /home/mohit/gocode/src/github.com/Clever/wag/server/gendb/table.go.tmpl
+//  /home/mohit/gocode/src/github.com/Clever/wag/server/gendb/tests.go.tmpl
 
 package gendb
 
@@ -86,7 +86,7 @@ var _bindata = map[string]*asset{
 			"\xe5\xe1\xe1\xd1\xfc\x09\x00\x00\xff\xff",
 		size: 602,
 		mode: 0775,
-		time: time.Unix(1524593583, 479895708),
+		time: time.Unix(1531951245, 365127477),
 	},
 	"dynamodb.go.tmpl": &asset{
 		name: "dynamodb.go.tmpl",
@@ -146,7 +146,7 @@ var _bindata = map[string]*asset{
 			"\xd3\x41\x45\x78\x6a\xbd\x99\xed\x7e\xe8\x34\xf6\x91\xfb\xf2\x9f\x00\x00\x00\xff\xff",
 		size: 6388,
 		mode: 0664,
-		time: time.Unix(1524593583, 479895708),
+		time: time.Unix(1531951245, 365127477),
 	},
 	"dynamodb_test.go.tmpl": &asset{
 		name: "dynamodb_test.go.tmpl",
@@ -190,7 +190,7 @@ var _bindata = map[string]*asset{
 			"\xd8\xc2\xbf\x2f\xc6\xb7\x58\x3c\xd2\xe0\x2d\x68\x96\xb8\x38\x88\xbf\x02\x00\x00\xff\xff",
 		size: 2094,
 		mode: 0664,
-		time: time.Unix(1524593583, 479895708),
+		time: time.Unix(1531951245, 365127477),
 	},
 	"interface.go.tmpl": &asset{
 		name: "interface.go.tmpl",
@@ -248,7 +248,7 @@ var _bindata = map[string]*asset{
 			"\xa9\x3a\xdc\x67\xb3\xc6\xcf\xbf\x02\x00\x00\xff\xff",
 		size: 6476,
 		mode: 0664,
-		time: time.Unix(1526930781, 442633259),
+		time: time.Unix(1531951245, 365127477),
 	},
 	"table.go.tmpl": &asset{
 		name: "table.go.tmpl",
@@ -372,7 +372,7 @@ var _bindata = map[string]*asset{
 			"\xff\xff",
 		size: 18062,
 		mode: 0664,
-		time: time.Unix(1525213289, 929200401),
+		time: time.Unix(1531951245, 365127477),
 	},
 	"tests.go.tmpl": &asset{
 		name: "tests.go.tmpl",
@@ -458,7 +458,7 @@ var _bindata = map[string]*asset{
 			"\x8c\xd0\xca\xb5\x1e\x15\x3a\x4b\xb3\xa8\x7c\xfb\x27\x00\x00\xff\xff",
 		size: 20564,
 		mode: 0664,
-		time: time.Unix(1527194792, 575052847),
+		time: time.Unix(1531951245, 365127477),
 	},
 }
 


### PR DESCRIPTION
By default `request` and the node HTTP Agent do not enable `keepAlive`. Setting `forever: true` enables `keepAlive` for node version > 0.12. For older versions the `request-forever` agent is used to provide custom request pools.

Setting this up in a way that does not change existing behavior but allows client consumers to opt-in to set keepAlive.