### PR TITLE
Use SignalFX not Lightstep

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -372,6 +372,7 @@
   revision = "40f4993ede74f673cfe96bed75ef8513a389a00a"
 
 [[projects]]
+  branch = "master"
   name = "github.com/uber/jaeger-client-go"
   packages = [
     ".",
@@ -392,8 +393,7 @@
     "transport",
     "utils"
   ]
-  revision = "1a782e2da844727691fef1757c72eb190c2909f0"
-  version = "v2.15.0"
+  revision = "84fe9bc9ad17d9a4bcf8e4387026088ac55664e2"
 
 [[projects]]
   name = "github.com/uber/jaeger-lib"
@@ -501,6 +501,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "2083394c9c51654b47e376779f14992ca7e4b7e17e795acdaf4774395d51441a"
+  inputs-digest = "5b993f750e5f72443c8eaecf9c85f5dbdf136ce70e0707438478e499919a360d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -91,6 +91,12 @@
   revision = "6b6bb4f2ae8f85e805aa695b8f18db881234effd"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/codahale/hdrhistogram"
+  packages = ["."]
+  revision = "3a0bb77429bd3a61596f5e8a3172445844342120"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
@@ -206,19 +212,6 @@
   revision = "58cd061d09382b6011f84c1291ebe50ef2e25bab"
 
 [[projects]]
-  name = "github.com/golang/protobuf"
-  packages = [
-    "proto",
-    "protoc-gen-go/descriptor",
-    "ptypes",
-    "ptypes/any",
-    "ptypes/duration",
-    "ptypes/timestamp"
-  ]
-  revision = "925541529c1fa6821df4e44ce2723319eb2be768"
-  version = "v1.0.0"
-
-[[projects]]
   name = "github.com/gorilla/context"
   packages = ["."]
   revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
@@ -271,18 +264,6 @@
   revision = "7cafcd837844e784b526369c9bce262804aebc60"
 
 [[projects]]
-  name = "github.com/lightstep/lightstep-tracer-go"
-  packages = [
-    ".",
-    "collectorpb",
-    "lightstep_thrift",
-    "lightsteppb",
-    "thrift_0_9_2/lib/go/thrift"
-  ]
-  revision = "f9f54d495e5c6752b58fae6b66a5cb1107e17b29"
-  version = "v0.15.2"
-
-[[projects]]
   name = "github.com/magiconair/properties"
   packages = ["."]
   revision = "c3beff4c2358b44d0493c7dda585e7db7ff28ae6"
@@ -319,6 +300,12 @@
   packages = ["."]
   revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
   version = "v1.1.0"
+
+[[projects]]
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
@@ -385,6 +372,36 @@
   revision = "40f4993ede74f673cfe96bed75ef8513a389a00a"
 
 [[projects]]
+  name = "github.com/uber/jaeger-client-go"
+  packages = [
+    ".",
+    "config",
+    "internal/baggage",
+    "internal/baggage/remote",
+    "internal/spanlog",
+    "internal/throttler",
+    "internal/throttler/remote",
+    "log",
+    "rpcmetrics",
+    "thrift",
+    "thrift-gen/agent",
+    "thrift-gen/baggage",
+    "thrift-gen/jaeger",
+    "thrift-gen/sampling",
+    "thrift-gen/zipkincore",
+    "transport",
+    "utils"
+  ]
+  revision = "1a782e2da844727691fef1757c72eb190c2909f0"
+  version = "v2.15.0"
+
+[[projects]]
+  name = "github.com/uber/jaeger-lib"
+  packages = ["metrics"]
+  revision = "ed3a127ec5fef7ae9ea95b01b542c47fbd999ce5"
+  version = "v1.5.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/xeipuuv/gojsonpointer"
   packages = ["."]
@@ -408,12 +425,7 @@
   packages = [
     "context",
     "context/ctxhttp",
-    "http2",
-    "http2/hpack",
-    "idna",
-    "internal/timeseries",
-    "lex/httplex",
-    "trace"
+    "idna"
   ]
   revision = "cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb"
 
@@ -455,45 +467,6 @@
   revision = "f8f2f88271bf2c23f28a09d288d26507a9503c97"
 
 [[projects]]
