### PR TITLE
Bump kayvee to 3.13.0

### DIFF
--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -382,7 +382,7 @@ const packageJSONTmplStr = `{
     "clever-discovery": "0.0.8",
     "opentracing": "^0.14.0",
     "request": "^2.87.0",
-    "kayvee": "^3.8.2",
+    "kayvee": "^3.13.0",
     "hystrixjs": "^0.2.0",
     "rxjs": "^5.4.1"
   },


### PR DESCRIPTION
The new kayvee version has some new stuff, particularly the new aspects of Clever's canary detection.

Checkist:
- [x] Run `make build`
- [x] Run `make generate`
- [X] Update the current version in the `/VERSION` file.
