### PR TITLE
Export typescript types

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,5 @@
-v3.9.1
+v3.10.0
+- v3.10.0: Export typescript types for models
 - v3.9.1: Upgrade to go1.13
 - v3.9.0: Add pod shortname to tracing tags
 - v3.8.0: Add serviceName option to support using both an SSO and non-SSO client

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -1047,6 +1047,7 @@ func getErrorTypes(s spec.Swagger) ([]string, error) {
 
 func methodDecl(s spec.Swagger, op *spec.Operation, path, method string) (string, error) {
 	returnType, err := ReturnType(s, op)
+	returnType = JSType(fmt.Sprintf("models.%s", returnType))
 	if err != nil {
 		return "", err
 	}
@@ -1060,6 +1061,7 @@ func methodDecl(s spec.Swagger, op *spec.Operation, path, method string) (string
 		var paramType JSType
 		if op.Parameters[0].ParamProps.Schema != nil {
 			paramType, err = asJSType(op.Parameters[0].ParamProps.Schema)
+			paramType = JSType(fmt.Sprintf("models.%s", paramType))
 		} else {
 			paramType, err = asJSTypeSimple(op.Parameters[0].SimpleSchema)
 		}
@@ -1355,11 +1357,10 @@ interface AddressOptions {
   address: string;
 }
 
-type {{.ServiceName}}Options = (DiscoveryOptions | AddressOptions) & GenericOptions; 
+type {{.ServiceName}}Options = (DiscoveryOptions | AddressOptions) & GenericOptions;
 
-{{range .IncludedTypes}}
-{{.}}
-{{end}}
+import models = {{.ServiceName}}.Models
+
 declare class {{.ServiceName}} {
   constructor(options: {{.ServiceName}}Options);
 
@@ -1381,7 +1382,13 @@ declare namespace {{.ServiceName}} {
     {{range .ErrorTypes}}
     {{.}}
     {{end}}
-  }
+	}
+
+	namespace Models {
+		{{range .IncludedTypes}}
+		{{.}}
+		{{end}}
+	}
 }
 
 export = {{.ServiceName}};

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -1387,13 +1387,13 @@ declare namespace {{.ServiceName}} {
     {{range .ErrorTypes}}
     {{.}}
     {{end}}
-	}
+  }
 
-	namespace Models {
-		{{range .IncludedTypes}}
-		{{.}}
-		{{end}}
-	}
+  namespace Models {
+    {{range .IncludedTypes}}
+    {{.}}
+    {{end}}
+  }
 }
 
 export = {{.ServiceName}};

--- a/samples/gen-js-blog/index.d.ts
+++ b/samples/gen-js-blog/index.d.ts
@@ -49,20 +49,15 @@ interface AddressOptions {
   address: string;
 }
 
-type BlogOptions = (DiscoveryOptions | AddressOptions) & GenericOptions; 
+type BlogOptions = (DiscoveryOptions | AddressOptions) & GenericOptions;
 
-
-type Section = {
-  id?: string;
-  name?: string;
-  period?: string;
-};
+import models = Blog.Models
 
 declare class Blog {
   constructor(options: BlogOptions);
 
   
-  getSectionsForStudent(student_id: string, options?: RequestOptions, cb?: Callback<Section[]>): Promise<Section[]>
+  getSectionsForStudent(student_id: string, options?: RequestOptions, cb?: Callback<models.Section[]>): Promise<models.Section[]>
   
 }
 
@@ -85,7 +80,17 @@ declare namespace Blog {
   message?: string;
 }
     
-  }
+	}
+
+	namespace Models {
+		
+		type Section = {
+  id?: string;
+  name?: string;
+  period?: string;
+};
+		
+	}
 }
 
 export = Blog;

--- a/samples/gen-js-db/index.d.ts
+++ b/samples/gen-js-db/index.d.ts
@@ -49,100 +49,9 @@ interface AddressOptions {
   address: string;
 }
 
-type SwaggerTestOptions = (DiscoveryOptions | AddressOptions) & GenericOptions; 
+type SwaggerTestOptions = (DiscoveryOptions | AddressOptions) & GenericOptions;
 
