### PR TITLE
Il 816 actually add span to header

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ definitions:
 
   * Add `TRACING_ACCESS_TOKEN` to your ark-config with the access token stored in the secret store. This will automatically report tracing data to [SignalFX](https://app.signalfx.com/#/trace/).
   * By default we tag traces with `http.method`, `span.kind`, `http.url`, `http.status_code`, and `error`. For more information about what these tags mean see: https://github.com/opentracing/opentracing.io/blob/95b966bd6a6b2cf0f231260e3e1fa6206ede2151/_docs/pages/api/data-conventions.md#component-identification
+  * Pass the tracer as an option when initializing the client or on each API call to be traced
 
 ## Using the Go Client
 Initialize the client with `New`

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-v1.11.0
-- Use Jaeger client as tracer instead of Lightstep client
+v1.11.1
+- Update JS client to actually send tracing information in headers

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -343,7 +343,7 @@ var packageJSONTmplStr = `{
   "dependencies": {
     "async": "^2.1.4",
     "clever-discovery": "0.0.8",
-    "opentracing": "^0.11.1",
+    "opentracing": "^0.14.0",
     "request": "^2.87.0",
     "kayvee": "^3.8.2",
     "hystrixjs": "^0.2.0",

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -87,6 +87,7 @@ const discovery = require("clever-discovery");
 const kayvee = require("kayvee");
 const request = require("request");
 const opentracing = require("opentracing");
+const globalTracing = require("opentracing/lib/global_tracer");
 const {commandFactory} = require("hystrixjs");
 const RollingNumberEvent = require("hystrixjs/lib/metrics/RollingNumberEvent");
 
@@ -216,7 +217,7 @@ class {{.ClassName}} {
    * forever: true attribute in request. Defaults to false
    * @param {module:{{.ServiceName}}.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
-   * @param {module:kayvee.Logger} [options.logger=logger.New("{{.ServiceName}}-wagclient")] - The Kayvee 
+   * @param {module:kayvee.Logger} [options.logger=logger.New("{{.ServiceName}}-wagclient")] - The Kayvee
    * logger to use in the client.
    * @param {Object} [options.circuit] - Options for constructing the client's circuit breaker.
    * @param {bool} [options.circuit.forceClosed] - When set to true the circuit will always be closed. Default: true.
@@ -406,7 +407,8 @@ var methodTmplStr = `
   {{end}}{{end}}
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         {{- if not .IterMethod}}
         span.logEvent("{{.Method}} {{.Path}}");
         {{- end}}

--- a/samples/gen-js-blog/README.md
+++ b/samples/gen-js-blog/README.md
@@ -57,7 +57,7 @@ Create a new client object.
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. Default is 5000ms. |
 | [options.keepalive] | <code>bool</code> |  | Set keepalive to true for client requests. This sets the forever: true attribute in request. Defaults to false |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_blog--Blog.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
-| [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;blog-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
+| [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;blog-wagclient&quot;)</code> | The Kayvee logger to use in the client. |
 | [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |
 | [options.circuit.forceClosed] | <code>bool</code> |  | When set to true the circuit will always be closed. Default: true. |
 | [options.circuit.maxConcurrentRequests] | <code>number</code> |  | the maximum number of concurrent requests the client can make at the same time. Default: 100. |

--- a/samples/gen-js-blog/index.js
+++ b/samples/gen-js-blog/index.js
@@ -3,6 +3,7 @@ const discovery = require("clever-discovery");
 const kayvee = require("kayvee");
 const request = require("request");
 const opentracing = require("opentracing");
+const globalTracing = require("opentracing/lib/global_tracer");
 const {commandFactory} = require("hystrixjs");
 const RollingNumberEvent = require("hystrixjs/lib/metrics/RollingNumberEvent");
 
@@ -132,7 +133,7 @@ class Blog {
    * forever: true attribute in request. Defaults to false
    * @param {module:blog.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
-   * @param {module:kayvee.Logger} [options.logger=logger.New("blog-wagclient")] - The Kayvee 
+   * @param {module:kayvee.Logger} [options.logger=logger.New("blog-wagclient")] - The Kayvee
    * logger to use in the client.
    * @param {Object} [options.circuit] - Options for constructing the client's circuit breaker.
    * @param {bool} [options.circuit.forceClosed] - When set to true the circuit will always be closed. Default: true.
@@ -285,7 +286,8 @@ class Blog {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /students/{student_id}/sections");
         span.setTag("span.kind", "client");
       }

--- a/samples/gen-js-blog/package.json
+++ b/samples/gen-js-blog/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "async": "^2.1.4",
     "clever-discovery": "0.0.8",
-    "opentracing": "^0.11.1",
+    "opentracing": "^0.14.0",
     "request": "^2.87.0",
     "kayvee": "^3.8.2",
     "hystrixjs": "^0.2.0",

--- a/samples/gen-js-db/README.md
+++ b/samples/gen-js-db/README.md
@@ -57,7 +57,7 @@ Create a new client object.
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. Default is 5000ms. |
 | [options.keepalive] | <code>bool</code> |  | Set keepalive to true for client requests. This sets the forever: true attribute in request. Defaults to false |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
-| [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;swagger-test-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
+| [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;swagger-test-wagclient&quot;)</code> | The Kayvee logger to use in the client. |
 | [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |
 | [options.circuit.forceClosed] | <code>bool</code> |  | When set to true the circuit will always be closed. Default: true. |
 | [options.circuit.maxConcurrentRequests] | <code>number</code> |  | the maximum number of concurrent requests the client can make at the same time. Default: 100. |

--- a/samples/gen-js-db/index.js
+++ b/samples/gen-js-db/index.js
@@ -3,6 +3,7 @@ const discovery = require("clever-discovery");
 const kayvee = require("kayvee");
 const request = require("request");
 const opentracing = require("opentracing");
+const globalTracing = require("opentracing/lib/global_tracer");
 const {commandFactory} = require("hystrixjs");
 const RollingNumberEvent = require("hystrixjs/lib/metrics/RollingNumberEvent");
 
@@ -132,7 +133,7 @@ class SwaggerTest {
    * forever: true attribute in request. Defaults to false
    * @param {module:swagger-test.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
-   * @param {module:kayvee.Logger} [options.logger=logger.New("swagger-test-wagclient")] - The Kayvee 
+   * @param {module:kayvee.Logger} [options.logger=logger.New("swagger-test-wagclient")] - The Kayvee
    * logger to use in the client.
    * @param {Object} [options.circuit] - Options for constructing the client's circuit breaker.
    * @param {bool} [options.circuit.forceClosed] - When set to true the circuit will always be closed. Default: true.
@@ -278,7 +279,8 @@ class SwaggerTest {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /v1/health/check");
         span.setTag("span.kind", "client");
       }

--- a/samples/gen-js-db/index.js
+++ b/samples/gen-js-db/index.js
@@ -3,7 +3,6 @@ const discovery = require("clever-discovery");
 const kayvee = require("kayvee");
 const request = require("request");
 const opentracing = require("opentracing");
-const globalTracing = require("opentracing/lib/global_tracer");
 const {commandFactory} = require("hystrixjs");
 const RollingNumberEvent = require("hystrixjs/lib/metrics/RollingNumberEvent");
 
@@ -179,6 +178,11 @@ class SwaggerTest {
     } else {
       this.logger =  new kayvee.logger("swagger-test-wagclient");
     }
+    if (options.tracer) {
+      this.tracer = options.tracer;
+    } else {
+      this.tracer = opentracing.globalTracer();
+    }
 
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
     this._hystrixCommand = commandFactory.getOrCreate("swagger-test").
@@ -272,6 +276,7 @@ class SwaggerTest {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -280,7 +285,7 @@ class SwaggerTest {
 
       if (span) {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
-        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /v1/health/check");
         span.setTag("span.kind", "client");
       }

--- a/samples/gen-js-db/package.json
+++ b/samples/gen-js-db/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "async": "^2.1.4",
     "clever-discovery": "0.0.8",
-    "opentracing": "^0.11.1",
+    "opentracing": "^0.14.0",
     "request": "^2.87.0",
     "kayvee": "^3.8.2",
     "hystrixjs": "^0.2.0",

--- a/samples/gen-js-deprecated/README.md
+++ b/samples/gen-js-deprecated/README.md
@@ -55,7 +55,7 @@ Create a new client object.
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. Default is 5000ms. |
 | [options.keepalive] | <code>bool</code> |  | Set keepalive to true for client requests. This sets the forever: true attribute in request. Defaults to false |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
-| [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;swagger-test-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
+| [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;swagger-test-wagclient&quot;)</code> | The Kayvee logger to use in the client. |
 | [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |
 | [options.circuit.forceClosed] | <code>bool</code> |  | When set to true the circuit will always be closed. Default: true. |
 | [options.circuit.maxConcurrentRequests] | <code>number</code> |  | the maximum number of concurrent requests the client can make at the same time. Default: 100. |

--- a/samples/gen-js-deprecated/index.js
+++ b/samples/gen-js-deprecated/index.js
@@ -3,6 +3,7 @@ const discovery = require("clever-discovery");
 const kayvee = require("kayvee");
 const request = require("request");
 const opentracing = require("opentracing");
+const globalTracing = require("opentracing/lib/global_tracer");
 const {commandFactory} = require("hystrixjs");
 const RollingNumberEvent = require("hystrixjs/lib/metrics/RollingNumberEvent");
 
@@ -132,7 +133,7 @@ class SwaggerTest {
    * forever: true attribute in request. Defaults to false
    * @param {module:swagger-test.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
-   * @param {module:kayvee.Logger} [options.logger=logger.New("swagger-test-wagclient")] - The Kayvee 
+   * @param {module:kayvee.Logger} [options.logger=logger.New("swagger-test-wagclient")] - The Kayvee
    * logger to use in the client.
    * @param {Object} [options.circuit] - Options for constructing the client's circuit breaker.
    * @param {bool} [options.circuit.forceClosed] - When set to true the circuit will always be closed. Default: true.

--- a/samples/gen-js-deprecated/index.js
+++ b/samples/gen-js-deprecated/index.js
@@ -3,7 +3,6 @@ const discovery = require("clever-discovery");
 const kayvee = require("kayvee");
 const request = require("request");
 const opentracing = require("opentracing");
-const globalTracing = require("opentracing/lib/global_tracer");
 const {commandFactory} = require("hystrixjs");
 const RollingNumberEvent = require("hystrixjs/lib/metrics/RollingNumberEvent");
 
@@ -178,6 +177,11 @@ class SwaggerTest {
       this.logger = options.logger;
     } else {
       this.logger =  new kayvee.logger("swagger-test-wagclient");
+    }
+    if (options.tracer) {
+      this.tracer = options.tracer;
+    } else {
+      this.tracer = opentracing.globalTracer();
     }
 
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);

--- a/samples/gen-js-deprecated/package.json
+++ b/samples/gen-js-deprecated/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "async": "^2.1.4",
     "clever-discovery": "0.0.8",
-    "opentracing": "^0.11.1",
+    "opentracing": "^0.14.0",
     "request": "^2.87.0",
     "kayvee": "^3.8.2",
     "hystrixjs": "^0.2.0",

--- a/samples/gen-js-errors/README.md
+++ b/samples/gen-js-errors/README.md
@@ -58,7 +58,7 @@ Create a new client object.
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. Default is 5000ms. |
 | [options.keepalive] | <code>bool</code> |  | Set keepalive to true for client requests. This sets the forever: true attribute in request. Defaults to false |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
-| [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;swagger-test-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
+| [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;swagger-test-wagclient&quot;)</code> | The Kayvee logger to use in the client. |
 | [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |
 | [options.circuit.forceClosed] | <code>bool</code> |  | When set to true the circuit will always be closed. Default: true. |
 | [options.circuit.maxConcurrentRequests] | <code>number</code> |  | the maximum number of concurrent requests the client can make at the same time. Default: 100. |

--- a/samples/gen-js-errors/index.js
+++ b/samples/gen-js-errors/index.js
@@ -3,6 +3,7 @@ const discovery = require("clever-discovery");
 const kayvee = require("kayvee");
 const request = require("request");
 const opentracing = require("opentracing");
+const globalTracing = require("opentracing/lib/global_tracer");
 const {commandFactory} = require("hystrixjs");
 const RollingNumberEvent = require("hystrixjs/lib/metrics/RollingNumberEvent");
 
@@ -132,7 +133,7 @@ class SwaggerTest {
    * forever: true attribute in request. Defaults to false
    * @param {module:swagger-test.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
-   * @param {module:kayvee.Logger} [options.logger=logger.New("swagger-test-wagclient")] - The Kayvee 
+   * @param {module:kayvee.Logger} [options.logger=logger.New("swagger-test-wagclient")] - The Kayvee
    * logger to use in the client.
    * @param {Object} [options.circuit] - Options for constructing the client's circuit breaker.
    * @param {bool} [options.circuit.forceClosed] - When set to true the circuit will always be closed. Default: true.
@@ -285,7 +286,8 @@ class SwaggerTest {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /v1/books/{id}");
         span.setTag("span.kind", "client");
       }

--- a/samples/gen-js-errors/index.js
+++ b/samples/gen-js-errors/index.js
@@ -3,7 +3,6 @@ const discovery = require("clever-discovery");
 const kayvee = require("kayvee");
 const request = require("request");
 const opentracing = require("opentracing");
-const globalTracing = require("opentracing/lib/global_tracer");
 const {commandFactory} = require("hystrixjs");
 const RollingNumberEvent = require("hystrixjs/lib/metrics/RollingNumberEvent");
 
@@ -179,6 +178,11 @@ class SwaggerTest {
     } else {
       this.logger =  new kayvee.logger("swagger-test-wagclient");
     }
+    if (options.tracer) {
+      this.tracer = options.tracer;
+    } else {
+      this.tracer = opentracing.globalTracer();
+    }
 
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
     this._hystrixCommand = commandFactory.getOrCreate("swagger-test").
@@ -275,6 +279,7 @@ class SwaggerTest {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -287,7 +292,7 @@ class SwaggerTest {
 
       if (span) {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
-        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /v1/books/{id}");
         span.setTag("span.kind", "client");
       }

--- a/samples/gen-js-errors/package.json
+++ b/samples/gen-js-errors/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "async": "^2.1.4",
     "clever-discovery": "0.0.8",
-    "opentracing": "^0.11.1",
+    "opentracing": "^0.14.0",
     "request": "^2.87.0",
     "kayvee": "^3.8.2",
     "hystrixjs": "^0.2.0",

--- a/samples/gen-js-nils/README.md
+++ b/samples/gen-js-nils/README.md
@@ -57,7 +57,7 @@ Create a new client object.
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. Default is 5000ms. |
 | [options.keepalive] | <code>bool</code> |  | Set keepalive to true for client requests. This sets the forever: true attribute in request. Defaults to false |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_nil-test--NilTest.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
-| [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;nil-test-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
+| [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;nil-test-wagclient&quot;)</code> | The Kayvee logger to use in the client. |
 | [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |
 | [options.circuit.forceClosed] | <code>bool</code> |  | When set to true the circuit will always be closed. Default: true. |
 | [options.circuit.maxConcurrentRequests] | <code>number</code> |  | the maximum number of concurrent requests the client can make at the same time. Default: 100. |

--- a/samples/gen-js-nils/index.js
+++ b/samples/gen-js-nils/index.js
@@ -3,6 +3,7 @@ const discovery = require("clever-discovery");
 const kayvee = require("kayvee");
 const request = require("request");
 const opentracing = require("opentracing");
+const globalTracing = require("opentracing/lib/global_tracer");
 const {commandFactory} = require("hystrixjs");
 const RollingNumberEvent = require("hystrixjs/lib/metrics/RollingNumberEvent");
 
@@ -132,7 +133,7 @@ class NilTest {
    * forever: true attribute in request. Defaults to false
    * @param {module:nil-test.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
-   * @param {module:kayvee.Logger} [options.logger=logger.New("nil-test-wagclient")] - The Kayvee 
+   * @param {module:kayvee.Logger} [options.logger=logger.New("nil-test-wagclient")] - The Kayvee
    * logger to use in the client.
    * @param {Object} [options.circuit] - Options for constructing the client's circuit breaker.
    * @param {bool} [options.circuit.forceClosed] - When set to true the circuit will always be closed. Default: true.
@@ -296,7 +297,8 @@ class NilTest {
   
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("POST /v1/check/{id}");
         span.setTag("span.kind", "client");
       }

--- a/samples/gen-js-nils/package.json
+++ b/samples/gen-js-nils/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "async": "^2.1.4",
     "clever-discovery": "0.0.8",
-    "opentracing": "^0.11.1",
+    "opentracing": "^0.14.0",
     "request": "^2.87.0",
     "kayvee": "^3.8.2",
     "hystrixjs": "^0.2.0",

--- a/samples/gen-js/README.md
+++ b/samples/gen-js/README.md
@@ -69,7 +69,7 @@ Create a new client object.
 | [options.timeout] | <code>number</code> |  | The timeout to use for all client requests, in milliseconds. This can be overridden on a per-request basis. Default is 5000ms. |
 | [options.keepalive] | <code>bool</code> |  | Set keepalive to true for client requests. This sets the forever: true attribute in request. Defaults to false |
 | [options.retryPolicy] | <code>[RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)</code> | <code>RetryPolicies.Single</code> | The logic to determine which requests to retry, as well as how many times to retry. |
-| [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;swagger-test-wagclient&quot;)</code> | The Kayvee  logger to use in the client. |
+| [options.logger] | <code>module:kayvee.Logger</code> | <code>logger.New(&quot;swagger-test-wagclient&quot;)</code> | The Kayvee logger to use in the client. |
 | [options.circuit] | <code>Object</code> |  | Options for constructing the client's circuit breaker. |
 | [options.circuit.forceClosed] | <code>bool</code> |  | When set to true the circuit will always be closed. Default: true. |
 | [options.circuit.maxConcurrentRequests] | <code>number</code> |  | the maximum number of concurrent requests the client can make at the same time. Default: 100. |

--- a/samples/gen-js/index.js
+++ b/samples/gen-js/index.js
@@ -3,7 +3,6 @@ const discovery = require("clever-discovery");
 const kayvee = require("kayvee");
 const request = require("request");
 const opentracing = require("opentracing");
-const globalTracing = require("opentracing/lib/global_tracer");
 const {commandFactory} = require("hystrixjs");
 const RollingNumberEvent = require("hystrixjs/lib/metrics/RollingNumberEvent");
 
@@ -179,6 +178,11 @@ class SwaggerTest {
     } else {
       this.logger =  new kayvee.logger("swagger-test-wagclient");
     }
+    if (options.tracer) {
+      this.tracer = options.tracer;
+    } else {
+      this.tracer = opentracing.globalTracer();
+    }
 
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
     this._hystrixCommand = commandFactory.getOrCreate("swagger-test").
@@ -274,6 +278,7 @@ class SwaggerTest {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -290,7 +295,7 @@ class SwaggerTest {
 
       if (span) {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
-        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /v1/authors");
         span.setTag("span.kind", "client");
       }
@@ -393,6 +398,7 @@ class SwaggerTest {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -409,7 +415,7 @@ class SwaggerTest {
 
       if (span) {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
-        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.setTag("span.kind", "client");
       }
 
@@ -560,6 +566,7 @@ class SwaggerTest {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -576,7 +583,7 @@ class SwaggerTest {
 
       if (span) {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
-        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("PUT /v1/authors");
         span.setTag("span.kind", "client");
       }
@@ -682,6 +689,7 @@ class SwaggerTest {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -698,7 +706,7 @@ class SwaggerTest {
 
       if (span) {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
-        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.setTag("span.kind", "client");
       }
 
@@ -859,6 +867,7 @@ class SwaggerTest {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -908,7 +917,7 @@ class SwaggerTest {
 
       if (span) {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
-        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /v1/books");
         span.setTag("span.kind", "client");
       }
@@ -1020,6 +1029,7 @@ class SwaggerTest {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -1069,7 +1079,7 @@ class SwaggerTest {
 
       if (span) {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
-        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.setTag("span.kind", "client");
       }
 
@@ -1220,6 +1230,7 @@ class SwaggerTest {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -1228,7 +1239,7 @@ class SwaggerTest {
 
       if (span) {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
-        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("POST /v1/books");
         span.setTag("span.kind", "client");
       }
@@ -1343,6 +1354,7 @@ class SwaggerTest {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -1351,7 +1363,7 @@ class SwaggerTest {
 
       if (span) {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
-        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("PUT /v1/books");
         span.setTag("span.kind", "client");
       }
@@ -1470,6 +1482,7 @@ class SwaggerTest {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -1492,7 +1505,7 @@ class SwaggerTest {
 
       if (span) {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
-        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /v1/books/{book_id}");
         span.setTag("span.kind", "client");
       }
@@ -1618,6 +1631,7 @@ class SwaggerTest {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -1630,7 +1644,7 @@ class SwaggerTest {
 
       if (span) {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
-        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /v1/books2/{id}");
         span.setTag("span.kind", "client");
       }
@@ -1746,6 +1760,7 @@ class SwaggerTest {
       }
 
       const timeout = options.timeout || this.timeout;
+      const tracer = options.tracer || this.tracer;
       const span = options.span;
 
       const headers = {};
@@ -1754,7 +1769,7 @@ class SwaggerTest {
 
       if (span) {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
-        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
+        tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /v1/health/check");
         span.setTag("span.kind", "client");
       }

--- a/samples/gen-js/index.js
+++ b/samples/gen-js/index.js
@@ -3,6 +3,7 @@ const discovery = require("clever-discovery");
 const kayvee = require("kayvee");
 const request = require("request");
 const opentracing = require("opentracing");
+const globalTracing = require("opentracing/lib/global_tracer");
 const {commandFactory} = require("hystrixjs");
 const RollingNumberEvent = require("hystrixjs/lib/metrics/RollingNumberEvent");
 
@@ -132,7 +133,7 @@ class SwaggerTest {
    * forever: true attribute in request. Defaults to false
    * @param {module:swagger-test.RetryPolicies} [options.retryPolicy=RetryPolicies.Single] - The logic to
    * determine which requests to retry, as well as how many times to retry.
-   * @param {module:kayvee.Logger} [options.logger=logger.New("swagger-test-wagclient")] - The Kayvee 
+   * @param {module:kayvee.Logger} [options.logger=logger.New("swagger-test-wagclient")] - The Kayvee
    * logger to use in the client.
    * @param {Object} [options.circuit] - Options for constructing the client's circuit breaker.
    * @param {bool} [options.circuit.forceClosed] - When set to true the circuit will always be closed. Default: true.
@@ -288,7 +289,8 @@ class SwaggerTest {
   
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /v1/authors");
         span.setTag("span.kind", "client");
       }
@@ -406,7 +408,8 @@ class SwaggerTest {
   
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.setTag("span.kind", "client");
       }
 
@@ -572,7 +575,8 @@ class SwaggerTest {
   
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("PUT /v1/authors");
         span.setTag("span.kind", "client");
       }
@@ -693,7 +697,8 @@ class SwaggerTest {
   
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.setTag("span.kind", "client");
       }
 
@@ -902,7 +907,8 @@ class SwaggerTest {
   
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /v1/books");
         span.setTag("span.kind", "client");
       }
@@ -1062,7 +1068,8 @@ class SwaggerTest {
   
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.setTag("span.kind", "client");
       }
 
@@ -1220,7 +1227,8 @@ class SwaggerTest {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("POST /v1/books");
         span.setTag("span.kind", "client");
       }
@@ -1342,7 +1350,8 @@ class SwaggerTest {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("PUT /v1/books");
         span.setTag("span.kind", "client");
       }
@@ -1482,7 +1491,8 @@ class SwaggerTest {
   
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /v1/books/{book_id}");
         span.setTag("span.kind", "client");
       }
@@ -1619,7 +1629,8 @@ class SwaggerTest {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /v1/books2/{id}");
         span.setTag("span.kind", "client");
       }
@@ -1742,7 +1753,8 @@ class SwaggerTest {
       const query = {};
 
       if (span) {
-        opentracing.inject(span, opentracing.FORMAT_TEXT_MAP, headers);
+        // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
+        globalTracing.globalTracer().inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.logEvent("GET /v1/health/check");
         span.setTag("span.kind", "client");
       }

--- a/samples/gen-js/package.json
+++ b/samples/gen-js/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "async": "^2.1.4",
     "clever-discovery": "0.0.8",
-    "opentracing": "^0.11.1",
+    "opentracing": "^0.14.0",
     "request": "^2.87.0",
     "kayvee": "^3.8.2",
     "hystrixjs": "^0.2.0",


### PR DESCRIPTION
https://clever.atlassian.net/browse/IL-816

The `opentracing.inject` function wasn't actually injecting the span into the header -- we need to get the tracer before attempting to inject.

Tested this by modifying the app-service client code in oauth, inserting log messages in both the client library and in the app-service server. Verified the trace ID was being passed into the header and it was parsed on the server side.