### PR TITLE
Allow multiple success cases

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,5 @@
-v3.14.1
+v3.15.0
+- v3.15.0 Allow multiple success responses
 - v3.14.1 Send client version as a header bugfix.
 - v3.14.0 Send client version as a header.
 - v3.13.3 Add constructor declarations to TypeScript error models

--- a/swagger/responses.go
+++ b/swagger/responses.go
@@ -68,10 +68,6 @@ func ValidateResponses(s spec.Swagger) error {
 				}
 			}
 
-			if successResponseCount > 1 {
-				return fmt.Errorf("can only define one success type (statusCode < 400) for %s", op.ID)
-			}
-
 			if !has400 {
 				refResponse, err := createRefResponse("BadRequest", "#/responses/BadRequest")
 				if err != nil {

--- a/swagger/responses_test.go
+++ b/swagger/responses_test.go
@@ -46,13 +46,6 @@ func Test3xxError(t *testing.T) {
 	assert.True(t, strings.Contains(err.Error(), "cannot define 3XX status codes"), err.Error())
 }
 
-func TestMultiSuccessError(t *testing.T) {
-	s := loadTestFile(t, "testyml/multisuccess.yml")
-	err := ValidateResponses(s)
-	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "one success type"), err.Error())
-}
-
 func loadTestFile(t *testing.T, filename string) spec.Swagger {
 	loads.AddLoader(fmts.YAMLMatcher, fmts.YAMLDoc)
 	doc, err := loads.Spec(filename)


### PR DESCRIPTION
We want to create an endpoint that will idempotently add a new
resource. If the request is sent twice in a row, that is ok. It will
create the resource on the first attempt, and respond with `201 Created`.
On the second attempt, it will respond with `200 OK`.

Todo:

- [x] Run `make build`
- [x] Run `make generate`
- [x] Update the current version in the `/VERSION` file.
