### PR TITLE
Update Go clients to use http.DefaultTransport

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ go-generate:
 	go generate ./hardcoded/
 	go generate ./server/gendb/
 
-generate: jsdoc2md
+generate: build jsdoc2md
 	./bin/wag -file samples/swagger.yml -go-package $(PKG)/samples/gen-go -js-path $(GOPATH)/src/$(PKG)/samples/gen-js
 	cd $(GOPATH)/src/$(PKG)/samples/gen-js && jsdoc2md index.js types.js > ./README.md
 	go generate $(PKG)/samples/gen-go...

--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,5 @@
-v3.10.1
+v3.10.2
+- v3.10.2: Default to http.DefaultTransport for go clients
 - v3.10.1: Default to keepalive: true for js clients.
 - v3.10.0: Export typescript types for models
 - v3.9.1: Upgrade to go1.13

--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -57,7 +57,7 @@ var _ = bytes.Compare
 type WagClient struct {
 	basePath    string
 	requestDoer doer
-	transport   http.RoundTripper
+	client   	*http.Client
 	timeout     time.Duration
 	// Keep the retry doer around so that we can set the number of retries
 	retryDoer *retryDoer
@@ -87,12 +87,12 @@ func New(basePath string) *WagClient {
 	}
 	circuit.init()
 	client := &WagClient{
+		basePath: basePath,
 		requestDoer: circuit,
+		client: &http.Client{Transport: http.DefaultTransport},
 		retryDoer: &retry,
 		circuitDoer: circuit,
 		defaultTimeout: 5 * time.Second,
- 		transport: &http.Transport{},
-		basePath: basePath,
 		logger: logger,
 	}
 	client.SetCircuitBreakerSettings(DefaultCircuitBreakerSettings)
@@ -175,7 +175,7 @@ func (c *WagClient) SetTimeout(timeout time.Duration){
 
 // SetTransport sets the http transport used by the client.
 func (c *WagClient) SetTransport(t http.RoundTripper){
-	c.transport = t
+	c.client.Transport = t
 }
 
 {{range $operationCode := .Operations}}
@@ -372,8 +372,6 @@ func methodDoerCode(s *spec.Swagger, op *spec.Operation) string {
 
 	buf.WriteString(fmt.Sprintf(`
 func (c *WagClient) do%sRequest(ctx context.Context, req *http.Request, headers map[string]string) %s {
-	client := &http.Client{Transport: c.transport}
-
 	req.Header.Set("Content-Type", "application/json")
 
 	for field, value := range headers {
@@ -391,7 +389,7 @@ func (c *WagClient) do%sRequest(ctx context.Context, req *http.Request, headers 
 		defer cancel()
 	    req = req.WithContext(ctx)
 	}
-	resp, err := c.requestDoer.Do(client, req)
+	resp, err := c.requestDoer.Do(c.client, req)
 	retCode := 0
 	if resp != nil {
 	  retCode = resp.StatusCode

--- a/samples/gen-go-db/client/client.go
+++ b/samples/gen-go-db/client/client.go
@@ -26,7 +26,7 @@ var _ = bytes.Compare
 type WagClient struct {
 	basePath    string
 	requestDoer doer
-	transport   http.RoundTripper
+	client      *http.Client
 	timeout     time.Duration
 	// Keep the retry doer around so that we can set the number of retries
 	retryDoer *retryDoer
@@ -56,12 +56,12 @@ func New(basePath string) *WagClient {
 	}
 	circuit.init()
 	client := &WagClient{
+		basePath:       basePath,
 		requestDoer:    circuit,
+		client:         &http.Client{Transport: http.DefaultTransport},
 		retryDoer:      &retry,
 		circuitDoer:    circuit,
 		defaultTimeout: 5 * time.Second,
-		transport:      &http.Transport{},
-		basePath:       basePath,
 		logger:         logger,
 	}
 	client.SetCircuitBreakerSettings(DefaultCircuitBreakerSettings)
@@ -144,7 +144,7 @@ func (c *WagClient) SetTimeout(timeout time.Duration) {
 
 // SetTransport sets the http transport used by the client.
 func (c *WagClient) SetTransport(t http.RoundTripper) {
-	c.transport = t
+	c.client.Transport = t
 }
 
 // HealthCheck makes a GET request to /health/check
@@ -169,8 +169,6 @@ func (c *WagClient) HealthCheck(ctx context.Context) error {
 }
 
 func (c *WagClient) doHealthCheckRequest(ctx context.Context, req *http.Request, headers map[string]string) error {
-	client := &http.Client{Transport: c.transport}
-
 	req.Header.Set("Content-Type", "application/json")
 
 	for field, value := range headers {
@@ -188,7 +186,7 @@ func (c *WagClient) doHealthCheckRequest(ctx context.Context, req *http.Request,
 		defer cancel()
 		req = req.WithContext(ctx)
 	}
-	resp, err := c.requestDoer.Do(client, req)
+	resp, err := c.requestDoer.Do(c.client, req)
 	retCode := 0
 	if resp != nil {
 		retCode = resp.StatusCode

--- a/samples/gen-go-deprecated/client/client.go
+++ b/samples/gen-go-deprecated/client/client.go
@@ -26,7 +26,7 @@ var _ = bytes.Compare
 type WagClient struct {
 	basePath    string
 	requestDoer doer
-	transport   http.RoundTripper
+	client      *http.Client
 	timeout     time.Duration
 	// Keep the retry doer around so that we can set the number of retries
 	retryDoer *retryDoer
@@ -56,12 +56,12 @@ func New(basePath string) *WagClient {
 	}
 	circuit.init()
 	client := &WagClient{
+		basePath:       basePath,
 		requestDoer:    circuit,
+		client:         &http.Client{Transport: http.DefaultTransport},
 		retryDoer:      &retry,
 		circuitDoer:    circuit,
 		defaultTimeout: 5 * time.Second,
-		transport:      &http.Transport{},
-		basePath:       basePath,
 		logger:         logger,
 	}
 	client.SetCircuitBreakerSettings(DefaultCircuitBreakerSettings)
@@ -144,7 +144,7 @@ func (c *WagClient) SetTimeout(timeout time.Duration) {
 
 // SetTransport sets the http transport used by the client.
 func (c *WagClient) SetTransport(t http.RoundTripper) {
-	c.transport = t
+	c.client.Transport = t
 }
 
 func shortHash(s string) string {

--- a/samples/gen-go-errors/client/client.go
+++ b/samples/gen-go-errors/client/client.go
@@ -26,7 +26,7 @@ var _ = bytes.Compare
 type WagClient struct {
 	basePath    string
 	requestDoer doer
-	transport   http.RoundTripper
+	client      *http.Client
 	timeout     time.Duration
 	// Keep the retry doer around so that we can set the number of retries
 	retryDoer *retryDoer
@@ -56,12 +56,12 @@ func New(basePath string) *WagClient {
 	}
 	circuit.init()
 	client := &WagClient{
+		basePath:       basePath,
 		requestDoer:    circuit,
+		client:         &http.Client{Transport: http.DefaultTransport},
 		retryDoer:      &retry,
 		circuitDoer:    circuit,
 		defaultTimeout: 5 * time.Second,
-		transport:      &http.Transport{},
-		basePath:       basePath,
 		logger:         logger,
 	}
 	client.SetCircuitBreakerSettings(DefaultCircuitBreakerSettings)
@@ -144,7 +144,7 @@ func (c *WagClient) SetTimeout(timeout time.Duration) {
 
 // SetTransport sets the http transport used by the client.
 func (c *WagClient) SetTransport(t http.RoundTripper) {
-	c.transport = t
+	c.client.Transport = t
 }
 
 // GetBook makes a GET request to /books/{id}
@@ -176,8 +176,6 @@ func (c *WagClient) GetBook(ctx context.Context, i *models.GetBookInput) error {
 }
 
 func (c *WagClient) doGetBookRequest(ctx context.Context, req *http.Request, headers map[string]string) error {
-	client := &http.Client{Transport: c.transport}
-
 	req.Header.Set("Content-Type", "application/json")
 
 	for field, value := range headers {
@@ -195,7 +193,7 @@ func (c *WagClient) doGetBookRequest(ctx context.Context, req *http.Request, hea
 		defer cancel()
 		req = req.WithContext(ctx)
 	}
-	resp, err := c.requestDoer.Do(client, req)
+	resp, err := c.requestDoer.Do(c.client, req)
 	retCode := 0
 	if resp != nil {
 		retCode = resp.StatusCode

--- a/samples/gen-go-nils/client/client.go
+++ b/samples/gen-go-nils/client/client.go
@@ -26,7 +26,7 @@ var _ = bytes.Compare
 type WagClient struct {
 	basePath    string
 	requestDoer doer
-	transport   http.RoundTripper
+	client      *http.Client
 	timeout     time.Duration
 	// Keep the retry doer around so that we can set the number of retries
 	retryDoer *retryDoer
@@ -56,12 +56,12 @@ func New(basePath string) *WagClient {
 	}
 	circuit.init()
 	client := &WagClient{
+		basePath:       basePath,
 		requestDoer:    circuit,
+		client:         &http.Client{Transport: http.DefaultTransport},
 		retryDoer:      &retry,
 		circuitDoer:    circuit,
 		defaultTimeout: 5 * time.Second,
-		transport:      &http.Transport{},
-		basePath:       basePath,
 		logger:         logger,
 	}
 	client.SetCircuitBreakerSettings(DefaultCircuitBreakerSettings)
@@ -144,7 +144,7 @@ func (c *WagClient) SetTimeout(timeout time.Duration) {
 
 // SetTransport sets the http transport used by the client.
 func (c *WagClient) SetTransport(t http.RoundTripper) {
-	c.transport = t
+	c.client.Transport = t
 }
 
 // NilCheck makes a POST request to /check/{id}
@@ -188,8 +188,6 @@ func (c *WagClient) NilCheck(ctx context.Context, i *models.NilCheckInput) error
 }
 
 func (c *WagClient) doNilCheckRequest(ctx context.Context, req *http.Request, headers map[string]string) error {
-	client := &http.Client{Transport: c.transport}
-
 	req.Header.Set("Content-Type", "application/json")
 
 	for field, value := range headers {
@@ -207,7 +205,7 @@ func (c *WagClient) doNilCheckRequest(ctx context.Context, req *http.Request, he
 		defer cancel()
 		req = req.WithContext(ctx)
 	}
-	resp, err := c.requestDoer.Do(client, req)
+	resp, err := c.requestDoer.Do(c.client, req)
 	retCode := 0
 	if resp != nil {
 		retCode = resp.StatusCode

--- a/server/gendb/bindata.go
+++ b/server/gendb/bindata.go
@@ -6,12 +6,12 @@
 //  asset-dir: true
 //  restore: true
 // sources:
-//  /home/ubuntu/go/src/github.com/Clever/wag/server/gendb/dynamodb-local.sh.tmpl
-//  /home/ubuntu/go/src/github.com/Clever/wag/server/gendb/dynamodb.go.tmpl
-//  /home/ubuntu/go/src/github.com/Clever/wag/server/gendb/dynamodb_test.go.tmpl
-//  /home/ubuntu/go/src/github.com/Clever/wag/server/gendb/interface.go.tmpl
-//  /home/ubuntu/go/src/github.com/Clever/wag/server/gendb/table.go.tmpl
-//  /home/ubuntu/go/src/github.com/Clever/wag/server/gendb/tests.go.tmpl
+//  /Users/sayansamanta/go/src/github.com/Clever/wag/server/gendb/dynamodb-local.sh.tmpl
+//  /Users/sayansamanta/go/src/github.com/Clever/wag/server/gendb/dynamodb.go.tmpl
+//  /Users/sayansamanta/go/src/github.com/Clever/wag/server/gendb/dynamodb_test.go.tmpl
+//  /Users/sayansamanta/go/src/github.com/Clever/wag/server/gendb/interface.go.tmpl
+//  /Users/sayansamanta/go/src/github.com/Clever/wag/server/gendb/table.go.tmpl
+//  /Users/sayansamanta/go/src/github.com/Clever/wag/server/gendb/tests.go.tmpl
 
 package gendb
 
@@ -85,8 +85,8 @@ var _bindata = map[string]*asset{
 			"\x5b\xe8\xf4\x51\xf0\xb5\x49\xca\x03\x27\xb1\x87\x16\x34\xc7\xa4\xf8\xf6\xf0\xf0\x68\xfe\x06\x00" +
 			"\x00\xff\xff",
 		size: 592,
-		mode: 0775,
-		time: time.Unix(1571852572, 662419650),
+		mode: 0755,
+		time: time.Unix(1572996316, 745377137),
 	},
 	"dynamodb.go.tmpl": &asset{
 		name: "dynamodb.go.tmpl",
@@ -156,8 +156,8 @@ var _bindata = map[string]*asset{
 			"\xa8\x3c\xcb\x84\xd4\x0a\xbc\x06\x48\x54\x22\xc9\x35\x13\xbc\xd7\xee\xdd\xb5\x96\x03\x0a\x67\x27" +
 			"\x79\x78\xf6\x75\x5c\xfc\x2b\x00\x00\xff\xff",
 		size: 7538,
-		mode: 0664,
-		time: time.Unix(1571852572, 662419650),
+		mode: 0644,
+		time: time.Unix(1572996316, 745503075),
 	},
 	"dynamodb_test.go.tmpl": &asset{
 		name: "dynamodb_test.go.tmpl",
@@ -208,8 +208,8 @@ var _bindata = map[string]*asset{
 			"\x79\x01\xfa\x62\x15\xe1\x05\x6a\x02\xfd\x8c\xc8\xc7\x6e\x22\xd9\xda\x22\x1f\x23\xe9\xa6\x48\xff" +
 			"\xa7\x8e\x1c\x1b\x2c\xc8\x70\x4d\x92\x21\xf9\x27\x00\x00\xff\xff",
 		size: 2694,
-		mode: 0664,
-		time: time.Unix(1571852572, 662419650),
+		mode: 0644,
+		time: time.Unix(1572996316, 745619395),
 	},
 	"interface.go.tmpl": &asset{
 		name: "interface.go.tmpl",
@@ -284,8 +284,8 @@ var _bindata = map[string]*asset{
 			"\x98\xf2\xfb\xe7\x7c\xa4\x77\x68\x6d\xfe\x78\xb5\x0f\x96\xba\xc7\x7a\x35\xdc\x74\x0d\xef\xc2\x48" +
 			"\xef\x6f\x28\xa4\xd6\x04\x34\xaa\xe3\xc1\x11\xf7\x77\x00\x00\x00\xff\xff",
 		size: 9158,
-		mode: 0664,
-		time: time.Unix(1571852572, 662419650),
+		mode: 0644,
+		time: time.Unix(1572996316, 745966697),
 	},
 	"table.go.tmpl": &asset{
 		name: "table.go.tmpl",
@@ -500,8 +500,8 @@ var _bindata = map[string]*asset{
 			"\xdc\x56\xd8\x37\x2b\xe2\x90\x17\x89\xba\x26\x41\x6c\x96\xbc\xf8\xe0\x44\x1d\x2d\x6e\xb0\x30\xd7" +
 			"\xb5\xed\x66\x2a\xa5\x1e\x4c\x96\x4a\xf9\xbf\x00\x00\x00\xff\xff",
 		size: 39245,
-		mode: 0664,
-		time: time.Unix(1571852572, 662419650),
+		mode: 0644,
+		time: time.Unix(1572996316, 746124892),
 	},
 	"tests.go.tmpl": &asset{
 		name: "tests.go.tmpl",
@@ -631,8 +631,8 @@ var _bindata = map[string]*asset{
 			"\xa2\x0f\x92\x67\xa6\xf7\x36\xe4\xd7\xc2\xf8\x2c\x96\xdd\x7c\x84\xc5\x04\xf1\xca\xa7\xff\x07\x00" +
 			"\x00\xff\xff",
 		size: 52573,
-		mode: 0664,
-		time: time.Unix(1571852572, 666419533),
+		mode: 0644,
+		time: time.Unix(1572996316, 746669986),
 	},
 }
 


### PR DESCRIPTION
We've been historically using a shared, zero valued `http.Transport` for all generated Go clients. Go has a `http.DefaultTransport` with some saner defaults. Let's go ahead and standardize on using the default for go clients.

Additionally, we switch from using a `http.Client` per request to a shared instance on the `WagClient`. `http.Client` is threadsafe. This is a minor optimization that I do not think carries risk (_famous last rights right_ 😅)