### PR TITLE
Go clients now use NewRequestWithContext 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Despite the presence of a `swagger.yml` file, WAG does not support all of the Sw
 WAG is a custom re-implementation of a subset of the Swagger version `2.0` standard.
 
 ## Usage
-Wag requires Go 1.7+.
+Wag requires Go 1.13+.
 ### Generating Code
 Create a swagger.yml file with your [service definition](http://editor.swagger.io/#/). Wag supports a [subset](https://github.com/Clever/wag#swagger-spec) of the Swagger spec.
 Copy the latest `wag.mk` from the [dev-handbook](https://github.com/Clever/dev-handbook/blob/master/make/wag.mk).

--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,5 @@
-v3.20.0
+v3.21.0
+- v3.21.0: Go client now uses context to control request lifecycle
 - v3.20.0: Add dynamodb codegen support for scanning over global secondary indexes.
 - v3.19.1: Codegen fix for KEYS_ONLY index with composite property made of required properties
 - v3.19.0: JSON with Marshal() instead of MarshalIndent()
@@ -6,10 +7,9 @@ v3.20.0
 - v3.17.0: Add support for configuration options and paramatrized settings.
 - v3.16.0: Support for binary fields.
 - v3.15.0: JS client enable compression
-- v3.14.3 Remove unused code.
-- v3.14.2 Stricter span checks to prevent tracing errors.
-- v3.14.1 Send client version as a header bugfix.
-- v3.14.0 Send client version as a header.
-- v3.13.3 Add constructor declarations to TypeScript error models
+- v3.14.3: Remove unused code.
+- v3.14.2: Stricter span checks to prevent tracing errors.
+- v3.14.1: Send client version as a header bugfix.
+- v3.14.0: Send client version as a header.
+- v3.13.3: Add constructor declarations to TypeScript error models
 - v3.13.1: adds a Canonical-Resource header to clients
-

--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -479,7 +479,7 @@ func buildRequestCode(s *spec.Swagger, op *spec.Operation, method string) string
 	buf.WriteString(buildBodyCode(s, op, method))
 
 	buf.WriteString(fmt.Sprintf(`
-	req, err := http.NewRequest("%s", path, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, "%s", path, bytes.NewBuffer(body))
 	%s
 `, strings.ToUpper(method), errorMessage(s, op)))
 
@@ -760,7 +760,7 @@ func (c *WagClient) New{{.CapOpID}}Iter(ctx context.Context, {{.Input}}) ({{.Cap
 }
 
 func (i *{{.OpID}}IterImpl) refresh() error {
-	req, err := http.NewRequest("{{.Method}}", i.nextURL, bytes.NewBuffer(i.body))
+	req, err := http.NewRequestWithContext(i.ctx, "{{.Method}}", i.nextURL, bytes.NewBuffer(i.body))
 
 	if err != nil {
 		i.err = err

--- a/samples/gen-go-blog/client/client.go
+++ b/samples/gen-go-blog/client/client.go
@@ -171,7 +171,7 @@ func (c *WagClient) GetSectionsForStudent(ctx context.Context, studentID string)
 
 	path = c.basePath + path
 
-	req, err := http.NewRequest("GET", path, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, "GET", path, bytes.NewBuffer(body))
 
 	if err != nil {
 		return nil, err

--- a/samples/gen-go-db/client/client.go
+++ b/samples/gen-go-db/client/client.go
@@ -165,7 +165,7 @@ func (c *WagClient) HealthCheck(ctx context.Context) error {
 	var body []byte
 	path := c.basePath + "/v1/health/check"
 
-	req, err := http.NewRequest("GET", path, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, "GET", path, bytes.NewBuffer(body))
 
 	if err != nil {
 		return err

--- a/samples/gen-go-errors/client/client.go
+++ b/samples/gen-go-errors/client/client.go
@@ -172,7 +172,7 @@ func (c *WagClient) GetBook(ctx context.Context, i *models.GetBookInput) error {
 
 	path = c.basePath + path
 
-	req, err := http.NewRequest("GET", path, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, "GET", path, bytes.NewBuffer(body))
 
 	if err != nil {
 		return err

--- a/samples/gen-go-nils/client/client.go
+++ b/samples/gen-go-nils/client/client.go
@@ -184,7 +184,7 @@ func (c *WagClient) NilCheck(ctx context.Context, i *models.NilCheckInput) error
 
 	}
 
-	req, err := http.NewRequest("POST", path, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, "POST", path, bytes.NewBuffer(body))
 
 	if err != nil {
 		return err

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -171,7 +171,7 @@ func (c *WagClient) GetAuthors(ctx context.Context, i *models.GetAuthorsInput) (
 
 	path = c.basePath + path
 
-	req, err := http.NewRequest("GET", path, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, "GET", path, bytes.NewBuffer(body))
 
 	if err != nil {
 		return nil, err
@@ -218,7 +218,7 @@ func (c *WagClient) NewGetAuthorsIter(ctx context.Context, i *models.GetAuthorsI
 }
 
 func (i *getAuthorsIterImpl) refresh() error {
-	req, err := http.NewRequest("GET", i.nextURL, bytes.NewBuffer(i.body))
+	req, err := http.NewRequestWithContext(i.ctx, "GET", i.nextURL, bytes.NewBuffer(i.body))
 
 	if err != nil {
 		i.err = err
@@ -370,7 +370,7 @@ func (c *WagClient) GetAuthorsWithPut(ctx context.Context, i *models.GetAuthorsW
 
 	}
 
-	req, err := http.NewRequest("PUT", path, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, "PUT", path, bytes.NewBuffer(body))
 
 	if err != nil {
 		return nil, err
@@ -428,7 +428,7 @@ func (c *WagClient) NewGetAuthorsWithPutIter(ctx context.Context, i *models.GetA
 }
 
 func (i *getAuthorsWithPutIterImpl) refresh() error {
-	req, err := http.NewRequest("PUT", i.nextURL, bytes.NewBuffer(i.body))
+	req, err := http.NewRequestWithContext(i.ctx, "PUT", i.nextURL, bytes.NewBuffer(i.body))
 
 	if err != nil {
 		i.err = err
@@ -571,7 +571,7 @@ func (c *WagClient) GetBooks(ctx context.Context, i *models.GetBooksInput) ([]mo
 
 	headers["authorization"] = i.Authorization
 
-	req, err := http.NewRequest("GET", path, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, "GET", path, bytes.NewBuffer(body))
 
 	if err != nil {
 		return nil, err
@@ -620,7 +620,7 @@ func (c *WagClient) NewGetBooksIter(ctx context.Context, i *models.GetBooksInput
 }
 
 func (i *getBooksIterImpl) refresh() error {
-	req, err := http.NewRequest("GET", i.nextURL, bytes.NewBuffer(i.body))
+	req, err := http.NewRequestWithContext(i.ctx, "GET", i.nextURL, bytes.NewBuffer(i.body))
 
 	if err != nil {
 		i.err = err
@@ -766,7 +766,7 @@ func (c *WagClient) CreateBook(ctx context.Context, i *models.Book) (*models.Boo
 
 	}
 
-	req, err := http.NewRequest("POST", path, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, "POST", path, bytes.NewBuffer(body))
 
 	if err != nil {
 		return nil, err
@@ -873,7 +873,7 @@ func (c *WagClient) PutBook(ctx context.Context, i *models.Book) (*models.Book, 
 
 	}
 
-	req, err := http.NewRequest("PUT", path, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, "PUT", path, bytes.NewBuffer(body))
 
 	if err != nil {
 		return nil, err
@@ -981,7 +981,7 @@ func (c *WagClient) GetBookByID(ctx context.Context, i *models.GetBookByIDInput)
 
 	headers["X-Dont-Rate-Limit-Me-Bro"] = i.XDontRateLimitMeBro
 
-	req, err := http.NewRequest("GET", path, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, "GET", path, bytes.NewBuffer(body))
 
 	if err != nil {
 		return nil, err
@@ -1100,7 +1100,7 @@ func (c *WagClient) GetBookByID2(ctx context.Context, id string) (*models.Book, 
 
 	path = c.basePath + path
 
-	req, err := http.NewRequest("GET", path, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, "GET", path, bytes.NewBuffer(body))
 
 	if err != nil {
 		return nil, err
@@ -1204,7 +1204,7 @@ func (c *WagClient) HealthCheck(ctx context.Context) error {
 	var body []byte
 	path := c.basePath + "/v1/health/check"
 
-	req, err := http.NewRequest("GET", path, bytes.NewBuffer(body))
+	req, err := http.NewRequestWithContext(ctx, "GET", path, bytes.NewBuffer(body))
 
 	if err != nil {
 		return err

--- a/server/gendb/bindata.go
+++ b/server/gendb/bindata.go
@@ -6,12 +6,12 @@
 //  asset-dir: true
 //  restore: true
 // sources:
-//  /Users/taylors/go/src/github.com/Clever/wag/server/gendb/dynamodb-local.sh.tmpl
-//  /Users/taylors/go/src/github.com/Clever/wag/server/gendb/dynamodb.go.tmpl
-//  /Users/taylors/go/src/github.com/Clever/wag/server/gendb/dynamodb_test.go.tmpl
-//  /Users/taylors/go/src/github.com/Clever/wag/server/gendb/interface.go.tmpl
-//  /Users/taylors/go/src/github.com/Clever/wag/server/gendb/table.go.tmpl
-//  /Users/taylors/go/src/github.com/Clever/wag/server/gendb/tests.go.tmpl
+//  /Users/sayansamanta/go/src/github.com/Clever/wag/server/gendb/dynamodb-local.sh.tmpl
+//  /Users/sayansamanta/go/src/github.com/Clever/wag/server/gendb/dynamodb.go.tmpl
+//  /Users/sayansamanta/go/src/github.com/Clever/wag/server/gendb/dynamodb_test.go.tmpl
+//  /Users/sayansamanta/go/src/github.com/Clever/wag/server/gendb/interface.go.tmpl
+//  /Users/sayansamanta/go/src/github.com/Clever/wag/server/gendb/table.go.tmpl
+//  /Users/sayansamanta/go/src/github.com/Clever/wag/server/gendb/tests.go.tmpl
 
 package gendb
 
@@ -86,7 +86,7 @@ var _bindata = map[string]*asset{
 			"\x00\xff\xff",
 		size: 592,
 		mode: 0755,
-		time: time.Unix(1564526222, 244478323),
+		time: time.Unix(1572996316, 745377137),
 	},
 	"dynamodb.go.tmpl": &asset{
 		name: "dynamodb.go.tmpl",
@@ -159,7 +159,7 @@ var _bindata = map[string]*asset{
 			"\x00\xff\xff",
 		size: 7990,
 		mode: 0644,
-		time: time.Unix(1585329125, 462856594),
+		time: time.Unix(1585674933, 845280937),
 	},
 	"dynamodb_test.go.tmpl": &asset{
 		name: "dynamodb_test.go.tmpl",
@@ -227,7 +227,7 @@ var _bindata = map[string]*asset{
 			"\x17\x87\xd4\x3b\x03\x8a\x29\x9e\xee\xd3\x7f\x05\x00\x00\xff\xff",
 		size: 3570,
 		mode: 0644,
-		time: time.Unix(1585251121, 973671240),
+		time: time.Unix(1585674933, 845812351),
 	},
 	"interface.go.tmpl": &asset{
 		name: "interface.go.tmpl",
@@ -308,7 +308,7 @@ var _bindata = map[string]*asset{
 			"\x00\x00\xff\xff",
 		size: 10487,
 		mode: 0644,
-		time: time.Unix(1585329125, 463832980),
+		time: time.Unix(1585674933, 846915077),
 	},
 	"table.go.tmpl": &asset{
 		name: "table.go.tmpl",
@@ -529,7 +529,7 @@ var _bindata = map[string]*asset{
 			"\xff\xff",
 		size: 41538,
 		mode: 0644,
-		time: time.Unix(1585329125, 464334904),
+		time: time.Unix(1585674933, 847695379),
 	},
 	"tests.go.tmpl": &asset{
 		name: "tests.go.tmpl",
@@ -668,7 +668,7 @@ var _bindata = map[string]*asset{
 			"\x9f\xfe\x1f\x00\x00\xff\xff",
 		size: 61677,
 		mode: 0644,
-		time: time.Unix(1585329125, 465697412),
+		time: time.Unix(1585674933, 849197473),
 	},
 }
 


### PR DESCRIPTION
From go 1.13 https://golang.org/doc/go1.13#net/http:

> A new function NewRequestWithContext has been added and it accepts a Context that controls the entire lifetime of the created outgoing Request, suitable for use with Client.Do and Transport.RoundTrip. 

Todo:
- [x] Run `make build`
- [x] Run `make generate`
- [x] Update the current version in the `/VERSION` file.