-
-type Branch = ("master" | "DEV_BRANCH" | "test");
-
-type Category = ("a" | "b");
-
-type Deployment = {
-  application?: string;
-  date?: string;
-  environment?: string;
-  version?: string;
-};
-
-type NoRangeThingWithCompositeAttributes = {
-  branch: string;
-  date: string;
-  name: string;
-  version?: number;
-};
-
-type Object = {
-  bar?: string;
-  foo?: string;
-};
-
-type SimpleThing = {
-  id?: string;
-  name?: string;
-};
-
-type TeacherSharingRule = {
-  app?: string;
-  district?: string;
-  id?: string;
-  school?: string;
-  sections?: string[];
-  teacher?: string;
-};
-
-type Thing = {
-  category?: Category;
-  createdAt?: string;
-  id?: string;
-  name?: string;
-  nestedObject?: Object;
-  version?: number;
-};
-
-type ThingWithCompositeAttributes = {
-  branch: string;
-  date: string;
-  name: string;
-  version?: number;
-};
-
-type ThingWithCompositeEnumAttributes = {
-  branchID: Branch;
-  date: string;
-  name: string;
-};
-
-type ThingWithDateRange = {
-  date?: string;
-  name?: string;
-};
-
-type ThingWithDateTimeComposite = {
-  created?: string;
-  id?: string;
-  resource?: string;
-  type?: string;
-};
-
-type ThingWithMatchingKeys = {
-  assocID?: string;
-  assocType?: string;
-  bear?: string;
-  created?: string;
-};
-
-type ThingWithRequiredFields = {
-  id: string;
-  name: string;
-};
-
-type ThingWithRequiredFields2 = {
-  id: string;
-  name: string;
-};
-
-type ThingWithUnderscores = {
-  id_app?: string;
-};
+import models = SwaggerTest.Models
 
 declare class SwaggerTest {
   constructor(options: SwaggerTestOptions);
@@ -171,7 +80,103 @@ declare namespace SwaggerTest {
   message?: string;
 }
     
-  }
+	}
+
+	namespace Models {
+		
+		type Branch = ("master" | "DEV_BRANCH" | "test");
+		
+		type Category = ("a" | "b");
+		
+		type Deployment = {
+  application?: string;
+  date?: string;
+  environment?: string;
+  version?: string;
+};
+		
+		type NoRangeThingWithCompositeAttributes = {
+  branch: string;
+  date: string;
+  name: string;
+  version?: number;
+};
+		
+		type Object = {
+  bar?: string;
+  foo?: string;
+};
+		
+		type SimpleThing = {
+  id?: string;
+  name?: string;
+};
+		
+		type TeacherSharingRule = {
+  app?: string;
+  district?: string;
+  id?: string;
+  school?: string;
+  sections?: string[];
+  teacher?: string;
+};
+		
+		type Thing = {
+  category?: Category;
+  createdAt?: string;
+  id?: string;
+  name?: string;
+  nestedObject?: Object;
+  version?: number;
+};
+		
+		type ThingWithCompositeAttributes = {
+  branch: string;
+  date: string;
+  name: string;
+  version?: number;
+};
+		
+		type ThingWithCompositeEnumAttributes = {
+  branchID: Branch;
+  date: string;
+  name: string;
+};
+		
+		type ThingWithDateRange = {
+  date?: string;
+  name?: string;
+};
+		
+		type ThingWithDateTimeComposite = {
+  created?: string;
+  id?: string;
+  resource?: string;
+  type?: string;
+};
+		
+		type ThingWithMatchingKeys = {
+  assocID?: string;
+  assocType?: string;
+  bear?: string;
+  created?: string;
+};
+		
+		type ThingWithRequiredFields = {
+  id: string;
+  name: string;
+};
+		
+		type ThingWithRequiredFields2 = {
+  id: string;
+  name: string;
+};
+		
+		type ThingWithUnderscores = {
+  id_app?: string;
+};
+		
+	}
 }
 
 export = SwaggerTest;

--- a/samples/gen-js-deprecated/index.d.ts
+++ b/samples/gen-js-deprecated/index.d.ts
@@ -49,8 +49,9 @@ interface AddressOptions {
   address: string;
 }
 
-type SwaggerTestOptions = (DiscoveryOptions | AddressOptions) & GenericOptions; 
+type SwaggerTestOptions = (DiscoveryOptions | AddressOptions) & GenericOptions;
 
+import models = SwaggerTest.Models
 
 declare class SwaggerTest {
   constructor(options: SwaggerTestOptions);
@@ -81,7 +82,11 @@ declare namespace SwaggerTest {
   message?: string;
 }
     
-  }
+	}
+
+	namespace Models {
+		
+	}
 }
 
 export = SwaggerTest;

--- a/samples/gen-js-errors/index.d.ts
+++ b/samples/gen-js-errors/index.d.ts
@@ -49,13 +49,9 @@ interface AddressOptions {
   address: string;
 }
 
-type SwaggerTestOptions = (DiscoveryOptions | AddressOptions) & GenericOptions; 
+type SwaggerTestOptions = (DiscoveryOptions | AddressOptions) & GenericOptions;
 
