### PR TITLE
prevent tracing errors in js client

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,5 @@
-v3.14.1
+v3.14.2
+- v13.14.2 Stricter span checks to prevent tracing errors.
 - v3.14.1 Send client version as a header bugfix.
 - v3.14.0 Send client version as a header.
 - v3.13.3 Add constructor declarations to TypeScript error models

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -434,7 +434,7 @@ const methodTmplStr = `
       }
 {{end}}{{end}}
 
-      if (span) {
+      if (span && typeof span.log === "function") {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
         tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         {{- if not .IterMethod}}
@@ -467,7 +467,7 @@ const methodTmplStr = `
       async.whilst(
         () => requestOptions.uri !== "",
         cbW => {
-          if (span) {
+          if (span && typeof span.log === "function") {
             span.log({event: "{{.Method}} {{.Path}}"});
           }
       const address = this.address;

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -438,7 +438,7 @@ const methodTmplStr = `
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
         tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         {{- if not .IterMethod}}
-        span.logEvent("{{.Method}} {{.Path}}");
+        span.log({event: "{{.Method}} {{.Path}}"});
         {{- end}}
         span.setTag("span.kind", "client");
       }
@@ -468,7 +468,7 @@ const methodTmplStr = `
         () => requestOptions.uri !== "",
         cbW => {
           if (span) {
-            span.logEvent("{{.Method}} {{.Path}}");
+            span.log({event: "{{.Method}} {{.Path}}"});
           }
       const address = this.address;
   {{- end}}

--- a/samples/gen-js-blog/index.js
+++ b/samples/gen-js-blog/index.js
@@ -299,10 +299,10 @@ class Blog {
 
       const query = {};
 
-      if (span) {
+      if (span && typeof span.log === "function") {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
         tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
-        span.logEvent("GET /students/{student_id}/sections");
+        span.log({event: "GET /students/{student_id}/sections"});
         span.setTag("span.kind", "client");
       }
 

--- a/samples/gen-js-db/index.js
+++ b/samples/gen-js-db/index.js
@@ -292,10 +292,10 @@ class SwaggerTest {
 
       const query = {};
 
-      if (span) {
+      if (span && typeof span.log === "function") {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
         tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
-        span.logEvent("GET /v1/health/check");
+        span.log({event: "GET /v1/health/check"});
         span.setTag("span.kind", "client");
       }
 

--- a/samples/gen-js-errors/index.js
+++ b/samples/gen-js-errors/index.js
@@ -299,10 +299,10 @@ class SwaggerTest {
 
       const query = {};
 
-      if (span) {
+      if (span && typeof span.log === "function") {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
         tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
-        span.logEvent("GET /v1/books/{id}");
+        span.log({event: "GET /v1/books/{id}"});
         span.setTag("span.kind", "client");
       }
 

--- a/samples/gen-js-nils/index.js
+++ b/samples/gen-js-nils/index.js
@@ -310,10 +310,10 @@ class NilTest {
       }
 
 
-      if (span) {
+      if (span && typeof span.log === "function") {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
         tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
-        span.logEvent("POST /v1/check/{id}");
+        span.log({event: "POST /v1/check/{id}"});
         span.setTag("span.kind", "client");
       }
 

--- a/samples/gen-js/index.js
+++ b/samples/gen-js/index.js
@@ -302,10 +302,10 @@ class SwaggerTest {
       }
 
 
-      if (span) {
+      if (span && typeof span.log === "function") {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
         tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
-        span.logEvent("GET /v1/authors");
+        span.log({event: "GET /v1/authors"});
         span.setTag("span.kind", "client");
       }
 
@@ -410,7 +410,7 @@ class SwaggerTest {
       }
 
 
-      if (span) {
+      if (span && typeof span.log === "function") {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
         tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.setTag("span.kind", "client");
@@ -438,8 +438,8 @@ class SwaggerTest {
       async.whilst(
         () => requestOptions.uri !== "",
         cbW => {
-          if (span) {
-            span.logEvent("GET /v1/authors");
+          if (span && typeof span.log === "function") {
+            span.log({event: "GET /v1/authors"});
           }
       const address = this.address;
       let retries = 0;
@@ -570,10 +570,10 @@ class SwaggerTest {
       }
 
 
-      if (span) {
+      if (span && typeof span.log === "function") {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
         tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
-        span.logEvent("PUT /v1/authors");
+        span.log({event: "PUT /v1/authors"});
         span.setTag("span.kind", "client");
       }
 
@@ -681,7 +681,7 @@ class SwaggerTest {
       }
 
 
-      if (span) {
+      if (span && typeof span.log === "function") {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
         tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.setTag("span.kind", "client");
@@ -711,8 +711,8 @@ class SwaggerTest {
       async.whilst(
         () => requestOptions.uri !== "",
         cbW => {
-          if (span) {
-            span.logEvent("PUT /v1/authors");
+          if (span && typeof span.log === "function") {
+            span.log({event: "PUT /v1/authors"});
           }
       const address = this.address;
       let retries = 0;
@@ -884,10 +884,10 @@ class SwaggerTest {
       }
 
 
-      if (span) {
+      if (span && typeof span.log === "function") {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
         tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
-        span.logEvent("GET /v1/books");
+        span.log({event: "GET /v1/books"});
         span.setTag("span.kind", "client");
       }
 
@@ -1034,7 +1034,7 @@ class SwaggerTest {
       }
 
 
-      if (span) {
+      if (span && typeof span.log === "function") {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
         tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
         span.setTag("span.kind", "client");
@@ -1062,8 +1062,8 @@ class SwaggerTest {
       async.whilst(
         () => requestOptions.uri !== "",
         cbW => {
-          if (span) {
-            span.logEvent("GET /v1/books");
+          if (span && typeof span.log === "function") {
+            span.log({event: "GET /v1/books"});
           }
       const address = this.address;
       let retries = 0;
@@ -1186,10 +1186,10 @@ class SwaggerTest {
 
       const query = {};
 
-      if (span) {
+      if (span && typeof span.log === "function") {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
         tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
-        span.logEvent("POST /v1/books");
+        span.log({event: "POST /v1/books"});
         span.setTag("span.kind", "client");
       }
 
@@ -1302,10 +1302,10 @@ class SwaggerTest {
 
       const query = {};
 
-      if (span) {
+      if (span && typeof span.log === "function") {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
         tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
-        span.logEvent("PUT /v1/books");
+        span.log({event: "PUT /v1/books"});
         span.setTag("span.kind", "client");
       }
 
@@ -1436,10 +1436,10 @@ class SwaggerTest {
       }
 
 
-      if (span) {
+      if (span && typeof span.log === "function") {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
         tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
-        span.logEvent("GET /v1/books/{book_id}");
+        span.log({event: "GET /v1/books/{book_id}"});
         span.setTag("span.kind", "client");
       }
 
@@ -1567,10 +1567,10 @@ class SwaggerTest {
 
       const query = {};
 
-      if (span) {
+      if (span && typeof span.log === "function") {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
         tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
-        span.logEvent("GET /v1/books2/{id}");
+        span.log({event: "GET /v1/books2/{id}"});
         span.setTag("span.kind", "client");
       }
 
@@ -1684,10 +1684,10 @@ class SwaggerTest {
 
       const query = {};
 
-      if (span) {
+      if (span && typeof span.log === "function") {
         // Need to get tracer to inject. Use HTTP headers format so we can properly escape special characters
         tracer.inject(span, opentracing.FORMAT_HTTP_HEADERS, headers);
-        span.logEvent("GET /v1/health/check");
+        span.log({event: "GET /v1/health/check"});
         span.setTag("span.kind", "client");
       }
 


### PR DESCRIPTION
Todo:

- [ ] Run `make build`
- [x] Run `make generate`
- [x] Update the current version in the `/VERSION` file.

- `span.logEvent` is deprecated, so it's been swapped for `span.log`  https://github.com/opentracing/opentracing-javascript/blob/cb74683fefe5bd4d711eaa0c273f3fc17a6c3781/src/span.ts#L151.
- Make the span check stricter to prevent errors we've seen caused by invalid spans. https://github.com/Clever/lockbox/pull/199
This should prevent the case that we encountered where span was `{}`. We could even wrap the tracing code in a `try...catch` block if we wanted to catch any kind of error.
