### PR TITLE
clean up unused code

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,5 @@
-v3.14.2
+v3.14.3
+- v3.14.3 Remove unused code.
 - v3.14.2 Stricter span checks to prevent tracing errors.
 - v3.14.1 Send client version as a header bugfix.
 - v3.14.0 Send client version as a header.

--- a/VERSION
+++ b/VERSION
@@ -1,5 +1,5 @@
 v3.14.2
-- v13.14.2 Stricter span checks to prevent tracing errors.
+- v3.14.2 Stricter span checks to prevent tracing errors.
 - v3.14.1 Send client version as a header bugfix.
 - v3.14.0 Send client version as a header.
 - v3.13.3 Add constructor declarations to TypeScript error models

--- a/main.go
+++ b/main.go
@@ -6,25 +6,18 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"sort"
-	"strings"
 
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/loads/fmts"
-	"github.com/go-openapi/spec"
 
-	"github.com/Clever/wag/clients/go"
-	"github.com/Clever/wag/clients/js"
+	goclient "github.com/Clever/wag/clients/go"
+	jsclient "github.com/Clever/wag/clients/js"
 	"github.com/Clever/wag/hardcoded"
 	"github.com/Clever/wag/models"
 	"github.com/Clever/wag/server"
 	"github.com/Clever/wag/swagger"
 	"github.com/Clever/wag/validation"
 )
-
-func capitalize(input string) string {
-	return strings.ToUpper(input[0:1]) + input[1:]
-}
 
 var version string
 
@@ -126,44 +119,4 @@ func main() {
 	if err := doerGenerator.WriteFile("client/doer.go"); err != nil {
 		log.Fatalf("Failed to copy doer.go: %s", err)
 	}
-}
-
-func sortedPathItemKeys(m map[string]spec.PathItem) []string {
-	sortedKeys := []string{}
-	for k := range m {
-		sortedKeys = append(sortedKeys, k)
-	}
-	sort.Strings(sortedKeys)
-	return sortedKeys
-}
-
-func sortedOperationsKeys(m map[string]*spec.Operation) []string {
-	sortedKeys := []string{}
-	for k := range m {
-		sortedKeys = append(sortedKeys, k)
-	}
-	sort.Strings(sortedKeys)
-	return sortedKeys
-}
-
-func sortedStatusCodeKeys(m map[int]spec.Response) []int {
-	sortedKeys := []int{}
-	for k := range m {
-		sortedKeys = append(sortedKeys, k)
-	}
-	sort.Ints(sortedKeys)
-	return sortedKeys
-}
-
-// importStatements takes a list of import strings and converts them to a formatted imports
-func importStatements(imports []string) string {
-	if len(imports) == 0 {
-		return ""
-	}
-	output := "import (\n"
-	for _, importStr := range imports {
-		output += fmt.Sprintf("\t\"%s\"\n", importStr)
-	}
-	output += ")\n\n"
-	return output
 }


### PR DESCRIPTION
Todo:

- [x] Run `make build`
- [x] Run `make generate`
- [x] Update the current version in the `/VERSION` file.

While I was looking through the codebase to get a better feel for wag, I noticed some unused functions in `main.go` that had been left behind from a refactor https://github.com/Clever/wag/commit/05821f664aa4d898d14dcf5d940003dc75373c14#diff-f8456eec252286d7dd7c40862aef0c49.

I also see a bunch of glide validation code, but I wonder if we could also remove that since we don't use glide anymore https://github.com/Clever/wag/blob/cf9f5de21695f155fd2d2c57a99a8846fd4d52ad/main.go#L49-L65