### PR TITLE
Add TypeScript error type constructor declarations

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,5 @@
-v3.13.2
+v3.13.3
+- v3.13.3 Add constructor declarations to TypeScript error models
 - v3.13.1: adds a Canonical-Resource header to clients
 - v3.12.0: Do not log process metrics when running locally
 - v3.11.0: Compress responses

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -1033,11 +1033,11 @@ func getErrorTypes(s spec.Swagger) ([]string, error) {
 				if schema, ok := s.Definitions[typeName]; !ok {
 					errorTypes = append(errorTypes, fmt.Sprintf("class %s {}", typeName))
 				} else if len(schema.Properties) > 0 {
-					errorType, err := asJSType(&schema, "models.")
+					declaration, err := generateErrorDeclaration(&schema, typeName, "models.")
 					if err != nil {
 						return errorTypes, err
 					}
-					errorTypes = append(errorTypes, fmt.Sprintf("class %s %s", typeName, errorType))
+					errorTypes = append(errorTypes, declaration)
 				}
 			}
 		}
@@ -1365,6 +1365,11 @@ declare namespace {{.ServiceName}} {
   const DefaultCircuitOptions: CircuitOptions;
 
   namespace Errors {
+    interface ErrorBody {
+      message: string;
+      [key: string]: any;
+    }
+
     {{range .ErrorTypes}}
     {{.}}
     {{end}}

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -1262,28 +1262,9 @@ func asJSType(schema *spec.Schema, refPrefix string) (JSType, error) {
 	}
 
 	if schema.Type[0] == "object" || len(schema.Properties) > 0 {
-		requiredFields := map[string]struct{}{}
-		for _, requiredField := range schema.Required {
-			requiredFields[requiredField] = struct{}{}
-		}
-
-		var keys []string
-		for k := range schema.Properties {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		fieldsStrings := []string{}
-		for _, k := range keys {
-			fieldSchema := schema.Properties[k]
-			t, err := asJSType(&fieldSchema, refPrefix)
-			if err != nil {
-				return JSType(""), err
-			}
-			if _, ok := requiredFields[k]; ok {
-				fieldsStrings = append(fieldsStrings, fmt.Sprintf("%s: %s;", k, t))
-			} else {
-				fieldsStrings = append(fieldsStrings, fmt.Sprintf("%s?: %s;", k, t))
-			}
+		fieldsStrings, err := generatePropertyDeclarations(schema, refPrefix)
+		if err != nil {
+			return JSType(""), err
 		}
 
 		if schema.AdditionalProperties != nil {

--- a/clients/js/type_script.go
+++ b/clients/js/type_script.go
@@ -1,0 +1,59 @@
+package jsclient
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/go-openapi/spec"
+)
+
+// Given a schema, generates type declarations for each property
+func generatePropertyDeclarations(schema *spec.Schema, refPrefix string) (
+	[]string,
+	error,
+) {
+	keys := []string{}
+	typeDeclarations := []string{}
+	requiredFields := extractRequiredFields(schema.Required)
+
+	for key := range schema.Properties {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		propertySchema := schema.Properties[key]
+		required := requiredFields[key]
+
+		typeForKey, err := asJSType(&propertySchema, refPrefix)
+		if err != nil {
+			return []string{}, fmt.Errorf("Error getting type for key '%s': %w", key, err)
+		}
+
+		declaration := generatePropertyDeclaration(key, typeForKey, required)
+		typeDeclarations = append(typeDeclarations, declaration)
+	}
+
+	return typeDeclarations, nil
+}
+
+// Given a property key, type, and requirement generate a property declaration
+func generatePropertyDeclaration(key string, typeForKey JSType, required bool) string {
+	if required {
+		return fmt.Sprintf("%s: %s;", key, typeForKey)
+	}
+
+	return fmt.Sprintf("%s?: %s;", key, typeForKey)
+}
+
+// Given a spec.Required generate a map of required fields
+func extractRequiredFields(required []string) map[string]bool {
+	requiredFields := map[string]bool{}
+
+	for _, key := range required {
+		requiredFields[key] = true
+	}
+
+	return requiredFields
+}

--- a/clients/js/type_script.go
+++ b/clients/js/type_script.go
@@ -3,9 +3,56 @@ package jsclient
 import (
 	"fmt"
 	"sort"
+	"strings"
+	"text/template"
 
 	"github.com/go-openapi/spec"
 )
+
+// TypeScriptErrorDeclaration holds attributes for an Error Type Decclaration
+type TypeScriptErrorDeclaration struct {
+	Name       string
+	Properties []string
+}
+
+const errorDeclarationTemplate = `class {{.Name}} {
+  {{- range $property := .Properties}}
+  {{$property}}
+  {{- end}}
+
+  constructor(body: ErrorBody);
+}`
+
+var t *template.Template
+
+func init() {
+	t = template.Must(template.New("ErrorTypeDeclaration").Parse(errorDeclarationTemplate))
+}
+
+// Given an error schema, generate a TypeScript type declaration for the error
+func generateErrorDeclaration(schema *spec.Schema, typeName, refPrefix string) (
+	string,
+	error,
+) {
+	var builder strings.Builder
+
+	properties, err := generatePropertyDeclarations(schema, refPrefix)
+	if err != nil {
+		return "", fmt.Errorf("Error generating property declarations: %w", err)
+	}
+
+	declaration := TypeScriptErrorDeclaration{
+		Name:       typeName,
+		Properties: properties,
+	}
+
+	err = t.ExecuteTemplate(&builder, "ErrorTypeDeclaration", declaration)
+	if err != nil {
+		return "", err
+	}
+
+	return builder.String(), nil
+}
 
 // Given a schema, generates type declarations for each property
 func generatePropertyDeclarations(schema *spec.Schema, refPrefix string) (

--- a/clients/js/type_script_test.go
+++ b/clients/js/type_script_test.go
@@ -1,0 +1,59 @@
+package jsclient
+
+import (
+	"testing"
+
+	"github.com/go-openapi/spec"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateErrorDeclaration(t *testing.T) {
+	schema := &spec.Schema{}
+	prefix := ""
+
+	t.Run("It generates a type declaration", func(t *testing.T) {
+		actual, err := generateErrorDeclaration(schema, "Foo", prefix)
+
+		expected := `class Foo {
+
+  constructor(body: ErrorBody);
+}`
+
+		assert.Nil(t, err, "No error occurred")
+		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("Given some additional properties", func(t *testing.T) {
+		properties := map[string]spec.Schema{
+			"bar": spec.Schema{},
+			"baz": spec.Schema{},
+		}
+		schema = schema.WithProperties(properties)
+		actual, err := generateErrorDeclaration(schema, "Foo", prefix)
+
+		expected := `class Foo {
+  bar?: any;
+  baz?: any;
+
+  constructor(body: ErrorBody);
+}`
+
+		assert.Nil(t, err, "No error occurred")
+		assert.Equal(t, expected, actual)
+
+		t.Run("When some of the properties are required", func(t *testing.T) {
+			schema = schema.WithRequired("bar")
+			actual, err := generateErrorDeclaration(schema, "Foo", prefix)
+
+			expected := `class Foo {
+  bar: any;
+  baz?: any;
+
+  constructor(body: ErrorBody);
+}`
+
+			assert.Nil(t, err, "No error occurred")
+			assert.Equal(t, expected, actual)
+		})
+	})
+}

--- a/samples/gen-js-blog/index.d.ts
+++ b/samples/gen-js-blog/index.d.ts
@@ -71,13 +71,22 @@ declare namespace Blog {
   const DefaultCircuitOptions: CircuitOptions;
 
   namespace Errors {
+    interface ErrorBody {
+      message: string;
+      [key: string]: any;
+    }
+
     
     class BadRequest {
   message?: string;
+
+  constructor(body: ErrorBody);
 }
     
     class InternalError {
   message?: string;
+
+  constructor(body: ErrorBody);
 }
     
   }

--- a/samples/gen-js-db/index.d.ts
+++ b/samples/gen-js-db/index.d.ts
@@ -71,13 +71,22 @@ declare namespace SwaggerTest {
   const DefaultCircuitOptions: CircuitOptions;
 
   namespace Errors {
+    interface ErrorBody {
+      message: string;
+      [key: string]: any;
+    }
+
     
     class BadRequest {
   message?: string;
+
+  constructor(body: ErrorBody);
 }
     
     class InternalError {
   message?: string;
+
+  constructor(body: ErrorBody);
 }
     
   }

--- a/samples/gen-js-deprecated/index.d.ts
+++ b/samples/gen-js-deprecated/index.d.ts
@@ -69,17 +69,28 @@ declare namespace SwaggerTest {
   const DefaultCircuitOptions: CircuitOptions;
 
   namespace Errors {
+    interface ErrorBody {
+      message: string;
+      [key: string]: any;
+    }
+
     
     class BadRequest {
   message?: string;
+
+  constructor(body: ErrorBody);
 }
     
     class NotFound {
   message?: string;
+
+  constructor(body: ErrorBody);
 }
     
     class InternalError {
   message?: string;
+
+  constructor(body: ErrorBody);
 }
     
   }

--- a/samples/gen-js-errors/index.d.ts
+++ b/samples/gen-js-errors/index.d.ts
@@ -71,19 +71,30 @@ declare namespace SwaggerTest {
   const DefaultCircuitOptions: CircuitOptions;
 
   namespace Errors {
+    interface ErrorBody {
+      message: string;
+      [key: string]: any;
+    }
+
     
     class ExtendedError {
   code?: number;
   message?: string;
+
+  constructor(body: ErrorBody);
 }
     
     class NotFound {
   message?: string;
+
+  constructor(body: ErrorBody);
 }
     
     class InternalError {
   code?: number;
   message?: string;
+
+  constructor(body: ErrorBody);
 }
     
   }

--- a/samples/gen-js-nils/index.d.ts
+++ b/samples/gen-js-nils/index.d.ts
@@ -71,13 +71,22 @@ declare namespace NilTest {
   const DefaultCircuitOptions: CircuitOptions;
 
   namespace Errors {
+    interface ErrorBody {
+      message: string;
+      [key: string]: any;
+    }
+
     
     class BadRequest {
   message?: string;
+
+  constructor(body: ErrorBody);
 }
     
     class InternalError {
   message?: string;
+
+  constructor(body: ErrorBody);
 }
     
   }

--- a/samples/gen-js/index.d.ts
+++ b/samples/gen-js/index.d.ts
@@ -88,22 +88,35 @@ declare namespace SwaggerTest {
   const DefaultCircuitOptions: CircuitOptions;
 
   namespace Errors {
+    interface ErrorBody {
+      message: string;
+      [key: string]: any;
+    }
+
     
     class BadRequest {
   message?: string;
+
+  constructor(body: ErrorBody);
 }
     
     class InternalError {
   message?: string;
+
+  constructor(body: ErrorBody);
 }
     
     class Unathorized {
   message?: string;
+
+  constructor(body: ErrorBody);
 }
     
     class Error {
   code?: number;
   message?: string;
+
+  constructor(body: ErrorBody);
 }
     
   }


### PR DESCRIPTION
_NOTE: I recommend reviewing commit by commit._

WAG generates a JavaScript client in `gen-js/index.js`, and alongside the client it generates a TypeScript type declaration file `gen-js/index.d.ts`.

Currently the Error object source code conflicts with the Error object type declarations. The Error objects must take one argument, and that argument must contian a `message` key, otherwise a runtime error is thrown. However, the TypeScript type declaration files do no define a constructor for Error objects so we can not construct these objects properly when using TypeScript.

This pull request defines constructors for Error objects in the TypeScript type declaration files.

See the `$ make generate` commit for an example of how this alters the generated type declarations in the `samples/` directory. https://github.com/Clever/wag/pull/277/commits/dc30f8304ea3f8bc6fba7cc7eb8dd7279e026e79

Todo:

- [x] Run `make build`
- [x] Run `make generate`
- [ ] Update the current version in the `/VERSION` file.
