### PR TITLE
Generate TypeScript union type for inputs that are enums

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,5 @@
-v3.17.0
+v3.18.0
+- v3.18.0: Generate TypeScript string unions for inputs that are enums.
 - v3.17.0: Add support for configuration options and paramatrized settings.
 - v3.16.0: Support for binary fields.
 - v3.15.0: JS client enable compression

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -1178,6 +1178,10 @@ func paramToJSType(param spec.Parameter) (JSType, error) {
 		return typeName, nil
 	}
 
+	if len(param.Enum) > 0 {
+		return typeFromEnum(param.Enum)
+	}
+
 	var typeName string
 	switch param.Type {
 	case "string":
@@ -1248,15 +1252,7 @@ func asJSType(schema *spec.Schema, refPrefix string) (JSType, error) {
 	}
 
 	if len(schema.Enum) > 0 {
-		enums := []string{}
-		for _, enum := range schema.Enum {
-			e, err := json.Marshal(enum)
-			if err != nil {
-				return JSType(""), err
-			}
-			enums = append(enums, string(e))
-		}
-		return JSType("(" + strings.Join(enums, " | ") + ")"), nil
+		return typeFromEnum(schema.Enum)
 	}
 
 	if len(schema.Type) > 1 {
@@ -1292,6 +1288,18 @@ func asJSType(schema *spec.Schema, refPrefix string) (JSType, error) {
 	}
 
 	return JSType(""), fmt.Errorf("Unknown type '%v'", schema.Type[0])
+}
+
+func typeFromEnum(enum []interface{}) (JSType, error) {
+	enums := []string{}
+	for _, enum := range enum {
+		e, err := json.Marshal(enum)
+		if err != nil {
+			return JSType(""), err
+		}
+		enums = append(enums, string(e))
+	}
+	return JSType("(" + strings.Join(enums, " | ") + ")"), nil
 }
 
 func defFromRef(ref string) (string, error) {

--- a/samples/gen-js/index.d.ts
+++ b/samples/gen-js/index.d.ts
@@ -180,7 +180,7 @@ declare namespace SwaggerTest {
     type GetBooksParams = {
   authors?: string[];
   available?: boolean;
-  state?: string;
+  state?: ("finished" | "inprogress");
   published?: string;
   snakeCase?: string;
   completed?: string;

--- a/server/gendb/bindata.go
+++ b/server/gendb/bindata.go
@@ -6,12 +6,12 @@
 //  asset-dir: true
 //  restore: true
 // sources:
-//  /home/bstein/code/wag/server/gendb/dynamodb-local.sh.tmpl
-//  /home/bstein/code/wag/server/gendb/dynamodb.go.tmpl
-//  /home/bstein/code/wag/server/gendb/dynamodb_test.go.tmpl
-//  /home/bstein/code/wag/server/gendb/interface.go.tmpl
-//  /home/bstein/code/wag/server/gendb/table.go.tmpl
-//  /home/bstein/code/wag/server/gendb/tests.go.tmpl
+//  /Users/adamvictor/go/src/github.com/Clever/wag/server/gendb/dynamodb-local.sh.tmpl
+//  /Users/adamvictor/go/src/github.com/Clever/wag/server/gendb/dynamodb.go.tmpl
+//  /Users/adamvictor/go/src/github.com/Clever/wag/server/gendb/dynamodb_test.go.tmpl
+//  /Users/adamvictor/go/src/github.com/Clever/wag/server/gendb/interface.go.tmpl
+//  /Users/adamvictor/go/src/github.com/Clever/wag/server/gendb/table.go.tmpl
+//  /Users/adamvictor/go/src/github.com/Clever/wag/server/gendb/tests.go.tmpl
 
 package gendb
 
@@ -85,8 +85,8 @@ var _bindata = map[string]*asset{
 			"\x5b\xe8\xf4\x51\xf0\xb5\x49\xca\x03\x27\xb1\x87\x16\x34\xc7\xa4\xf8\xf6\xf0\xf0\x68\xfe\x06\x00" +
 			"\x00\xff\xff",
 		size: 592,
-		mode: 0775,
-		time: time.Unix(1581380830, 934346068),
+		mode: 0755,
+		time: time.Unix(1568225074, 388738493),
 	},
 	"dynamodb.go.tmpl": &asset{
 		name: "dynamodb.go.tmpl",
@@ -156,8 +156,8 @@ var _bindata = map[string]*asset{
 			"\xa8\x3c\xcb\x84\xd4\x0a\xbc\x06\x48\x54\x22\xc9\x35\x13\xbc\xd7\xee\xdd\xb5\x96\x03\x0a\x67\x27" +
 			"\x79\x78\xf6\x75\x5c\xfc\x2b\x00\x00\xff\xff",
 		size: 7538,
-		mode: 0664,
-		time: time.Unix(1581380830, 934346068),
+		mode: 0644,
+		time: time.Unix(1568225074, 388933090),
 	},
 	"dynamodb_test.go.tmpl": &asset{
 		name: "dynamodb_test.go.tmpl",
@@ -224,8 +224,8 @@ var _bindata = map[string]*asset{
 			"\x13\x5e\x98\x44\x8b\xff\xa2\x6c\xc7\xdb\x40\x55\x0b\x87\x62\x80\xc8\x8f\x10\xbe\x7e\x17\xfd\x96" +
 			"\x17\x87\xd4\x3b\x03\x8a\x29\x9e\xee\xd3\x7f\x05\x00\x00\xff\xff",
 		size: 3570,
-		mode: 0664,
-		time: time.Unix(1581380830, 934346068),
+		mode: 0644,
+		time: time.Unix(1581643120, 477522416),
 	},
 	"interface.go.tmpl": &asset{
 		name: "interface.go.tmpl",
@@ -302,8 +302,8 @@ var _bindata = map[string]*asset{
 			"\x24\x16\xae\xcd\x87\xc3\x21\xb9\xd4\xbe\xd6\xab\xe5\x4d\x5b\xf0\xae\x1c\xe9\x7c\xbf\x22\x05\x27" +
 			"\xa0\x61\x1d\xf7\xb6\xb8\x3f\x03\x00\x00\xff\xff",
 		size: 9538,
-		mode: 0664,
-		time: time.Unix(1581380830, 934346068),
+		mode: 0644,
+		time: time.Unix(1581643120, 478016856),
 	},
 	"table.go.tmpl": &asset{
 		name: "table.go.tmpl",
@@ -520,8 +520,8 @@ var _bindata = map[string]*asset{
 			"\xc4\x64\xc9\xf3\x2f\x6d\x54\xd1\xe2\x16\x73\x73\x5d\xd9\xae\xa7\x52\xaa\xc1\xa4\xa9\x94\x7f\x07" +
 			"\x00\x00\xff\xff",
 		size: 39738,
-		mode: 0664,
-		time: time.Unix(1581380830, 934346068),
+		mode: 0644,
+		time: time.Unix(1581643120, 478472291),
 	},
 	"tests.go.tmpl": &asset{
 		name: "tests.go.tmpl",
@@ -651,8 +651,8 @@ var _bindata = map[string]*asset{
 			"\xa2\x0f\x92\x67\xa6\xf7\x36\xe4\xd7\xc2\xf8\x2c\x96\xdd\x7c\x84\xc5\x04\xf1\xca\xa7\xff\x07\x00" +
 			"\x00\xff\xff",
 		size: 52573,
-		mode: 0664,
-		time: time.Unix(1581380830, 934346068),
+		mode: 0644,
+		time: time.Unix(1568225074, 390439401),
 	},
 }
 


### PR DESCRIPTION
Previously, the TypeScript types for input params that were enums were just being generated as `string` instead of the more specific union types we generate for `enums` in the `definitions` section. This change makes it so we generate union types instead using the same logic as elsewhere. See the generated samples file for the difference!

Todo:

- [X] Run `make build`
- [X] Run `make generate`
- [X] Update the current version in the `/VERSION` file.
