### PR TITLE
Il 899 finish spans

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
-v1.13.2
-- DynamoDB codegen supports scans
+v1.13.3
+- Close spans in WAG client after initializing them

--- a/_hardcoded/doer.go
+++ b/_hardcoded/doer.go
@@ -58,6 +58,7 @@ func (d tracingDoer) Do(c *http.Client, r *http.Request) (*http.Response, error)
 		opentracing.HTTPHeadersCarrier(r.Header)); err != nil {
 		return nil, fmt.Errorf("couldn't inject tracing headers (%v)", err)
 	}
+	defer sp.Finish()
 	return d.d.Do(c, r)
 }
 

--- a/samples/gen-go-blog/client/doer.go
+++ b/samples/gen-go-blog/client/doer.go
@@ -58,6 +58,7 @@ func (d tracingDoer) Do(c *http.Client, r *http.Request) (*http.Response, error)
 		opentracing.HTTPHeadersCarrier(r.Header)); err != nil {
 		return nil, fmt.Errorf("couldn't inject tracing headers (%v)", err)
 	}
+	defer sp.Finish()
 	return d.d.Do(c, r)
 }
 

--- a/samples/gen-go-db/client/doer.go
+++ b/samples/gen-go-db/client/doer.go
@@ -58,6 +58,7 @@ func (d tracingDoer) Do(c *http.Client, r *http.Request) (*http.Response, error)
 		opentracing.HTTPHeadersCarrier(r.Header)); err != nil {
 		return nil, fmt.Errorf("couldn't inject tracing headers (%v)", err)
 	}
+	defer sp.Finish()
 	return d.d.Do(c, r)
 }
 

--- a/samples/gen-go-deprecated/client/doer.go
+++ b/samples/gen-go-deprecated/client/doer.go
@@ -58,6 +58,7 @@ func (d tracingDoer) Do(c *http.Client, r *http.Request) (*http.Response, error)
 		opentracing.HTTPHeadersCarrier(r.Header)); err != nil {
 		return nil, fmt.Errorf("couldn't inject tracing headers (%v)", err)
 	}
+	defer sp.Finish()
 	return d.d.Do(c, r)
 }
 

--- a/samples/gen-go-errors/client/doer.go
+++ b/samples/gen-go-errors/client/doer.go
@@ -58,6 +58,7 @@ func (d tracingDoer) Do(c *http.Client, r *http.Request) (*http.Response, error)
 		opentracing.HTTPHeadersCarrier(r.Header)); err != nil {
 		return nil, fmt.Errorf("couldn't inject tracing headers (%v)", err)
 	}
+	defer sp.Finish()
 	return d.d.Do(c, r)
 }
 

--- a/samples/gen-go-nils/client/doer.go
+++ b/samples/gen-go-nils/client/doer.go
@@ -58,6 +58,7 @@ func (d tracingDoer) Do(c *http.Client, r *http.Request) (*http.Response, error)
 		opentracing.HTTPHeadersCarrier(r.Header)); err != nil {
 		return nil, fmt.Errorf("couldn't inject tracing headers (%v)", err)
 	}
+	defer sp.Finish()
 	return d.d.Do(c, r)
 }
 

--- a/samples/gen-go/client/doer.go
+++ b/samples/gen-go/client/doer.go
@@ -58,6 +58,7 @@ func (d tracingDoer) Do(c *http.Client, r *http.Request) (*http.Response, error)
 		opentracing.HTTPHeadersCarrier(r.Header)); err != nil {
 		return nil, fmt.Errorf("couldn't inject tracing headers (%v)", err)
 	}
+	defer sp.Finish()
 	return d.d.Do(c, r)
 }
 


### PR DESCRIPTION
Previous implementation of traces were not finishing spans from the client-side. This change fixes that by finishing the spans