-
-type ExtendedError = {
-  code?: number;
-  message?: string;
-};
+import models = SwaggerTest.Models
 
 declare class SwaggerTest {
   constructor(options: SwaggerTestOptions);
@@ -90,7 +86,16 @@ declare namespace SwaggerTest {
   message?: string;
 }
     
-  }
+	}
+
+	namespace Models {
+		
+		type ExtendedError = {
+  code?: number;
+  message?: string;
+};
+		
+	}
 }
 
 export = SwaggerTest;

--- a/samples/gen-js-nils/index.d.ts
+++ b/samples/gen-js-nils/index.d.ts
@@ -49,27 +49,15 @@ interface AddressOptions {
   address: string;
 }
 
-type NilTestOptions = (DiscoveryOptions | AddressOptions) & GenericOptions; 
+type NilTestOptions = (DiscoveryOptions | AddressOptions) & GenericOptions;
 
-
-type NilCheckParams = {
-  id: string;
-  query?: string;
-  header?: string;
-  array?: string[];
-  body?: NilFields;
-};
-
-type NilFields = {
-  id?: string;
-  optional?: string;
-};
+import models = NilTest.Models
 
 declare class NilTest {
   constructor(options: NilTestOptions);
 
   
-  nilCheck(params: NilCheckParams, options?: RequestOptions, cb?: Callback<void>): Promise<void>
+  nilCheck(params: models.NilCheckParams, options?: RequestOptions, cb?: Callback<void>): Promise<void>
   
 }
 
@@ -92,7 +80,24 @@ declare namespace NilTest {
   message?: string;
 }
     
-  }
+	}
+
+	namespace Models {
+		
+		type NilCheckParams = {
+  id: string;
+  query?: string;
+  header?: string;
+  array?: string[];
+  body?: NilFields;
+};
+		
+		type NilFields = {
+  id?: string;
+  optional?: string;
+};
+		
+	}
 }
 
 export = NilTest;

--- a/samples/gen-js/index.d.ts
+++ b/samples/gen-js/index.d.ts
@@ -49,106 +49,30 @@ interface AddressOptions {
   address: string;
 }
 
-type SwaggerTestOptions = (DiscoveryOptions | AddressOptions) & GenericOptions; 
+type SwaggerTestOptions = (DiscoveryOptions | AddressOptions) & GenericOptions;
 
