### PR TITLE
Add linguist-generated to samples directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+samples/ linguist-generated


### PR DESCRIPTION
Tagging files with `linguist-generated` makes it so they don't auto-expand during code review. Just makes PRs a little easier