### PR TITLE
add canonical-resource header

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,5 @@
-v3.12.0
+v3.13.0
+- v3.13.0: adds a Canonical-Resource header
 - v3.12.0: Do not log process metrics when running locally
 - v3.11.0: Compress responses
 - v3.10.2: Default to http.DefaultTransport for go clients
@@ -15,4 +16,3 @@ v3.12.0
 - v3.5.0: add tracing support to generated dynamodb pkg
 - v3.4.1: make dynamodb gets strongly consistent
 - v3.4.0: migrate to GuaranteedThroughputProbabilisticSampler
-- v3.3.3: include more tracing metadata

--- a/samples/gen-go-blog/server/handlers.go
+++ b/samples/gen-go-blog/server/handlers.go
@@ -155,6 +155,7 @@ func (h handler) GetSectionsForStudentHandler(ctx context.Context, w http.Respon
 
 	sp.LogFields(log.Int("response-size-bytes", len(respBytes)))
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Canonical-Resource", "GetSectionsForStudent")
 	w.WriteHeader(statusCodeForGetSectionsForStudent(resp))
 	w.Write(respBytes)
 

--- a/samples/gen-go/server/handlers.go
+++ b/samples/gen-go/server/handlers.go
@@ -160,6 +160,7 @@ func (h handler) GetAuthorsHandler(ctx context.Context, w http.ResponseWriter, r
 
 	sp.LogFields(log.Int("response-size-bytes", len(respBytes)))
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Canonical-Resource", "GetAuthors")
 	w.WriteHeader(statusCodeForGetAuthors(resp))
 	w.Write(respBytes)
 
@@ -291,6 +292,7 @@ func (h handler) GetAuthorsWithPutHandler(ctx context.Context, w http.ResponseWr
 
 	sp.LogFields(log.Int("response-size-bytes", len(respBytes)))
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Canonical-Resource", "GetAuthorsWithPut")
 	w.WriteHeader(statusCodeForGetAuthorsWithPut(resp))
 	w.Write(respBytes)
 
@@ -443,6 +445,7 @@ func (h handler) GetBooksHandler(ctx context.Context, w http.ResponseWriter, r *
 
 	sp.LogFields(log.Int("response-size-bytes", len(respBytes)))
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Canonical-Resource", "GetBooks")
 	w.WriteHeader(statusCodeForGetBooks(resp))
 	w.Write(respBytes)
 
@@ -672,6 +675,7 @@ func (h handler) CreateBookHandler(ctx context.Context, w http.ResponseWriter, r
 
 	sp.LogFields(log.Int("response-size-bytes", len(respBytes)))
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Canonical-Resource", "CreateBook")
 	w.WriteHeader(statusCodeForCreateBook(resp))
 	w.Write(respBytes)
 
@@ -786,6 +790,7 @@ func (h handler) PutBookHandler(ctx context.Context, w http.ResponseWriter, r *h
 
 	sp.LogFields(log.Int("response-size-bytes", len(respBytes)))
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Canonical-Resource", "PutBook")
 	w.WriteHeader(statusCodeForPutBook(resp))
 	w.Write(respBytes)
 
@@ -908,6 +913,7 @@ func (h handler) GetBookByIDHandler(ctx context.Context, w http.ResponseWriter, 
 
 	sp.LogFields(log.Int("response-size-bytes", len(respBytes)))
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Canonical-Resource", "GetBookByID")
 	w.WriteHeader(statusCodeForGetBookByID(resp))
 	w.Write(respBytes)
 
@@ -1066,6 +1072,7 @@ func (h handler) GetBookByID2Handler(ctx context.Context, w http.ResponseWriter,
 
 	sp.LogFields(log.Int("response-size-bytes", len(respBytes)))
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Canonical-Resource", "GetBookByID2")
 	w.WriteHeader(statusCodeForGetBookByID2(resp))
 	w.Write(respBytes)
 

--- a/server/gendb/bindata.go
+++ b/server/gendb/bindata.go
@@ -6,12 +6,12 @@
 //  asset-dir: true
 //  restore: true
 // sources:
-//  /Users/sayansamanta/go/src/github.com/Clever/wag/server/gendb/dynamodb-local.sh.tmpl
-//  /Users/sayansamanta/go/src/github.com/Clever/wag/server/gendb/dynamodb.go.tmpl
-//  /Users/sayansamanta/go/src/github.com/Clever/wag/server/gendb/dynamodb_test.go.tmpl
-//  /Users/sayansamanta/go/src/github.com/Clever/wag/server/gendb/interface.go.tmpl
-//  /Users/sayansamanta/go/src/github.com/Clever/wag/server/gendb/table.go.tmpl
-//  /Users/sayansamanta/go/src/github.com/Clever/wag/server/gendb/tests.go.tmpl
+//  /home/ubuntu/go/src/github.com/Clever/wag/server/gendb/dynamodb-local.sh.tmpl
+//  /home/ubuntu/go/src/github.com/Clever/wag/server/gendb/dynamodb.go.tmpl
+//  /home/ubuntu/go/src/github.com/Clever/wag/server/gendb/dynamodb_test.go.tmpl
+//  /home/ubuntu/go/src/github.com/Clever/wag/server/gendb/interface.go.tmpl
+//  /home/ubuntu/go/src/github.com/Clever/wag/server/gendb/table.go.tmpl
+//  /home/ubuntu/go/src/github.com/Clever/wag/server/gendb/tests.go.tmpl
 
 package gendb
 
@@ -85,8 +85,8 @@ var _bindata = map[string]*asset{
 			"\x5b\xe8\xf4\x51\xf0\xb5\x49\xca\x03\x27\xb1\x87\x16\x34\xc7\xa4\xf8\xf6\xf0\xf0\x68\xfe\x06\x00" +
 			"\x00\xff\xff",
 		size: 592,
-		mode: 0755,
-		time: time.Unix(1572996316, 745377137),
+		mode: 0775,
+		time: time.Unix(1571852572, 662419650),
 	},
 	"dynamodb.go.tmpl": &asset{
 		name: "dynamodb.go.tmpl",
@@ -156,8 +156,8 @@ var _bindata = map[string]*asset{
 			"\xa8\x3c\xcb\x84\xd4\x0a\xbc\x06\x48\x54\x22\xc9\x35\x13\xbc\xd7\xee\xdd\xb5\x96\x03\x0a\x67\x27" +
 			"\x79\x78\xf6\x75\x5c\xfc\x2b\x00\x00\xff\xff",
 		size: 7538,
-		mode: 0644,
-		time: time.Unix(1572996316, 745503075),
+		mode: 0664,
+		time: time.Unix(1571852572, 662419650),
 	},
 	"dynamodb_test.go.tmpl": &asset{
 		name: "dynamodb_test.go.tmpl",
@@ -208,8 +208,8 @@ var _bindata = map[string]*asset{
 			"\x79\x01\xfa\x62\x15\xe1\x05\x6a\x02\xfd\x8c\xc8\xc7\x6e\x22\xd9\xda\x22\x1f\x23\xe9\xa6\x48\xff" +
 			"\xa7\x8e\x1c\x1b\x2c\xc8\x70\x4d\x92\x21\xf9\x27\x00\x00\xff\xff",
 		size: 2694,
-		mode: 0644,
-		time: time.Unix(1572996316, 745619395),
+		mode: 0664,
+		time: time.Unix(1571852572, 662419650),
 	},
 	"interface.go.tmpl": &asset{
 		name: "interface.go.tmpl",
@@ -284,8 +284,8 @@ var _bindata = map[string]*asset{
 			"\x98\xf2\xfb\xe7\x7c\xa4\x77\x68\x6d\xfe\x78\xb5\x0f\x96\xba\xc7\x7a\x35\xdc\x74\x0d\xef\xc2\x48" +
 			"\xef\x6f\x28\xa4\xd6\x04\x34\xaa\xe3\xc1\x11\xf7\x77\x00\x00\x00\xff\xff",
 		size: 9158,
-		mode: 0644,
-		time: time.Unix(1572996316, 745966697),
+		mode: 0664,
+		time: time.Unix(1571852572, 662419650),
 	},
 	"table.go.tmpl": &asset{
 		name: "table.go.tmpl",
@@ -500,8 +500,8 @@ var _bindata = map[string]*asset{
 			"\xdc\x56\xd8\x37\x2b\xe2\x90\x17\x89\xba\x26\x41\x6c\x96\xbc\xf8\xe0\x44\x1d\x2d\x6e\xb0\x30\xd7" +
 			"\xb5\xed\x66\x2a\xa5\x1e\x4c\x96\x4a\xf9\xbf\x00\x00\x00\xff\xff",
 		size: 39245,
-		mode: 0644,
-		time: time.Unix(1572996316, 746124892),
+		mode: 0664,
+		time: time.Unix(1571852572, 662419650),
 	},
 	"tests.go.tmpl": &asset{
 		name: "tests.go.tmpl",
@@ -631,8 +631,8 @@ var _bindata = map[string]*asset{
 			"\xa2\x0f\x92\x67\xa6\xf7\x36\xe4\xd7\xc2\xf8\x2c\x96\xdd\x7c\x84\xc5\x04\xf1\xca\xa7\xff\x07\x00" +
 			"\x00\xff\xff",
 		size: 52573,
-		mode: 0644,
-		time: time.Unix(1572996316, 746669986),
+		mode: 0664,
+		time: time.Unix(1571852572, 666419533),
 	},
 }
 

--- a/server/genserver.go
+++ b/server/genserver.go
@@ -400,6 +400,7 @@ func (h handler) {{.Op}}Handler(ctx context.Context, w http.ResponseWriter, r *h
 
 	sp.LogFields(log.Int("response-size-bytes", len(respBytes)))
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Canonical-Resource", "{{.Op}}")
 	w.WriteHeader(statusCodeFor{{.Op}}(resp))
 	w.Write(respBytes)
 {{else}}


### PR DESCRIPTION
this is specifically in response to
https://github.com/twitter/diffy/issues/30

But in general it also seems reasonable to include the operation name in the response

Todo:

- [ ] Run `make build`
- [ ] Run `make generate`
- [ ] Update the current version in the `/VERSION` file.