-
-type Author = {
-  id?: string;
-  name?: string;
-};
-
-type AuthorArray = Author[];
-
-type AuthorSet = {
-  randomProp?: number;
-  results?: AuthorArray;
-};
-
-type AuthorsResponse = {
-  authorSet?: AuthorSet;
-  metadata?: AuthorsResponseMetadata;
-};
-
-type AuthorsResponseMetadata = {
-  count?: number;
-};
-
-type Book = {
-  author?: string;
-  genre?: ("scifi" | "mystery" | "horror");
-  id?: number;
-  name?: string;
-  other?: { [key: string]: string };
-  otherArray?: { [key: string]: string[] };
-};
-
-type Error = {
-  code?: number;
-  message?: string;
-};
-
-type GetAuthorsParams = {
-  name?: string;
-  startingAfter?: string;
-};
-
-type GetAuthorsWithPutParams = {
-  name?: string;
-  startingAfter?: string;
-  favoriteBooks?: Book;
-};
-
-type GetBookByIDParams = {
-  bookID: number;
-  authorID?: string;
-  authorization?: string;
-  XDontRateLimitMeBro?: string;
-  randomBytes?: string;
-};
-
-type GetBooksParams = {
-  authors?: string[];
-  available?: boolean;
-  state?: string;
-  published?: string;
-  snakeCase?: string;
-  completed?: string;
-  maxPages?: number;
-  minPages?: number;
-  pagesToTime?: number;
-  authorization?: string;
-  startingAfter?: number;
-};
-
-type OmitEmpty = {
-  arrayFieldNotOmitted?: string[];
-  arrayFieldOmitted?: string[];
-};
-
-type Unathorized = {
-  message?: string;
-};
+import models = SwaggerTest.Models
 
 declare class SwaggerTest {
   constructor(options: SwaggerTestOptions);
 
   
-  getAuthors(params: GetAuthorsParams, options?: RequestOptions, cb?: Callback<AuthorsResponse>): Promise<AuthorsResponse>
-  getAuthorsIter(params: GetAuthorsParams, options?: RequestOptions): IterResult<ArrayInner<AuthorsResponse["authorSet"]["results"]>>
+  getAuthors(params: models.GetAuthorsParams, options?: RequestOptions, cb?: Callback<models.AuthorsResponse>): Promise<models.AuthorsResponse>
+  getAuthorsIter(params: models.GetAuthorsParams, options?: RequestOptions): IterResult<ArrayInner<models.AuthorsResponse["authorSet"]["results"]>>
   
-  getAuthorsWithPut(params: GetAuthorsWithPutParams, options?: RequestOptions, cb?: Callback<AuthorsResponse>): Promise<AuthorsResponse>
-  getAuthorsWithPutIter(params: GetAuthorsWithPutParams, options?: RequestOptions): IterResult<ArrayInner<AuthorsResponse["authorSet"]["results"]>>
+  getAuthorsWithPut(params: models.GetAuthorsWithPutParams, options?: RequestOptions, cb?: Callback<models.AuthorsResponse>): Promise<models.AuthorsResponse>
+  getAuthorsWithPutIter(params: models.GetAuthorsWithPutParams, options?: RequestOptions): IterResult<ArrayInner<models.AuthorsResponse["authorSet"]["results"]>>
   
-  getBooks(params: GetBooksParams, options?: RequestOptions, cb?: Callback<Book[]>): Promise<Book[]>
-  getBooksIter(params: GetBooksParams, options?: RequestOptions): IterResult<ArrayInner<Book[]>>
+  getBooks(params: models.GetBooksParams, options?: RequestOptions, cb?: Callback<models.Book[]>): Promise<models.Book[]>
+  getBooksIter(params: models.GetBooksParams, options?: RequestOptions): IterResult<ArrayInner<models.Book[]>>
   
-  createBook(newBook: Book, options?: RequestOptions, cb?: Callback<Book>): Promise<Book>
+  createBook(newBook: models.Book, options?: RequestOptions, cb?: Callback<models.Book>): Promise<models.Book>
   
-  putBook(newBook?: Book, options?: RequestOptions, cb?: Callback<Book>): Promise<Book>
+  putBook(newBook?: models.Book, options?: RequestOptions, cb?: Callback<models.Book>): Promise<models.Book>
   
-  getBookByID(params: GetBookByIDParams, options?: RequestOptions, cb?: Callback<Book>): Promise<Book>
+  getBookByID(params: models.GetBookByIDParams, options?: RequestOptions, cb?: Callback<models.Book>): Promise<models.Book>
   
-  getBookByID2(id: string, options?: RequestOptions, cb?: Callback<Book>): Promise<Book>
+  getBookByID2(id: string, options?: RequestOptions, cb?: Callback<models.Book>): Promise<models.Book>
   
   healthCheck(options?: RequestOptions, cb?: Callback<void>): Promise<void>
   
@@ -182,7 +106,88 @@ declare namespace SwaggerTest {
   message?: string;
 }
     
-  }
+	}
+
+	namespace Models {
+		
+		type Author = {
+  id?: string;
+  name?: string;
+};
+		
+		type AuthorArray = Author[];
+		
+		type AuthorSet = {
+  randomProp?: number;
+  results?: AuthorArray;
+};
+		
+		type AuthorsResponse = {
+  authorSet?: AuthorSet;
+  metadata?: AuthorsResponseMetadata;
+};
+		
+		type AuthorsResponseMetadata = {
+  count?: number;
+};
+		
+		type Book = {
+  author?: string;
+  genre?: ("scifi" | "mystery" | "horror");
+  id?: number;
+  name?: string;
+  other?: { [key: string]: string };
+  otherArray?: { [key: string]: string[] };
+};
+		
+		type Error = {
+  code?: number;
+  message?: string;
+};
+		
+		type GetAuthorsParams = {
+  name?: string;
+  startingAfter?: string;
+};
+		
+		type GetAuthorsWithPutParams = {
+  name?: string;
+  startingAfter?: string;
+  favoriteBooks?: Book;
+};
+		
+		type GetBookByIDParams = {
+  bookID: number;
+  authorID?: string;
+  authorization?: string;
+  XDontRateLimitMeBro?: string;
+  randomBytes?: string;
+};
+		
+		type GetBooksParams = {
+  authors?: string[];
+  available?: boolean;
+  state?: string;
+  published?: string;
+  snakeCase?: string;
+  completed?: string;
+  maxPages?: number;
+  minPages?: number;
+  pagesToTime?: number;
+  authorization?: string;
+  startingAfter?: number;
+};
+		
+		type OmitEmpty = {
+  arrayFieldNotOmitted?: string[];
+  arrayFieldOmitted?: string[];
+};
+		
+		type Unathorized = {
+  message?: string;
+};
+		
+	}
 }
 
 export = SwaggerTest;