-  branch = "master"
-  name = "google.golang.org/genproto"
-  packages = [
-    "googleapis/api/annotations",
-    "googleapis/rpc/status"
-  ]
-  revision = "2b5a72b8730b0b16380010cfe5286c42108d88e7"
-
-[[projects]]
-  name = "google.golang.org/grpc"
-  packages = [
-    ".",
-    "balancer",
-    "balancer/base",
-    "balancer/roundrobin",
-    "codes",
-    "connectivity",
-    "credentials",
-    "encoding",
-    "encoding/proto",
-    "grpclb/grpc_lb_v1/messages",
-    "grpclog",
-    "internal",
-    "keepalive",
-    "metadata",
-    "naming",
-    "peer",
-    "resolver",
-    "resolver/dns",
-    "resolver/passthrough",
-    "stats",
-    "status",
-    "tap",
-    "transport"
-  ]
-  revision = "8e4536a86ab602859c20df5ebfd0bd4228d08655"
-  version = "v1.10.0"
-
-[[projects]]
   name = "gopkg.in/Clever/kayvee-go.v6"
   packages = [
     ".",
@@ -528,6 +501,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ff57fe4c1fe7f0dc67ba632d02b2febd170494c3996b35e7d9ffae034f32103f"
+  inputs-digest = "2083394c9c51654b47e376779f14992ca7e4b7e17e795acdaf4774395d51441a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -72,8 +72,7 @@ required = ["github.com/tmthrgd/go-bindata", "github.com/golang/mock/mockgen"]
   branch = "master"
 
 [[constraint]]
-  name = "github.com/lightstep/lightstep-tracer-go"
-  version = "0.15.2"
+  name = "github.com/uber/jaeger-client-go"
 
 [[constraint]]
   name = "github.com/opentracing/opentracing-go"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -73,6 +73,7 @@ required = ["github.com/tmthrgd/go-bindata", "github.com/golang/mock/mockgen"]
 
 [[constraint]]
   name = "github.com/uber/jaeger-client-go"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/opentracing/opentracing-go"

--- a/README.md
+++ b/README.md
@@ -239,28 +239,7 @@ definitions:
   This is done via [opentracing](http://opentracing.io/).
   In order for it to work, you are required to do two things:
 
-  * Configure your `main()` function to report tracing data to [LightStep](http://lightstep.com/).
-     We are testing Lightstep as a way to view tracing-related data:
-```go
-package main
-
-import (
-	lightstep "github.com/lightstep/lightstep-tracer-go"
-	opentracing "github.com/opentracing/opentracing-go"
-)
-
-func main() {
-	tags := make(map[string]interface{})
-	tags[lightstep.ComponentNameKey] = "<name of the repo>"
-	lightstepTracer := lightstep.NewTracer(lightstep.Options{
-	    AccessToken: os.Getenv("LIGHTSTEP_ACCESS_TOKEN"),
-	    Tags:        tags,
-	})
-	defer lightstep.FlushLightStepTracer(lightstepTracer)
-	opentracing.InitGlobalTracer(lightstepTracer)
-	...
-}
-```
+  * Add `TRACING_ACCESS_TOKEN` to your ark-config with the access token stored in the secret store. This will automatically report tracing data to [SignalFX](https://app.signalfx.com/#/trace/).
   * By default we tag traces with `http.method`, `span.kind`, `http.url`, `http.status_code`, and `error`. For more information about what these tags mean see: https://github.com/opentracing/opentracing.io/blob/95b966bd6a6b2cf0f231260e3e1fa6206ede2151/_docs/pages/api/data-conventions.md#component-identification
 
 ## Using the Go Client
@@ -361,8 +340,8 @@ import * as SampleClientLib from 'sample-client-lib-js';
 const app = express();
 const sampleClient = new SampleClientLib({discovery: true}); // Using discovery
 
-const LIGHTSTEP_ACCESS_TOKEN = "access_token";
-app.use(middleware({access_token: LIGHTSTEP_ACCESS_TOKEN}));
+const TRACING_ACCESS_TOKEN = "access_token";
+app.use(middleware({access_token: TRACING_ACCESS_TOKEN}));
 
 app.get("/my-url", (req, res) => {
   sampleClient.getBookById("bookID", {span: req.span}, (err, book) => {

--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,2 @@
-v1.10.1
-- fixup in formatting
-- Allow setting keepalive in node clients
+v1.11.0
+- Use Jaeger client as tracer instead of Lightstep client

--- a/hardcoded/hardcoded.go
+++ b/hardcoded/hardcoded.go
@@ -215,7 +215,7 @@ var _bindata = map[string]*asset{
 			"\xff",
 		size: 10896,
 		mode: 0664,
-		time: time.Unix(1535140588, 518097822),
+		time: time.Unix(1516994792, 136823186),
 	},
 	"../_hardcoded/middleware.go": &asset{
 		name: "middleware.go",
@@ -288,7 +288,7 @@ var _bindata = map[string]*asset{
 			"\x1a\xbe\x96\x1d\x92\x46\xd8\x7a\x8f\xd2\xf1\x82\xfe\x7f\x00\x00\x00\xff\xff",
 		size: 3827,
 		mode: 0664,
-		time: time.Unix(1535140588, 518097822),
+		time: time.Unix(1516994792, 136823186),
 	},
 }
 

--- a/samples/gen-go-blog/server/router.go
+++ b/samples/gen-go-blog/server/router.go
@@ -55,11 +55,11 @@ func (s *Server) Serve() error {
 	if tracingToken := os.Getenv("TRACING_ACCESS_TOKEN"); tracingToken != "" {
 		ingestUrl := os.Getenv("TRACING_INGEST_URL")
 		if ingestUrl == "" {
-			ingestUrl = "https://ingest.signalfx.com"
+			ingestUrl = "https://ingest.signalfx.com/v1/trace"
 		}
 
 		// Create a Jaeger HTTP Thrift transport
-		transport := transport.NewHTTPTransport(ingestUrl+"/v1/trace",
+		transport := transport.NewHTTPTransport(ingestUrl,
 			transport.HTTPBasicAuth("auth", tracingToken))
 
 		// Add rate limited sampling. We will only sample [Param] requests per second

--- a/samples/gen-go-blog/server/router.go
+++ b/samples/gen-go-blog/server/router.go
@@ -52,24 +52,35 @@ func (s *Server) Serve() error {
 		s.l.Info("please provide a kvconfig.yml file to enable app log routing")
 	}
 
-	if signalfxToken := os.Getenv("SIGNALFX_ACCESS_TOKEN"); signalfxToken != "" {
-		ingestUrl := os.Getenv("SIGNALFX_INGEST_URL")
+	if tracingToken := os.Getenv("TRACING_ACCESS_TOKEN"); tracingToken != "" {
+		ingestUrl := os.Getenv("TRACING_INGEST_URL")
 		if ingestUrl == "" {
 			ingestUrl = "https://ingest.signalfx.com"
 		}
 
 		// Create a Jaeger HTTP Thrift transport
 		transport := transport.NewHTTPTransport(ingestUrl+"/v1/trace",
-			transport.HTTPBasicAuth("auth", signalfxToken))
+			transport.HTTPBasicAuth("auth", tracingToken))
 
-		cfg, err := jaegercfg.FromEnv()
-		if err != nil {
-			log.Fatal("Could not parse Jaeger env vars: ", err.Error())
+		// Add rate limited sampling. We will only sample [Param] requests per second
+		// and [MaxOperations] different endpoints. Any endpoint above the [MaxOperations]
+		// limit will be probabilistically sampled.
+		cfgSampler := &jaegercfg.SamplerConfig{
+			Type:          jaeger.SamplerTypeRateLimiting,
+			Param:         5,
+			MaxOperations: 100,
 		}
-		cfg.ServiceName = "blog"
-		cfg.Sampler = &jaegercfg.SamplerConfig{
-			Type:  jaeger.SamplerTypeRateLimiting,
-			Param: 500,
+		cfgTags := []opentracing.Tag{
+			opentracing.Tag{Key: "app_name", Value: os.Getenv("_APP_NAME")},
+			opentracing.Tag{Key: "build_id", Value: os.Getenv("_BUILD_ID")},
+			opentracing.Tag{Key: "deploy_env", Value: os.Getenv("_DEPLOY_ENV")},
+			opentracing.Tag{Key: "team_owner", Value: os.Getenv("_TEAM_OWNER")},
+		}
+
+		cfg := &jaegercfg.Configuration{
+			ServiceName: "blog",
+			Sampler:     cfgSampler,
+			Tags:        cfgTags,
 		}
 
 		signalfxTracer, closer, err := cfg.NewTracer(jaegercfg.Reporter(jaeger.NewRemoteReporter(transport)))
@@ -80,7 +91,7 @@ func (s *Server) Serve() error {
 
 		opentracing.SetGlobalTracer(signalfxTracer)
 	} else {
-		s.l.Error("please set SIGNALFX_ACCESS_TOKEN to enable tracing")
+		s.l.Error("please set TRACING_ACCESS_TOKEN to enable tracing")
 	}
 
 	s.l.Counter("server-started")

--- a/samples/gen-go-blog/server/router.go
+++ b/samples/gen-go-blog/server/router.go
@@ -13,8 +13,10 @@ import (
 	"github.com/Clever/go-process-metrics/metrics"
 	"github.com/gorilla/mux"
 	"github.com/kardianos/osext"
-	lightstep "github.com/lightstep/lightstep-tracer-go"
 	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/uber/jaeger-client-go"
+	jaegercfg "github.com/uber/jaeger-client-go/config"
+	"github.com/uber/jaeger-client-go/transport"
 	"gopkg.in/Clever/kayvee-go.v6/logger"
 	kvMiddleware "gopkg.in/Clever/kayvee-go.v6/middleware"
 	"gopkg.in/tylerb/graceful.v1"
@@ -50,18 +52,35 @@ func (s *Server) Serve() error {
 		s.l.Info("please provide a kvconfig.yml file to enable app log routing")
 	}
 
-	if lightstepToken := os.Getenv("LIGHTSTEP_ACCESS_TOKEN"); lightstepToken != "" {
-		tags := make(map[string]interface{})
-		tags[lightstep.ComponentNameKey] = "blog"
-		lightstepTracer := lightstep.NewTracer(lightstep.Options{
-			AccessToken: lightstepToken,
-			Tags:        tags,
-			UseGRPC:     true,
-		})
-		defer lightstep.FlushLightStepTracer(lightstepTracer)
-		opentracing.InitGlobalTracer(lightstepTracer)
+	if signalfxToken := os.Getenv("SIGNALFX_ACCESS_TOKEN"); signalfxToken != "" {
+		ingestUrl := os.Getenv("SIGNALFX_INGEST_URL")
+		if ingestUrl == "" {
+			ingestUrl = "https://ingest.signalfx.com"
+		}
+
+		// Create a Jaeger HTTP Thrift transport
+		transport := transport.NewHTTPTransport(ingestUrl+"/v1/trace",
+			transport.HTTPBasicAuth("auth", signalfxToken))
+
+		cfg, err := jaegercfg.FromEnv()
+		if err != nil {
+			log.Fatal("Could not parse Jaeger env vars: ", err.Error())
+		}
+		cfg.ServiceName = "blog"
+		cfg.Sampler = &jaegercfg.SamplerConfig{
+			Type:  jaeger.SamplerTypeRateLimiting,
+			Param: 500,
+		}
+
+		signalfxTracer, closer, err := cfg.NewTracer(jaegercfg.Reporter(jaeger.NewRemoteReporter(transport)))
+		if err != nil {
+			log.Fatal("Could not initialize jaeger tracer: ", err.Error())
+		}
+		defer closer.Close()
+
+		opentracing.SetGlobalTracer(signalfxTracer)
 	} else {
-		s.l.Error("please set LIGHTSTEP_ACCESS_TOKEN to enable tracing")
+		s.l.Error("please set SIGNALFX_ACCESS_TOKEN to enable tracing")
 	}
 
 	s.l.Counter("server-started")

--- a/samples/gen-go-db/server/router.go
+++ b/samples/gen-go-db/server/router.go
@@ -55,11 +55,11 @@ func (s *Server) Serve() error {
 	if tracingToken := os.Getenv("TRACING_ACCESS_TOKEN"); tracingToken != "" {
 		ingestUrl := os.Getenv("TRACING_INGEST_URL")
 		if ingestUrl == "" {
-			ingestUrl = "https://ingest.signalfx.com"
+			ingestUrl = "https://ingest.signalfx.com/v1/trace"
 		}
 
 		// Create a Jaeger HTTP Thrift transport
-		transport := transport.NewHTTPTransport(ingestUrl+"/v1/trace",
+		transport := transport.NewHTTPTransport(ingestUrl,
 			transport.HTTPBasicAuth("auth", tracingToken))
 
 		// Add rate limited sampling. We will only sample [Param] requests per second

--- a/samples/gen-go-db/server/router.go
+++ b/samples/gen-go-db/server/router.go
@@ -52,24 +52,35 @@ func (s *Server) Serve() error {
 		s.l.Info("please provide a kvconfig.yml file to enable app log routing")
 	}
 
-	if signalfxToken := os.Getenv("SIGNALFX_ACCESS_TOKEN"); signalfxToken != "" {
-		ingestUrl := os.Getenv("SIGNALFX_INGEST_URL")
+	if tracingToken := os.Getenv("TRACING_ACCESS_TOKEN"); tracingToken != "" {
+		ingestUrl := os.Getenv("TRACING_INGEST_URL")
 		if ingestUrl == "" {
 			ingestUrl = "https://ingest.signalfx.com"
 		}
 
 		// Create a Jaeger HTTP Thrift transport
 		transport := transport.NewHTTPTransport(ingestUrl+"/v1/trace",
-			transport.HTTPBasicAuth("auth", signalfxToken))
+			transport.HTTPBasicAuth("auth", tracingToken))
 
-		cfg, err := jaegercfg.FromEnv()
-		if err != nil {
-			log.Fatal("Could not parse Jaeger env vars: ", err.Error())
+		// Add rate limited sampling. We will only sample [Param] requests per second
+		// and [MaxOperations] different endpoints. Any endpoint above the [MaxOperations]
+		// limit will be probabilistically sampled.
+		cfgSampler := &jaegercfg.SamplerConfig{
+			Type:          jaeger.SamplerTypeRateLimiting,
+			Param:         5,
+			MaxOperations: 100,
 		}
-		cfg.ServiceName = "swagger-test"
-		cfg.Sampler = &jaegercfg.SamplerConfig{
-			Type:  jaeger.SamplerTypeRateLimiting,
-			Param: 500,
+		cfgTags := []opentracing.Tag{
+			opentracing.Tag{Key: "app_name", Value: os.Getenv("_APP_NAME")},
+			opentracing.Tag{Key: "build_id", Value: os.Getenv("_BUILD_ID")},
+			opentracing.Tag{Key: "deploy_env", Value: os.Getenv("_DEPLOY_ENV")},
+			opentracing.Tag{Key: "team_owner", Value: os.Getenv("_TEAM_OWNER")},
+		}
+
+		cfg := &jaegercfg.Configuration{
+			ServiceName: "swagger-test",
+			Sampler:     cfgSampler,
+			Tags:        cfgTags,
 		}
 
 		signalfxTracer, closer, err := cfg.NewTracer(jaegercfg.Reporter(jaeger.NewRemoteReporter(transport)))
@@ -80,7 +91,7 @@ func (s *Server) Serve() error {
 
 		opentracing.SetGlobalTracer(signalfxTracer)
 	} else {
-		s.l.Error("please set SIGNALFX_ACCESS_TOKEN to enable tracing")
+		s.l.Error("please set TRACING_ACCESS_TOKEN to enable tracing")
 	}
 
 	s.l.Counter("server-started")

--- a/samples/gen-go-deprecated/server/router.go
+++ b/samples/gen-go-deprecated/server/router.go
@@ -55,11 +55,11 @@ func (s *Server) Serve() error {
 	if tracingToken := os.Getenv("TRACING_ACCESS_TOKEN"); tracingToken != "" {
 		ingestUrl := os.Getenv("TRACING_INGEST_URL")
 		if ingestUrl == "" {
-			ingestUrl = "https://ingest.signalfx.com"
+			ingestUrl = "https://ingest.signalfx.com/v1/trace"
 		}
 
 		// Create a Jaeger HTTP Thrift transport
-		transport := transport.NewHTTPTransport(ingestUrl+"/v1/trace",
+		transport := transport.NewHTTPTransport(ingestUrl,
 			transport.HTTPBasicAuth("auth", tracingToken))
 
 		// Add rate limited sampling. We will only sample [Param] requests per second

--- a/samples/gen-go-deprecated/server/router.go
+++ b/samples/gen-go-deprecated/server/router.go
@@ -52,24 +52,35 @@ func (s *Server) Serve() error {
 		s.l.Info("please provide a kvconfig.yml file to enable app log routing")
 	}
 
-	if signalfxToken := os.Getenv("SIGNALFX_ACCESS_TOKEN"); signalfxToken != "" {
-		ingestUrl := os.Getenv("SIGNALFX_INGEST_URL")
+	if tracingToken := os.Getenv("TRACING_ACCESS_TOKEN"); tracingToken != "" {
+		ingestUrl := os.Getenv("TRACING_INGEST_URL")
 		if ingestUrl == "" {
 			ingestUrl = "https://ingest.signalfx.com"
 		}
 
 		// Create a Jaeger HTTP Thrift transport
 		transport := transport.NewHTTPTransport(ingestUrl+"/v1/trace",
-			transport.HTTPBasicAuth("auth", signalfxToken))
+			transport.HTTPBasicAuth("auth", tracingToken))
 
-		cfg, err := jaegercfg.FromEnv()
-		if err != nil {
-			log.Fatal("Could not parse Jaeger env vars: ", err.Error())
+		// Add rate limited sampling. We will only sample [Param] requests per second
+		// and [MaxOperations] different endpoints. Any endpoint above the [MaxOperations]
+		// limit will be probabilistically sampled.
+		cfgSampler := &jaegercfg.SamplerConfig{
+			Type:          jaeger.SamplerTypeRateLimiting,
+			Param:         5,
+			MaxOperations: 100,
 		}
-		cfg.ServiceName = "swagger-test"
-		cfg.Sampler = &jaegercfg.SamplerConfig{
-			Type:  jaeger.SamplerTypeRateLimiting,
-			Param: 500,
+		cfgTags := []opentracing.Tag{
+			opentracing.Tag{Key: "app_name", Value: os.Getenv("_APP_NAME")},
+			opentracing.Tag{Key: "build_id", Value: os.Getenv("_BUILD_ID")},
+			opentracing.Tag{Key: "deploy_env", Value: os.Getenv("_DEPLOY_ENV")},
+			opentracing.Tag{Key: "team_owner", Value: os.Getenv("_TEAM_OWNER")},
+		}
+
+		cfg := &jaegercfg.Configuration{
+			ServiceName: "swagger-test",
+			Sampler:     cfgSampler,
+			Tags:        cfgTags,
 		}
 
 		signalfxTracer, closer, err := cfg.NewTracer(jaegercfg.Reporter(jaeger.NewRemoteReporter(transport)))
@@ -80,7 +91,7 @@ func (s *Server) Serve() error {
 
 		opentracing.SetGlobalTracer(signalfxTracer)
 	} else {
-		s.l.Error("please set SIGNALFX_ACCESS_TOKEN to enable tracing")
+		s.l.Error("please set TRACING_ACCESS_TOKEN to enable tracing")
 	}
 
 	s.l.Counter("server-started")

--- a/samples/gen-go-errors/server/router.go
+++ b/samples/gen-go-errors/server/router.go
@@ -55,11 +55,11 @@ func (s *Server) Serve() error {
 	if tracingToken := os.Getenv("TRACING_ACCESS_TOKEN"); tracingToken != "" {
 		ingestUrl := os.Getenv("TRACING_INGEST_URL")
 		if ingestUrl == "" {
-			ingestUrl = "https://ingest.signalfx.com"
+			ingestUrl = "https://ingest.signalfx.com/v1/trace"
 		}
 
 		// Create a Jaeger HTTP Thrift transport
-		transport := transport.NewHTTPTransport(ingestUrl+"/v1/trace",
+		transport := transport.NewHTTPTransport(ingestUrl,
 			transport.HTTPBasicAuth("auth", tracingToken))
 
 		// Add rate limited sampling. We will only sample [Param] requests per second

--- a/samples/gen-go-errors/server/router.go
+++ b/samples/gen-go-errors/server/router.go
@@ -52,24 +52,35 @@ func (s *Server) Serve() error {
 		s.l.Info("please provide a kvconfig.yml file to enable app log routing")
 	}
 
-	if signalfxToken := os.Getenv("SIGNALFX_ACCESS_TOKEN"); signalfxToken != "" {
-		ingestUrl := os.Getenv("SIGNALFX_INGEST_URL")
+	if tracingToken := os.Getenv("TRACING_ACCESS_TOKEN"); tracingToken != "" {
+		ingestUrl := os.Getenv("TRACING_INGEST_URL")
 		if ingestUrl == "" {
 			ingestUrl = "https://ingest.signalfx.com"
 		}
 
 		// Create a Jaeger HTTP Thrift transport
 		transport := transport.NewHTTPTransport(ingestUrl+"/v1/trace",
-			transport.HTTPBasicAuth("auth", signalfxToken))
+			transport.HTTPBasicAuth("auth", tracingToken))
 
-		cfg, err := jaegercfg.FromEnv()
-		if err != nil {
-			log.Fatal("Could not parse Jaeger env vars: ", err.Error())
+		// Add rate limited sampling. We will only sample [Param] requests per second
+		// and [MaxOperations] different endpoints. Any endpoint above the [MaxOperations]
+		// limit will be probabilistically sampled.
+		cfgSampler := &jaegercfg.SamplerConfig{
+			Type:          jaeger.SamplerTypeRateLimiting,
+			Param:         5,
+			MaxOperations: 100,
 		}
-		cfg.ServiceName = "swagger-test"
-		cfg.Sampler = &jaegercfg.SamplerConfig{
-			Type:  jaeger.SamplerTypeRateLimiting,
-			Param: 500,
+		cfgTags := []opentracing.Tag{
+			opentracing.Tag{Key: "app_name", Value: os.Getenv("_APP_NAME")},
+			opentracing.Tag{Key: "build_id", Value: os.Getenv("_BUILD_ID")},
+			opentracing.Tag{Key: "deploy_env", Value: os.Getenv("_DEPLOY_ENV")},
+			opentracing.Tag{Key: "team_owner", Value: os.Getenv("_TEAM_OWNER")},
+		}
+
+		cfg := &jaegercfg.Configuration{
+			ServiceName: "swagger-test",
+			Sampler:     cfgSampler,
+			Tags:        cfgTags,
 		}
 
 		signalfxTracer, closer, err := cfg.NewTracer(jaegercfg.Reporter(jaeger.NewRemoteReporter(transport)))
@@ -80,7 +91,7 @@ func (s *Server) Serve() error {
 
 		opentracing.SetGlobalTracer(signalfxTracer)
 	} else {
-		s.l.Error("please set SIGNALFX_ACCESS_TOKEN to enable tracing")
+		s.l.Error("please set TRACING_ACCESS_TOKEN to enable tracing")
 	}
 
 	s.l.Counter("server-started")

--- a/samples/gen-go-nils/server/router.go
+++ b/samples/gen-go-nils/server/router.go
@@ -55,11 +55,11 @@ func (s *Server) Serve() error {
 	if tracingToken := os.Getenv("TRACING_ACCESS_TOKEN"); tracingToken != "" {
 		ingestUrl := os.Getenv("TRACING_INGEST_URL")
 		if ingestUrl == "" {
-			ingestUrl = "https://ingest.signalfx.com"
+			ingestUrl = "https://ingest.signalfx.com/v1/trace"
 		}
 
 		// Create a Jaeger HTTP Thrift transport
-		transport := transport.NewHTTPTransport(ingestUrl+"/v1/trace",
+		transport := transport.NewHTTPTransport(ingestUrl,
 			transport.HTTPBasicAuth("auth", tracingToken))
 
 		// Add rate limited sampling. We will only sample [Param] requests per second

--- a/samples/gen-go-nils/server/router.go
+++ b/samples/gen-go-nils/server/router.go
@@ -13,8 +13,10 @@ import (
 	"github.com/Clever/go-process-metrics/metrics"
 	"github.com/gorilla/mux"
 	"github.com/kardianos/osext"
-	lightstep "github.com/lightstep/lightstep-tracer-go"
 	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/uber/jaeger-client-go"
+	jaegercfg "github.com/uber/jaeger-client-go/config"
+	"github.com/uber/jaeger-client-go/transport"
 	"gopkg.in/Clever/kayvee-go.v6/logger"
 	kvMiddleware "gopkg.in/Clever/kayvee-go.v6/middleware"
 	"gopkg.in/tylerb/graceful.v1"
@@ -50,18 +52,35 @@ func (s *Server) Serve() error {
 		s.l.Info("please provide a kvconfig.yml file to enable app log routing")
 	}
 
-	if lightstepToken := os.Getenv("LIGHTSTEP_ACCESS_TOKEN"); lightstepToken != "" {
-		tags := make(map[string]interface{})
-		tags[lightstep.ComponentNameKey] = "nil-test"
-		lightstepTracer := lightstep.NewTracer(lightstep.Options{
-			AccessToken: lightstepToken,
-			Tags:        tags,
-			UseGRPC:     true,
-		})
-		defer lightstep.FlushLightStepTracer(lightstepTracer)
-		opentracing.InitGlobalTracer(lightstepTracer)
+	if signalfxToken := os.Getenv("SIGNALFX_ACCESS_TOKEN"); signalfxToken != "" {
+		ingestUrl := os.Getenv("SIGNALFX_INGEST_URL")
+		if ingestUrl == "" {
+			ingestUrl = "https://ingest.signalfx.com"
+		}
+
+		// Create a Jaeger HTTP Thrift transport
+		transport := transport.NewHTTPTransport(ingestUrl+"/v1/trace",
+			transport.HTTPBasicAuth("auth", signalfxToken))
+
+		cfg, err := jaegercfg.FromEnv()
+		if err != nil {
+			log.Fatal("Could not parse Jaeger env vars: ", err.Error())
+		}
+		cfg.ServiceName = "nil-test"
+		cfg.Sampler = &jaegercfg.SamplerConfig{
+			Type:  jaeger.SamplerTypeRateLimiting,
+			Param: 500,
+		}
+
+		signalfxTracer, closer, err := cfg.NewTracer(jaegercfg.Reporter(jaeger.NewRemoteReporter(transport)))
+		if err != nil {
+			log.Fatal("Could not initialize jaeger tracer: ", err.Error())
+		}
+		defer closer.Close()
+
+		opentracing.SetGlobalTracer(signalfxTracer)
 	} else {
-		s.l.Error("please set LIGHTSTEP_ACCESS_TOKEN to enable tracing")
+		s.l.Error("please set SIGNALFX_ACCESS_TOKEN to enable tracing")
 	}
 
 	s.l.Counter("server-started")

--- a/samples/gen-go/server/router.go
+++ b/samples/gen-go/server/router.go
@@ -55,11 +55,11 @@ func (s *Server) Serve() error {
 	if tracingToken := os.Getenv("TRACING_ACCESS_TOKEN"); tracingToken != "" {
 		ingestUrl := os.Getenv("TRACING_INGEST_URL")
 		if ingestUrl == "" {
-			ingestUrl = "https://ingest.signalfx.com"
+			ingestUrl = "https://ingest.signalfx.com/v1/trace"
 		}
 
 		// Create a Jaeger HTTP Thrift transport
-		transport := transport.NewHTTPTransport(ingestUrl+"/v1/trace",
+		transport := transport.NewHTTPTransport(ingestUrl,
 			transport.HTTPBasicAuth("auth", tracingToken))
 
 		// Add rate limited sampling. We will only sample [Param] requests per second

--- a/samples/gen-go/server/router.go
+++ b/samples/gen-go/server/router.go
@@ -52,24 +52,35 @@ func (s *Server) Serve() error {
 		s.l.Info("please provide a kvconfig.yml file to enable app log routing")
 	}
 
-	if signalfxToken := os.Getenv("SIGNALFX_ACCESS_TOKEN"); signalfxToken != "" {
-		ingestUrl := os.Getenv("SIGNALFX_INGEST_URL")
+	if tracingToken := os.Getenv("TRACING_ACCESS_TOKEN"); tracingToken != "" {
+		ingestUrl := os.Getenv("TRACING_INGEST_URL")
 		if ingestUrl == "" {
 			ingestUrl = "https://ingest.signalfx.com"
 		}
 
 		// Create a Jaeger HTTP Thrift transport
 		transport := transport.NewHTTPTransport(ingestUrl+"/v1/trace",
-			transport.HTTPBasicAuth("auth", signalfxToken))
+			transport.HTTPBasicAuth("auth", tracingToken))
 
-		cfg, err := jaegercfg.FromEnv()
-		if err != nil {
-			log.Fatal("Could not parse Jaeger env vars: ", err.Error())
+		// Add rate limited sampling. We will only sample [Param] requests per second
+		// and [MaxOperations] different endpoints. Any endpoint above the [MaxOperations]
+		// limit will be probabilistically sampled.
+		cfgSampler := &jaegercfg.SamplerConfig{
+			Type:          jaeger.SamplerTypeRateLimiting,
+			Param:         5,
+			MaxOperations: 100,
 		}
-		cfg.ServiceName = "swagger-test"
-		cfg.Sampler = &jaegercfg.SamplerConfig{
-			Type:  jaeger.SamplerTypeRateLimiting,
-			Param: 500,
+		cfgTags := []opentracing.Tag{
+			opentracing.Tag{Key: "app_name", Value: os.Getenv("_APP_NAME")},
+			opentracing.Tag{Key: "build_id", Value: os.Getenv("_BUILD_ID")},
+			opentracing.Tag{Key: "deploy_env", Value: os.Getenv("_DEPLOY_ENV")},
+			opentracing.Tag{Key: "team_owner", Value: os.Getenv("_TEAM_OWNER")},
+		}
+
+		cfg := &jaegercfg.Configuration{
+			ServiceName: "swagger-test",
+			Sampler:     cfgSampler,
+			Tags:        cfgTags,
 		}
 
 		signalfxTracer, closer, err := cfg.NewTracer(jaegercfg.Reporter(jaeger.NewRemoteReporter(transport)))
@@ -80,7 +91,7 @@ func (s *Server) Serve() error {
 
 		opentracing.SetGlobalTracer(signalfxTracer)
 	} else {
-		s.l.Error("please set SIGNALFX_ACCESS_TOKEN to enable tracing")
+		s.l.Error("please set TRACING_ACCESS_TOKEN to enable tracing")
 	}
 
 	s.l.Counter("server-started")

--- a/server/gendb/bindata.go
+++ b/server/gendb/bindata.go
@@ -6,12 +6,12 @@
 //  asset-dir: true
 //  restore: true
 // sources:
-//  /home/vagrant/src/github.com/Clever/wag/server/gendb/dynamodb-local.sh.tmpl
-//  /home/vagrant/src/github.com/Clever/wag/server/gendb/dynamodb.go.tmpl
-//  /home/vagrant/src/github.com/Clever/wag/server/gendb/dynamodb_test.go.tmpl
-//  /home/vagrant/src/github.com/Clever/wag/server/gendb/interface.go.tmpl
-//  /home/vagrant/src/github.com/Clever/wag/server/gendb/table.go.tmpl
-//  /home/vagrant/src/github.com/Clever/wag/server/gendb/tests.go.tmpl
+//  /home/vagrant/go/src/github.com/Clever/wag/server/gendb/dynamodb-local.sh.tmpl
+//  /home/vagrant/go/src/github.com/Clever/wag/server/gendb/dynamodb.go.tmpl
+//  /home/vagrant/go/src/github.com/Clever/wag/server/gendb/dynamodb_test.go.tmpl
+//  /home/vagrant/go/src/github.com/Clever/wag/server/gendb/interface.go.tmpl
+//  /home/vagrant/go/src/github.com/Clever/wag/server/gendb/table.go.tmpl
+//  /home/vagrant/go/src/github.com/Clever/wag/server/gendb/tests.go.tmpl
 
 package gendb
 
@@ -86,7 +86,7 @@ var _bindata = map[string]*asset{
 			"\xe5\xe1\xe1\xd1\xfc\x09\x00\x00\xff\xff",
 		size: 602,
 		mode: 0775,
-		time: time.Unix(1535140588, 526101822),
+		time: time.Unix(1540231597, 908331216),
 	},
 	"dynamodb.go.tmpl": &asset{
 		name: "dynamodb.go.tmpl",
@@ -146,7 +146,7 @@ var _bindata = map[string]*asset{
 			"\xd3\x41\x45\x78\x6a\xbd\x99\xed\x7e\xe8\x34\xf6\x91\xfb\xf2\x9f\x00\x00\x00\xff\xff",
 		size: 6388,
 		mode: 0664,
-		time: time.Unix(1535140588, 526101822),
+		time: time.Unix(1540231597, 908331216),
 	},
 	"dynamodb_test.go.tmpl": &asset{
 		name: "dynamodb_test.go.tmpl",
@@ -190,7 +190,7 @@ var _bindata = map[string]*asset{
 			"\xd8\xc2\xbf\x2f\xc6\xb7\x58\x3c\xd2\xe0\x2d\x68\x96\xb8\x38\x88\xbf\x02\x00\x00\xff\xff",
 		size: 2094,
 		mode: 0664,
-		time: time.Unix(1535140588, 526101822),
+		time: time.Unix(1540231597, 908331216),
 	},
 	"interface.go.tmpl": &asset{
 		name: "interface.go.tmpl",
@@ -248,7 +248,7 @@ var _bindata = map[string]*asset{
 			"\xa9\x3a\xdc\x67\xb3\xc6\xcf\xbf\x02\x00\x00\xff\xff",
 		size: 6476,
 		mode: 0664,
-		time: time.Unix(1535140588, 526101822),
+		time: time.Unix(1540231597, 908331216),
 	},
 	"table.go.tmpl": &asset{
 		name: "table.go.tmpl",
@@ -372,7 +372,7 @@ var _bindata = map[string]*asset{
 			"\xff\xff",
 		size: 18062,
 		mode: 0664,
-		time: time.Unix(1535140588, 526101822),
+		time: time.Unix(1540231597, 908331216),
 	},
 	"tests.go.tmpl": &asset{
 		name: "tests.go.tmpl",
@@ -458,7 +458,7 @@ var _bindata = map[string]*asset{
 			"\x8c\xd0\xca\xb5\x1e\x15\x3a\x4b\xb3\xa8\x7c\xfb\x27\x00\x00\xff\xff",
 		size: 20564,
 		mode: 0664,
-		time: time.Unix(1535140588, 526101822),
+		time: time.Unix(1540231597, 908331216),
 	},
 }
 

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -95,24 +95,35 @@ func (s *Server) Serve() error {
 		s.l.Info("please provide a kvconfig.yml file to enable app log routing")
 	}
 
-	if signalfxToken := os.Getenv("SIGNALFX_ACCESS_TOKEN"); signalfxToken != "" {
-		ingestUrl := os.Getenv("SIGNALFX_INGEST_URL")
+	if tracingToken := os.Getenv("TRACING_ACCESS_TOKEN"); tracingToken != "" {
+		ingestUrl := os.Getenv("TRACING_INGEST_URL")
 		if ingestUrl == "" {
 			ingestUrl = "https://ingest.signalfx.com"
 		}
 
 		// Create a Jaeger HTTP Thrift transport
 		transport := transport.NewHTTPTransport(ingestUrl+"/v1/trace",
-			transport.HTTPBasicAuth("auth", signalfxToken))
+			transport.HTTPBasicAuth("auth", tracingToken))
 
-		cfg, err := jaegercfg.FromEnv()
-		if err != nil {
-			log.Fatal("Could not parse Jaeger env vars: ", err.Error())
-		}
-		cfg.ServiceName = "{{.Title}}"
-		cfg.Sampler = &jaegercfg.SamplerConfig{
+		// Add rate limited sampling. We will only sample [Param] requests per second
+		// and [MaxOperations] different endpoints. Any endpoint above the [MaxOperations]
+		// limit will be probabilistically sampled.
+		cfgSampler := &jaegercfg.SamplerConfig{
 			Type: jaeger.SamplerTypeRateLimiting,
-			Param: 500,
+			Param: 5,
+			MaxOperations: 100,
+		}
+		cfgTags := []opentracing.Tag{
+			opentracing.Tag{Key: "app_name", Value: os.Getenv("_APP_NAME")},
+			opentracing.Tag{Key: "build_id", Value: os.Getenv("_BUILD_ID")},
+			opentracing.Tag{Key: "deploy_env", Value: os.Getenv("_DEPLOY_ENV")},
+			opentracing.Tag{Key: "team_owner", Value: os.Getenv("_TEAM_OWNER")},
+		}
+
+		cfg := &jaegercfg.Configuration{
+			ServiceName: "{{.Title}}",
+			Sampler: cfgSampler,
+			Tags: cfgTags,
 		}
 
 		signalfxTracer, closer, err := cfg.NewTracer(jaegercfg.Reporter(jaeger.NewRemoteReporter(transport)))
@@ -123,7 +134,7 @@ func (s *Server) Serve() error {
 
 		opentracing.SetGlobalTracer(signalfxTracer)
 	} else {
-		s.l.Error("please set SIGNALFX_ACCESS_TOKEN to enable tracing")
+		s.l.Error("please set TRACING_ACCESS_TOKEN to enable tracing")
 	}
 
 	s.l.Counter("server-started")

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -54,13 +54,15 @@ import (
 	"path"
 
 	"github.com/gorilla/mux"
-	lightstep "github.com/lightstep/lightstep-tracer-go"
 	opentracing "github.com/opentracing/opentracing-go"
 	"gopkg.in/Clever/kayvee-go.v6/logger"
 	kvMiddleware "gopkg.in/Clever/kayvee-go.v6/middleware"
 	"gopkg.in/tylerb/graceful.v1"
 	"github.com/Clever/go-process-metrics/metrics"
 	"github.com/kardianos/osext"
+	"github.com/uber/jaeger-client-go"
+	jaegercfg "github.com/uber/jaeger-client-go/config"
+	"github.com/uber/jaeger-client-go/transport"
 )
 
 type contextKey struct{}
@@ -93,18 +95,35 @@ func (s *Server) Serve() error {
 		s.l.Info("please provide a kvconfig.yml file to enable app log routing")
 	}
 
-	if lightstepToken := os.Getenv("LIGHTSTEP_ACCESS_TOKEN"); lightstepToken != "" {
-		tags := make(map[string]interface{})
-		tags[lightstep.ComponentNameKey] = "{{.Title}}"
-		lightstepTracer := lightstep.NewTracer(lightstep.Options{
-			AccessToken: lightstepToken,
-			Tags:        tags,
-			UseGRPC:     true,
-		})
-		defer lightstep.FlushLightStepTracer(lightstepTracer)
-		opentracing.InitGlobalTracer(lightstepTracer)
+	if signalfxToken := os.Getenv("SIGNALFX_ACCESS_TOKEN"); signalfxToken != "" {
+		ingestUrl := os.Getenv("SIGNALFX_INGEST_URL")
+		if ingestUrl == "" {
+			ingestUrl = "https://ingest.signalfx.com"
+		}
+
+		// Create a Jaeger HTTP Thrift transport
+		transport := transport.NewHTTPTransport(ingestUrl+"/v1/trace",
+			transport.HTTPBasicAuth("auth", signalfxToken))
+
+		cfg, err := jaegercfg.FromEnv()
+		if err != nil {
+			log.Fatal("Could not parse Jaeger env vars: ", err.Error())
+		}
+		cfg.ServiceName = "{{.Title}}"
+		cfg.Sampler = &jaegercfg.SamplerConfig{
+			Type: jaeger.SamplerTypeRateLimiting,
+			Param: 500,
+		}
+
+		signalfxTracer, closer, err := cfg.NewTracer(jaegercfg.Reporter(jaeger.NewRemoteReporter(transport)))
+		if err != nil {
+			log.Fatal("Could not initialize jaeger tracer: ", err.Error())
+		}
+		defer closer.Close()
+
+		opentracing.SetGlobalTracer(signalfxTracer)
 	} else {
-		s.l.Error("please set LIGHTSTEP_ACCESS_TOKEN to enable tracing")
+		s.l.Error("please set SIGNALFX_ACCESS_TOKEN to enable tracing")
 	}
 
 	s.l.Counter("server-started")

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -98,11 +98,11 @@ func (s *Server) Serve() error {
 	if tracingToken := os.Getenv("TRACING_ACCESS_TOKEN"); tracingToken != "" {
 		ingestUrl := os.Getenv("TRACING_INGEST_URL")
 		if ingestUrl == "" {
-			ingestUrl = "https://ingest.signalfx.com"
+			ingestUrl = "https://ingest.signalfx.com/v1/trace"
 		}
 
 		// Create a Jaeger HTTP Thrift transport
-		transport := transport.NewHTTPTransport(ingestUrl+"/v1/trace",
+		transport := transport.NewHTTPTransport(ingestUrl,
 			transport.HTTPBasicAuth("auth", tracingToken))
 
 		// Add rate limited sampling. We will only sample [Param] requests per second


### PR DESCRIPTION
**JIRA**
https://clever.atlassian.net/browse/IL-816

**Overview**
Trying to access SignalFX as a tracing solution rather than Lightstep. This change makes instrumentation go through the Jaegar tracer built by Uber that passes to SignalFX rather than Lightstep's tracer.

**Testing**
Example traces sent to SignalFX:
https://app.signalfx.com/#/traces?startTimeUTC=1540245277000&endTimeUTC=1540252477000

**Rollout/Concerns**
* I don't know if the YML variables get updated when running 
* Need to update version