### PR TITLE
Address JS client code callback bugs

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,3 @@
-v3.0.1
-- Check empty hash key in DynamoDB input
+v3.0.2
+- [JS client code] Apply provided callback, if any, to circuit-breaker errors
+- [JS client code] Don't return a rejected promise if provided callback handles it

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -178,6 +178,21 @@ function responseLog(logger, req, res, err) {
 }
 
 /**
+ * Takes a promise and uses the provided callback (if any) to handle promise
+ * resolutions and rejections
+ */
+function applyCallback(promise, cb) {
+  if (!cb) {
+    return promise;
+  }
+  return promise.then((result) => {
+    cb(null, result);
+  }).catch((err) => {
+    cb(err);
+  });
+}
+
+/**
  * Default circuit breaker options.
  * @alias module:{{.ServiceName}}.DefaultCircuitOptions
  */
@@ -359,29 +374,14 @@ var packageJSONTmplStr = `{
 var methodTmplStr = `
   {{.MethodDefinition}}
     {{if .IterMethod -}}
-    const it = (f, saveResults, cb) => new Promise((resolve, reject) => {
+    const it = (f, saveResults) => new Promise((resolve, reject) => {
     {{- else -}}
     if (!cb && typeof options === "function") {
-      cb = options;
       options = undefined;
     }
 
     return new Promise((resolve, reject) => {
     {{- end}}
-      const rejecter = (err) => {
-        reject(err);
-        if (cb) {
-          cb(err);
-        }
-      };
-      const resolver = (data) => {
-        resolve(data);
-        if (cb) {
-          cb(null, data);
-        }
-      };
-
-
       if (!options) {
         options = {};
       }
@@ -393,7 +393,7 @@ var methodTmplStr = `
       const headers = {};
       {{- range $param := .PathParams}}
       if (!params.{{$param.JSName}}) {
-        rejecter(new Error("{{$param.JSName}} must be non-empty because it's a path parameter"));
+        reject(new Error("{{$param.JSName}} must be non-empty because it's a path parameter"));
         return;
       }
       {{- end -}}
@@ -420,7 +420,7 @@ var methodTmplStr = `
         span.setTag("span.kind", "client");
       }
 
-	  const requestOptions = {
+      const requestOptions = {
         method: "{{.Method}}",
         uri: this.address + "{{.PathCode}}",
         json: true,
@@ -462,7 +462,7 @@ var methodTmplStr = `
             err._fromRequest = true;
             responseLog(logger, requestOptions, response, err)
             {{- if not .IterMethod}}
-            rejecter(err);
+            reject(err);
             {{- else}}
             cbW(err);
             {{- end}}
@@ -474,13 +474,13 @@ var methodTmplStr = `
               var err = new Errors.{{ $response.Name }}(body || {});
               responseLog(logger, requestOptions, response, err);
               {{- if not $.IterMethod}}
-              rejecter(err);
+              reject(err);
               {{- else}}
               cbW(err);
               {{- end}}
               return;
             {{else}}{{if $response.IsNoData}}
-              resolver();
+              resolve();
               break;
             {{else}}
               {{if $.IterMethod -}}
@@ -490,7 +490,7 @@ var methodTmplStr = `
                 body{{$.IterResourceAccessString}}.forEach(f);
               }
               {{- else -}}
-              resolver(body);
+              resolve(body);
               {{- end}}
               break;
             {{end}}{{end}}
@@ -498,7 +498,7 @@ var methodTmplStr = `
               var err = new Error("Received unexpected statusCode " + response.statusCode);
               responseLog(logger, requestOptions, response, err);
               {{- if not .IterMethod}}
-              rejecter(err);
+              reject(err);
               {{- else}}
               cbW(err);
               {{- end}}
@@ -522,13 +522,13 @@ var methodTmplStr = `
         },
         err => {
           if (err) {
-            rejecter(err);
+            reject(err);
             return;
           }
           if (saveResults) {
-            resolver(results);
+            resolve(results);
           } else {
-            resolver();
+            resolve();
           }
         }
       );
@@ -538,9 +538,9 @@ var methodTmplStr = `
     {{- if .IterMethod}}
 
     return {
-      map: (f, cb) => this._hystrixCommand.execute(it, [f, true, cb]),
-      toArray: cb => this._hystrixCommand.execute(it, [x => x, true, cb]),
-      forEach: (f, cb) => this._hystrixCommand.execute(it, [f, false, cb]),
+      map: (f, cb) => applyCallback(this._hystrixCommand.execute(it, [f, true]), cb),
+      toArray: cb => applyCallback(this._hystrixCommand.execute(it, [x => x, true]), cb),
+      forEach: (f, cb) => applyCallback(this._hystrixCommand.execute(it, [f, false]), cb),
     };
     {{- end}}
   }
@@ -569,8 +569,13 @@ var singleParamMethodDefinitionTemplateString = `/**{{if .Description}}
   {{.MethodName}}({{range $param := .Params}}{{$param.JSName}}, {{end}}options) {
   {{- else}}
   {{.MethodName}}({{range $param := .Params}}{{$param.JSName}}, {{end}}options, cb) {
-    return this._hystrixCommand.execute(this._{{.MethodName}}, arguments);
+    let callback = cb;
+    if (!cb && typeof options === "function") {
+      callback = options;
+    }
+    return applyCallback(this._hystrixCommand.execute(this._{{.MethodName}}, arguments), callback);
   }
+
   _{{.MethodName}}({{range $param := .Params}}{{$param.JSName}}, {{end}}options, cb) {
   {{- end}}
     const params = {};{{range $param := .Params}}
@@ -601,8 +606,13 @@ var pluralParamMethodDefinitionTemplateString = `/**{{if .Description}}
   {{.MethodName}}(params, options) {
   {{- else}}
   {{.MethodName}}(params, options, cb) {
-    return this._hystrixCommand.execute(this._{{.MethodName}}, arguments);
+    let callback = cb;
+    if (!cb && typeof options === "function") {
+      callback = options;
+    }
+    return applyCallback(this._hystrixCommand.execute(this._{{.MethodName}}, arguments), callback);
   }
+
   _{{.MethodName}}(params, options, cb) {
   {{- end}}`
 

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -158,6 +158,7 @@ const noRetryPolicy = {
  * Request status log is used to
  * to output the status of a request returned
  * by the client.
+ * @private
  */
 function responseLog(logger, req, res, err) {
   var res = res || { };
@@ -180,6 +181,7 @@ function responseLog(logger, req, res, err) {
 /**
  * Takes a promise and uses the provided callback (if any) to handle promise
  * resolutions and rejections
+ * @private
  */
 function applyCallback(promise, cb) {
   if (!cb) {

--- a/samples/gen-js-blog/README.md
+++ b/samples/gen-js-blog/README.md
@@ -14,6 +14,10 @@
 to output the status of a request returned
 by the client.</p>
 </dd>
+<dt><a href="#applyCallback">applyCallback()</a></dt>
+<dd><p>Takes a promise and uses the provided callback (if any) to handle promise
+resolutions and rejections</p>
+</dd>
 </dl>
 
 <a name="module_blog"></a>
@@ -164,5 +168,12 @@ Default circuit breaker options.
 Request status log is used to
 to output the status of a request returned
 by the client.
+
+**Kind**: global function  
+<a name="applyCallback"></a>
+
+## applyCallback()
+Takes a promise and uses the provided callback (if any) to handle promise
+resolutions and rejections
 
 **Kind**: global function  

--- a/samples/gen-js-blog/README.md
+++ b/samples/gen-js-blog/README.md
@@ -1,25 +1,3 @@
-## Modules
-
-<dl>
-<dt><a href="#module_blog">blog</a></dt>
-<dd><p>blog client library.</p>
-</dd>
-</dl>
-
-## Functions
-
-<dl>
-<dt><a href="#responseLog">responseLog()</a></dt>
-<dd><p>Request status log is used to
-to output the status of a request returned
-by the client.</p>
-</dd>
-<dt><a href="#applyCallback">applyCallback()</a></dt>
-<dd><p>Takes a promise and uses the provided callback (if any) to handle promise
-resolutions and rejections</p>
-</dd>
-</dl>
-
 <a name="module_blog"></a>
 
 ## blog
@@ -162,18 +140,3 @@ InternalError
 Default circuit breaker options.
 
 **Kind**: static constant of <code>[Blog](#exp_module_blog--Blog)</code>  
-<a name="responseLog"></a>
-
-## responseLog()
-Request status log is used to
-to output the status of a request returned
-by the client.
-
-**Kind**: global function  
-<a name="applyCallback"></a>
-
-## applyCallback()
-Takes a promise and uses the provided callback (if any) to handle promise
-resolutions and rejections
-
-**Kind**: global function  

--- a/samples/gen-js-blog/index.js
+++ b/samples/gen-js-blog/index.js
@@ -74,6 +74,7 @@ const noRetryPolicy = {
  * Request status log is used to
  * to output the status of a request returned
  * by the client.
+ * @private
  */
 function responseLog(logger, req, res, err) {
   var res = res || { };
@@ -96,6 +97,7 @@ function responseLog(logger, req, res, err) {
 /**
  * Takes a promise and uses the provided callback (if any) to handle promise
  * resolutions and rejections
+ * @private
  */
 function applyCallback(promise, cb) {
   if (!cb) {

--- a/samples/gen-js-db/README.md
+++ b/samples/gen-js-db/README.md
@@ -1,25 +1,3 @@
-## Modules
-
-<dl>
-<dt><a href="#module_swagger-test">swagger-test</a></dt>
-<dd><p>swagger-test client library.</p>
-</dd>
-</dl>
-
-## Functions
-
-<dl>
-<dt><a href="#responseLog">responseLog()</a></dt>
-<dd><p>Request status log is used to
-to output the status of a request returned
-by the client.</p>
-</dd>
-<dt><a href="#applyCallback">applyCallback()</a></dt>
-<dd><p>Takes a promise and uses the provided callback (if any) to handle promise
-resolutions and rejections</p>
-</dd>
-</dl>
-
 <a name="module_swagger-test"></a>
 
 ## swagger-test
@@ -159,18 +137,3 @@ InternalError
 Default circuit breaker options.
 
 **Kind**: static constant of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
-<a name="responseLog"></a>
-
-## responseLog()
-Request status log is used to
-to output the status of a request returned
-by the client.
-
-**Kind**: global function  
-<a name="applyCallback"></a>
-
-## applyCallback()
-Takes a promise and uses the provided callback (if any) to handle promise
-resolutions and rejections
-
-**Kind**: global function  

--- a/samples/gen-js-db/README.md
+++ b/samples/gen-js-db/README.md
@@ -14,6 +14,10 @@
 to output the status of a request returned
 by the client.</p>
 </dd>
+<dt><a href="#applyCallback">applyCallback()</a></dt>
+<dd><p>Takes a promise and uses the provided callback (if any) to handle promise
+resolutions and rejections</p>
+</dd>
 </dl>
 
 <a name="module_swagger-test"></a>
@@ -161,5 +165,12 @@ Default circuit breaker options.
 Request status log is used to
 to output the status of a request returned
 by the client.
+
+**Kind**: global function  
+<a name="applyCallback"></a>
+
+## applyCallback()
+Takes a promise and uses the provided callback (if any) to handle promise
+resolutions and rejections
 
 **Kind**: global function  

--- a/samples/gen-js-db/index.js
+++ b/samples/gen-js-db/index.js
@@ -74,6 +74,7 @@ const noRetryPolicy = {
  * Request status log is used to
  * to output the status of a request returned
  * by the client.
+ * @private
  */
 function responseLog(logger, req, res, err) {
   var res = res || { };
@@ -96,6 +97,7 @@ function responseLog(logger, req, res, err) {
 /**
  * Takes a promise and uses the provided callback (if any) to handle promise
  * resolutions and rejections
+ * @private
  */
 function applyCallback(promise, cb) {
   if (!cb) {

--- a/samples/gen-js-deprecated/README.md
+++ b/samples/gen-js-deprecated/README.md
@@ -1,25 +1,3 @@
-## Modules
-
-<dl>
-<dt><a href="#module_swagger-test">swagger-test</a></dt>
-<dd><p>swagger-test client library.</p>
-</dd>
-</dl>
-
-## Functions
-
-<dl>
-<dt><a href="#responseLog">responseLog()</a></dt>
-<dd><p>Request status log is used to
-to output the status of a request returned
-by the client.</p>
-</dd>
-<dt><a href="#applyCallback">applyCallback()</a></dt>
-<dd><p>Takes a promise and uses the provided callback (if any) to handle promise
-resolutions and rejections</p>
-</dd>
-</dl>
-
 <a name="module_swagger-test"></a>
 
 ## swagger-test
@@ -154,18 +132,3 @@ InternalError
 Default circuit breaker options.
 
 **Kind**: static constant of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
-<a name="responseLog"></a>
-
-## responseLog()
-Request status log is used to
-to output the status of a request returned
-by the client.
-
-**Kind**: global function  
-<a name="applyCallback"></a>
-
-## applyCallback()
-Takes a promise and uses the provided callback (if any) to handle promise
-resolutions and rejections
-
-**Kind**: global function  

--- a/samples/gen-js-deprecated/README.md
+++ b/samples/gen-js-deprecated/README.md
@@ -14,6 +14,10 @@
 to output the status of a request returned
 by the client.</p>
 </dd>
+<dt><a href="#applyCallback">applyCallback()</a></dt>
+<dd><p>Takes a promise and uses the provided callback (if any) to handle promise
+resolutions and rejections</p>
+</dd>
 </dl>
 
 <a name="module_swagger-test"></a>
@@ -156,5 +160,12 @@ Default circuit breaker options.
 Request status log is used to
 to output the status of a request returned
 by the client.
+
+**Kind**: global function  
+<a name="applyCallback"></a>
+
+## applyCallback()
+Takes a promise and uses the provided callback (if any) to handle promise
+resolutions and rejections
 
 **Kind**: global function  

--- a/samples/gen-js-deprecated/index.js
+++ b/samples/gen-js-deprecated/index.js
@@ -74,6 +74,7 @@ const noRetryPolicy = {
  * Request status log is used to
  * to output the status of a request returned
  * by the client.
+ * @private
  */
 function responseLog(logger, req, res, err) {
   var res = res || { };
@@ -96,6 +97,7 @@ function responseLog(logger, req, res, err) {
 /**
  * Takes a promise and uses the provided callback (if any) to handle promise
  * resolutions and rejections
+ * @private
  */
 function applyCallback(promise, cb) {
   if (!cb) {

--- a/samples/gen-js-deprecated/index.js
+++ b/samples/gen-js-deprecated/index.js
@@ -94,6 +94,21 @@ function responseLog(logger, req, res, err) {
 }
 
 /**
+ * Takes a promise and uses the provided callback (if any) to handle promise
+ * resolutions and rejections
+ */
+function applyCallback(promise, cb) {
+  if (!cb) {
+    return promise;
+  }
+  return promise.then((result) => {
+    cb(null, result);
+  }).catch((err) => {
+    cb(err);
+  });
+}
+
+/**
  * Default circuit breaker options.
  * @alias module:swagger-test.DefaultCircuitOptions
  */

--- a/samples/gen-js-errors/README.md
+++ b/samples/gen-js-errors/README.md
@@ -1,25 +1,3 @@
-## Modules
-
-<dl>
-<dt><a href="#module_swagger-test">swagger-test</a></dt>
-<dd><p>swagger-test client library.</p>
-</dd>
-</dl>
-
-## Functions
-
-<dl>
-<dt><a href="#responseLog">responseLog()</a></dt>
-<dd><p>Request status log is used to
-to output the status of a request returned
-by the client.</p>
-</dd>
-<dt><a href="#applyCallback">applyCallback()</a></dt>
-<dd><p>Takes a promise and uses the provided callback (if any) to handle promise
-resolutions and rejections</p>
-</dd>
-</dl>
-
 <a name="module_swagger-test"></a>
 
 ## swagger-test
@@ -178,18 +156,3 @@ InternalError
 Default circuit breaker options.
 
 **Kind**: static constant of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
-<a name="responseLog"></a>
-
-## responseLog()
-Request status log is used to
-to output the status of a request returned
-by the client.
-
-**Kind**: global function  
-<a name="applyCallback"></a>
-
-## applyCallback()
-Takes a promise and uses the provided callback (if any) to handle promise
-resolutions and rejections
-
-**Kind**: global function  

--- a/samples/gen-js-errors/README.md
+++ b/samples/gen-js-errors/README.md
@@ -14,6 +14,10 @@
 to output the status of a request returned
 by the client.</p>
 </dd>
+<dt><a href="#applyCallback">applyCallback()</a></dt>
+<dd><p>Takes a promise and uses the provided callback (if any) to handle promise
+resolutions and rejections</p>
+</dd>
 </dl>
 
 <a name="module_swagger-test"></a>
@@ -180,5 +184,12 @@ Default circuit breaker options.
 Request status log is used to
 to output the status of a request returned
 by the client.
+
+**Kind**: global function  
+<a name="applyCallback"></a>
+
+## applyCallback()
+Takes a promise and uses the provided callback (if any) to handle promise
+resolutions and rejections
 
 **Kind**: global function  

--- a/samples/gen-js-errors/index.js
+++ b/samples/gen-js-errors/index.js
@@ -74,6 +74,7 @@ const noRetryPolicy = {
  * Request status log is used to
  * to output the status of a request returned
  * by the client.
+ * @private
  */
 function responseLog(logger, req, res, err) {
   var res = res || { };
@@ -96,6 +97,7 @@ function responseLog(logger, req, res, err) {
 /**
  * Takes a promise and uses the provided callback (if any) to handle promise
  * resolutions and rejections
+ * @private
  */
 function applyCallback(promise, cb) {
   if (!cb) {

--- a/samples/gen-js-nils/README.md
+++ b/samples/gen-js-nils/README.md
@@ -14,6 +14,10 @@
 to output the status of a request returned
 by the client.</p>
 </dd>
+<dt><a href="#applyCallback">applyCallback()</a></dt>
+<dd><p>Takes a promise and uses the provided callback (if any) to handle promise
+resolutions and rejections</p>
+</dd>
 </dl>
 
 <a name="module_nil-test"></a>
@@ -169,5 +173,12 @@ Default circuit breaker options.
 Request status log is used to
 to output the status of a request returned
 by the client.
+
+**Kind**: global function  
+<a name="applyCallback"></a>
+
+## applyCallback()
+Takes a promise and uses the provided callback (if any) to handle promise
+resolutions and rejections
 
 **Kind**: global function  

--- a/samples/gen-js-nils/README.md
+++ b/samples/gen-js-nils/README.md
@@ -1,25 +1,3 @@
-## Modules
-
-<dl>
-<dt><a href="#module_nil-test">nil-test</a></dt>
-<dd><p>nil-test client library.</p>
-</dd>
-</dl>
-
-## Functions
-
-<dl>
-<dt><a href="#responseLog">responseLog()</a></dt>
-<dd><p>Request status log is used to
-to output the status of a request returned
-by the client.</p>
-</dd>
-<dt><a href="#applyCallback">applyCallback()</a></dt>
-<dd><p>Takes a promise and uses the provided callback (if any) to handle promise
-resolutions and rejections</p>
-</dd>
-</dl>
-
 <a name="module_nil-test"></a>
 
 ## nil-test
@@ -167,18 +145,3 @@ InternalError
 Default circuit breaker options.
 
 **Kind**: static constant of <code>[NilTest](#exp_module_nil-test--NilTest)</code>  
-<a name="responseLog"></a>
-
-## responseLog()
-Request status log is used to
-to output the status of a request returned
-by the client.
-
-**Kind**: global function  
-<a name="applyCallback"></a>
-
-## applyCallback()
-Takes a promise and uses the provided callback (if any) to handle promise
-resolutions and rejections
-
-**Kind**: global function  

--- a/samples/gen-js-nils/index.js
+++ b/samples/gen-js-nils/index.js
@@ -74,6 +74,7 @@ const noRetryPolicy = {
  * Request status log is used to
  * to output the status of a request returned
  * by the client.
+ * @private
  */
 function responseLog(logger, req, res, err) {
   var res = res || { };
@@ -96,6 +97,7 @@ function responseLog(logger, req, res, err) {
 /**
  * Takes a promise and uses the provided callback (if any) to handle promise
  * resolutions and rejections
+ * @private
  */
 function applyCallback(promise, cb) {
   if (!cb) {

--- a/samples/gen-js-nils/index.js
+++ b/samples/gen-js-nils/index.js
@@ -94,6 +94,21 @@ function responseLog(logger, req, res, err) {
 }
 
 /**
+ * Takes a promise and uses the provided callback (if any) to handle promise
+ * resolutions and rejections
+ */
+function applyCallback(promise, cb) {
+  if (!cb) {
+    return promise;
+  }
+  return promise.then((result) => {
+    cb(null, result);
+  }).catch((err) => {
+    cb(err);
+  });
+}
+
+/**
  * Default circuit breaker options.
  * @alias module:nil-test.DefaultCircuitOptions
  */
@@ -253,29 +268,19 @@ class NilTest {
    * @reject {Error}
    */
   nilCheck(params, options, cb) {
-    return this._hystrixCommand.execute(this._nilCheck, arguments);
+    let callback = cb;
+    if (!cb && typeof options === "function") {
+      callback = options;
+    }
+    return applyCallback(this._hystrixCommand.execute(this._nilCheck, arguments), callback);
   }
+
   _nilCheck(params, options, cb) {
     if (!cb && typeof options === "function") {
-      cb = options;
       options = undefined;
     }
 
     return new Promise((resolve, reject) => {
-      const rejecter = (err) => {
-        reject(err);
-        if (cb) {
-          cb(err);
-        }
-      };
-      const resolver = (data) => {
-        resolve(data);
-        if (cb) {
-          cb(null, data);
-        }
-      };
-
-
       if (!options) {
         options = {};
       }
@@ -286,7 +291,7 @@ class NilTest {
 
       const headers = {};
       if (!params.id) {
-        rejecter(new Error("id must be non-empty because it's a path parameter"));
+        reject(new Error("id must be non-empty because it's a path parameter"));
         return;
       }
       headers["header"] = params.header;
@@ -308,7 +313,7 @@ class NilTest {
         span.setTag("span.kind", "client");
       }
 
-	  const requestOptions = {
+      const requestOptions = {
         method: "POST",
         uri: this.address + "/v1/check/" + params.id + "",
         json: true,
@@ -340,31 +345,31 @@ class NilTest {
           if (err) {
             err._fromRequest = true;
             responseLog(logger, requestOptions, response, err)
-            rejecter(err);
+            reject(err);
             return;
           }
 
           switch (response.statusCode) {
             case 200:
-              resolver();
+              resolve();
               break;
             
             case 400:
               var err = new Errors.BadRequest(body || {});
               responseLog(logger, requestOptions, response, err);
-              rejecter(err);
+              reject(err);
               return;
             
             case 500:
               var err = new Errors.InternalError(body || {});
               responseLog(logger, requestOptions, response, err);
-              rejecter(err);
+              reject(err);
               return;
             
             default:
               var err = new Error("Received unexpected statusCode " + response.statusCode);
               responseLog(logger, requestOptions, response, err);
-              rejecter(err);
+              reject(err);
               return;
           }
         });

--- a/samples/gen-js/README.md
+++ b/samples/gen-js/README.md
@@ -14,6 +14,10 @@
 to output the status of a request returned
 by the client.</p>
 </dd>
+<dt><a href="#applyCallback">applyCallback()</a></dt>
+<dd><p>Takes a promise and uses the provided callback (if any) to handle promise
+resolutions and rejections</p>
+</dd>
 </dl>
 
 <a name="module_swagger-test"></a>
@@ -430,5 +434,12 @@ Default circuit breaker options.
 Request status log is used to
 to output the status of a request returned
 by the client.
+
+**Kind**: global function  
+<a name="applyCallback"></a>
+
+## applyCallback()
+Takes a promise and uses the provided callback (if any) to handle promise
+resolutions and rejections
 
 **Kind**: global function  

--- a/samples/gen-js/README.md
+++ b/samples/gen-js/README.md
@@ -1,25 +1,3 @@
-## Modules
-
-<dl>
-<dt><a href="#module_swagger-test">swagger-test</a></dt>
-<dd><p>swagger-test client library.</p>
-</dd>
-</dl>
-
-## Functions
-
-<dl>
-<dt><a href="#responseLog">responseLog()</a></dt>
-<dd><p>Request status log is used to
-to output the status of a request returned
-by the client.</p>
-</dd>
-<dt><a href="#applyCallback">applyCallback()</a></dt>
-<dd><p>Takes a promise and uses the provided callback (if any) to handle promise
-resolutions and rejections</p>
-</dd>
-</dl>
-
 <a name="module_swagger-test"></a>
 
 ## swagger-test
@@ -428,18 +406,3 @@ Error
 Default circuit breaker options.
 
 **Kind**: static constant of <code>[SwaggerTest](#exp_module_swagger-test--SwaggerTest)</code>  
-<a name="responseLog"></a>
-
-## responseLog()
-Request status log is used to
-to output the status of a request returned
-by the client.
-
-**Kind**: global function  
-<a name="applyCallback"></a>
-
-## applyCallback()
-Takes a promise and uses the provided callback (if any) to handle promise
-resolutions and rejections
-
-**Kind**: global function  

--- a/samples/gen-js/index.js
+++ b/samples/gen-js/index.js
@@ -74,6 +74,7 @@ const noRetryPolicy = {
  * Request status log is used to
  * to output the status of a request returned
  * by the client.
+ * @private
  */
 function responseLog(logger, req, res, err) {
   var res = res || { };
@@ -96,6 +97,7 @@ function responseLog(logger, req, res, err) {
 /**
  * Takes a promise and uses the provided callback (if any) to handle promise
  * resolutions and rejections
+ * @private
  */
 function applyCallback(promise, cb) {
   if (!cb) {

--- a/server/gendb/bindata.go
+++ b/server/gendb/bindata.go
@@ -6,12 +6,12 @@
 //  asset-dir: true
 //  restore: true
 // sources:
-//  /Users/aaronstein/go/src/github.com/Clever/wag/server/gendb/dynamodb-local.sh.tmpl
-//  /Users/aaronstein/go/src/github.com/Clever/wag/server/gendb/dynamodb.go.tmpl
-//  /Users/aaronstein/go/src/github.com/Clever/wag/server/gendb/dynamodb_test.go.tmpl
-//  /Users/aaronstein/go/src/github.com/Clever/wag/server/gendb/interface.go.tmpl
-//  /Users/aaronstein/go/src/github.com/Clever/wag/server/gendb/table.go.tmpl
-//  /Users/aaronstein/go/src/github.com/Clever/wag/server/gendb/tests.go.tmpl
+//  /home/vagrant/src/github.com/Clever/wag/server/gendb/dynamodb-local.sh.tmpl
+//  /home/vagrant/src/github.com/Clever/wag/server/gendb/dynamodb.go.tmpl
+//  /home/vagrant/src/github.com/Clever/wag/server/gendb/dynamodb_test.go.tmpl
+//  /home/vagrant/src/github.com/Clever/wag/server/gendb/interface.go.tmpl
+//  /home/vagrant/src/github.com/Clever/wag/server/gendb/table.go.tmpl
+//  /home/vagrant/src/github.com/Clever/wag/server/gendb/tests.go.tmpl
 
 package gendb
 
@@ -85,8 +85,8 @@ var _bindata = map[string]*asset{
 			"\x5b\xe8\xf4\x51\xf0\xb5\x49\xca\x03\x27\xb1\x87\x16\x34\xc7\xa4\xf8\xf6\xf0\xf0\x68\xfe\x06\x00" +
 			"\x00\xff\xff",
 		size: 592,
-		mode: 0755,
-		time: time.Unix(1556041339, 502391471),
+		mode: 0775,
+		time: time.Unix(1556581619, 477877647),
 	},
 	"dynamodb.go.tmpl": &asset{
 		name: "dynamodb.go.tmpl",
@@ -151,8 +151,8 @@ var _bindata = map[string]*asset{
 			"\xc8\xaa\x2c\xb9\x50\x12\x9c\x06\x08\x94\x3c\xaf\x14\xe5\x2c\xe8\x47\x77\xa3\xc4\x38\x81\xe7\x67" +
 			"\x21\x7c\xfe\x65\x20\xfe\x1d\x00\x00\xff\xff",
 		size: 7249,
-		mode: 0644,
-		time: time.Unix(1556041339, 503264092),
+		mode: 0664,
+		time: time.Unix(1556581619, 477877647),
 	},
 	"dynamodb_test.go.tmpl": &asset{
 		name: "dynamodb_test.go.tmpl",
@@ -203,8 +203,8 @@ var _bindata = map[string]*asset{
 			"\x79\x01\xfa\x62\x15\xe1\x05\x6a\x02\xfd\x8c\xc8\xc7\x6e\x22\xd9\xda\x22\x1f\x23\xe9\xa6\x48\xff" +
 			"\xa7\x8e\x1c\x1b\x2c\xc8\x70\x4d\x92\x21\xf9\x27\x00\x00\xff\xff",
 		size: 2694,
-		mode: 0644,
-		time: time.Unix(1556041339, 504086585),
+		mode: 0664,
+		time: time.Unix(1556581619, 477877647),
 	},
 	"interface.go.tmpl": &asset{
 		name: "interface.go.tmpl",
@@ -280,8 +280,8 @@ var _bindata = map[string]*asset{
 			"\xac\x57\xc3\x4d\xdb\xf0\x36\x8c\x74\xfe\x86\x42\x2a\x4d\x40\xa3\x3a\xec\x1d\x71\xff\x07\x00\x00" +
 			"\xff\xff",
 		size: 9170,
-		mode: 0644,
-		time: time.Unix(1556041978, 722935923),
+		mode: 0664,
+		time: time.Unix(1556581619, 477877647),
 	},
 	"table.go.tmpl": &asset{
 		name: "table.go.tmpl",
@@ -492,8 +492,8 @@ var _bindata = map[string]*asset{
 			"\x59\x11\x87\xbc\x48\xd4\x35\x09\x62\xf2\xe4\xe5\xf7\x2e\xd8\x64\x71\x83\xb9\xbb\xb6\x3e\xd7\x53" +
 			"\x29\x76\x32\x79\x2a\xe5\xff\x02\x00\x00\xff\xff",
 		size: 38715,
-		mode: 0644,
-		time: time.Unix(1556043791, 336855494),
+		mode: 0664,
+		time: time.Unix(1556581619, 477877647),
 	},
 	"tests.go.tmpl": &asset{
 		name: "tests.go.tmpl",
@@ -622,8 +622,8 @@ var _bindata = map[string]*asset{
 			"\x7d\x54\x3c\x33\xbd\x37\x21\xbf\x12\xce\x67\xb9\xea\x15\x43\x2a\xa6\x1a\xaf\x7c\xfb\x33\x00\x00" +
 			"\xff\xff",
 		size: 52549,
-		mode: 0644,
-		time: time.Unix(1556041339, 506706310),
+		mode: 0664,
+		time: time.Unix(1556581619, 477877647),
 	},
 }
 


### PR DESCRIPTION
> Commit by commit reviewing recommended

# Overview

This PR addresses two JS client code bugs, both involving callback syntax.

## Fix 1

The client code will now apply the provided callback (if any) to circuit-breaker errors.

Consider the following code sample:

```ts
wagClient.someCall(input, (err, data) => {
  if (err) {
    res.sendStatus(500);
    return;
  }
  res.json(data);
});
```

With the existing client code, if the circuit breaker kicks in, the callback will never actually be called and the request will hang. Now, we'll call the callback and `err` will be populated with the circuit-breaker error.

## Fix 2

The client code will no longer return a rejected promise if the provided callback handles it.

Consider the same code sample as above:

```ts
wagClient.someCall(input, (err, data) => {
  if (err) {
    res.sendStatus(500);
    return;
  }
  res.json(data);
});
```

With the existing client code, even though the callback is handling the error, an unhandled promise rejection will still be generated. That'll no longer be the case.

# Testing

- [x] Made sure that existing JS client code tests still pass
- [x] Added an additional test

# Rollout

This change won't actually make it to production until:

1. A WAG client is regenereated, and
2. A repo pulls that updated WAG client in