--- a/server/gendb/bindata.go
+++ b/server/gendb/bindata.go
@@ -6,12 +6,12 @@
 //  asset-dir: true
 //  restore: true
 // sources:
-//  /Users/aaronstein/go/src/github.com/Clever/wag/server/gendb/dynamodb-local.sh.tmpl
-//  /Users/aaronstein/go/src/github.com/Clever/wag/server/gendb/dynamodb.go.tmpl
-//  /Users/aaronstein/go/src/github.com/Clever/wag/server/gendb/dynamodb_test.go.tmpl
-//  /Users/aaronstein/go/src/github.com/Clever/wag/server/gendb/interface.go.tmpl
-//  /Users/aaronstein/go/src/github.com/Clever/wag/server/gendb/table.go.tmpl
-//  /Users/aaronstein/go/src/github.com/Clever/wag/server/gendb/tests.go.tmpl
+//  /Users/johnhuang/go/src/github.com/Clever/wag/server/gendb/dynamodb-local.sh.tmpl
+//  /Users/johnhuang/go/src/github.com/Clever/wag/server/gendb/dynamodb.go.tmpl
+//  /Users/johnhuang/go/src/github.com/Clever/wag/server/gendb/dynamodb_test.go.tmpl
+//  /Users/johnhuang/go/src/github.com/Clever/wag/server/gendb/interface.go.tmpl
+//  /Users/johnhuang/go/src/github.com/Clever/wag/server/gendb/table.go.tmpl
+//  /Users/johnhuang/go/src/github.com/Clever/wag/server/gendb/tests.go.tmpl
 
 package gendb
 
@@ -86,7 +86,7 @@ var _bindata = map[string]*asset{
 			"\x00\xff\xff",
 		size: 592,
 		mode: 0755,
-		time: time.Unix(1556041339, 502391471),
+		time: time.Unix(1555980746, 405928035),
 	},
 	"dynamodb.go.tmpl": &asset{
 		name: "dynamodb.go.tmpl",
@@ -157,7 +157,7 @@ var _bindata = map[string]*asset{
 			"\x79\x78\xf6\x75\x5c\xfc\x2b\x00\x00\xff\xff",
 		size: 7538,
 		mode: 0644,
-		time: time.Unix(1565986784, 283204182),
+		time: time.Unix(1571765555, 936957343),
 	},
 	"dynamodb_test.go.tmpl": &asset{
 		name: "dynamodb_test.go.tmpl",
@@ -209,7 +209,7 @@ var _bindata = map[string]*asset{
 			"\xa7\x8e\x1c\x1b\x2c\xc8\x70\x4d\x92\x21\xf9\x27\x00\x00\xff\xff",
 		size: 2694,
 		mode: 0644,
-		time: time.Unix(1556041339, 504086585),
+		time: time.Unix(1555980746, 406654319),
 	},
 	"interface.go.tmpl": &asset{
 		name: "interface.go.tmpl",
@@ -285,7 +285,7 @@ var _bindata = map[string]*asset{
 			"\xef\x6f\x28\xa4\xd6\x04\x34\xaa\xe3\xc1\x11\xf7\x77\x00\x00\x00\xff\xff",
 		size: 9158,
 		mode: 0644,
-		time: time.Unix(1565986784, 285299036),
+		time: time.Unix(1571765555, 937687631),
 	},
 	"table.go.tmpl": &asset{
 		name: "table.go.tmpl",
@@ -501,7 +501,7 @@ var _bindata = map[string]*asset{
 			"\xb5\xed\x66\x2a\xa5\x1e\x4c\x96\x4a\xf9\xbf\x00\x00\x00\xff\xff",
 		size: 39245,
 		mode: 0644,
-		time: time.Unix(1571782686, 302855100),
+		time: time.Unix(1571765555, 937974008),
 	},
 	"tests.go.tmpl": &asset{
 		name: "tests.go.tmpl",
@@ -632,7 +632,7 @@ var _bindata = map[string]*asset{
 			"\x00\xff\xff",
 		size: 52573,
 		mode: 0644,
-		time: time.Unix(1571782686, 304230900),
+		time: time.Unix(1571765555, 938948258),
 	},
 }
 


### PR DESCRIPTION
Move the generate typescript types into a `Models` sub-namespace, which will allow them to be access via `ServiceName.Models.Type`

I ran this binary on app-service here https://github.com/Clever/app-service/pull/341

Todo:

- [x] Run `make build`
- [x] Run `make generate`
- [x] Update the current version in the `/VERSION` file.
