### PR TITLE
Rewrite graceful server shutdown

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -100,10 +100,6 @@ required = ["github.com/tmthrgd/go-bindata", "github.com/golang/mock/mockgen", "
   branch = "v2"
 
 [[constraint]]
-  name = "gopkg.in/tylerb/graceful.v1"
-  version = "1.0.0"
-
-[[constraint]]
   name = "gopkg.in/yaml.v2"
   branch = "v2"
 

--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,5 @@
-v3.21.0
+v3.22.0
+- v3.22.0: Use http.Server.Shutdown for graceful end of life handling
 - v3.21.0: Go client now uses context to control request lifecycle
 - v3.20.0: Add dynamodb codegen support for scanning over global secondary indexes.
 - v3.19.1: Codegen fix for KEYS_ONLY index with composite property made of required properties

--- a/samples/gen-go-blog/server/router.go
+++ b/samples/gen-go-blog/server/router.go
@@ -4,13 +4,16 @@ package server
 
 import (
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"path"
 	"strconv"
+	"syscall"
 	"time"
 
 	// register pprof listener
@@ -26,7 +29,6 @@ import (
 	"github.com/uber/jaeger-client-go/transport"
 	"gopkg.in/Clever/kayvee-go.v6/logger"
 	kvMiddleware "gopkg.in/Clever/kayvee-go.v6/middleware"
-	"gopkg.in/tylerb/graceful.v1"
 )
 
 const (
@@ -146,7 +148,35 @@ func (s *Server) Serve() error {
 	s.l.Counter("server-started")
 
 	// Give the sever 30 seconds to shut down
-	return graceful.RunWithErr(s.addr, 30*time.Second, s.Handler)
+	server := &http.Server{
+		Addr:        s.addr,
+		Handler:     s.Handler,
+		IdleTimeout: 3 * time.Minute,
+	}
+	server.SetKeepAlivesEnabled(true)
+
+	// Give the server 30 seconds to shut down gracefully after it receives a signal
+	shutdown := make(chan struct{})
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt, os.Signal(syscall.SIGTERM))
+		sig := <-c
+		s.l.CriticalD("shutdown-initiated", logger.M{"signal": sig.String()})
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		defer close(shutdown)
+		if err := server.Shutdown(ctx); err != nil {
+			s.l.CriticalD("error-during-shutdown", logger.M{"error": err.Error()})
+		}
+	}()
+
+	if err := server.ListenAndServe(); err != http.ErrServerClosed {
+		return err
+	}
+	// ensure we wait for graceful shutdown
+	<-shutdown
+
+	return nil
 }
 
 type handler struct {

--- a/samples/gen-go-db/server/router.go
+++ b/samples/gen-go-db/server/router.go
@@ -4,13 +4,16 @@ package server
 
 import (
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"path"
 	"strconv"
+	"syscall"
 	"time"
 
 	// register pprof listener
@@ -26,7 +29,6 @@ import (
 	"github.com/uber/jaeger-client-go/transport"
 	"gopkg.in/Clever/kayvee-go.v6/logger"
 	kvMiddleware "gopkg.in/Clever/kayvee-go.v6/middleware"
-	"gopkg.in/tylerb/graceful.v1"
 )
 
 const (
@@ -146,7 +148,35 @@ func (s *Server) Serve() error {
 	s.l.Counter("server-started")
 
 	// Give the sever 30 seconds to shut down
-	return graceful.RunWithErr(s.addr, 30*time.Second, s.Handler)
+	server := &http.Server{
+		Addr:        s.addr,
+		Handler:     s.Handler,
+		IdleTimeout: 3 * time.Minute,
+	}
+	server.SetKeepAlivesEnabled(true)
+
+	// Give the server 30 seconds to shut down gracefully after it receives a signal
+	shutdown := make(chan struct{})
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt, os.Signal(syscall.SIGTERM))
+		sig := <-c
+		s.l.CriticalD("shutdown-initiated", logger.M{"signal": sig.String()})
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		defer close(shutdown)
+		if err := server.Shutdown(ctx); err != nil {
+			s.l.CriticalD("error-during-shutdown", logger.M{"error": err.Error()})
+		}
+	}()
+
+	if err := server.ListenAndServe(); err != http.ErrServerClosed {
+		return err
+	}
+	// ensure we wait for graceful shutdown
+	<-shutdown
+
+	return nil
 }
 
 type handler struct {

--- a/samples/gen-go-deprecated/server/router.go
+++ b/samples/gen-go-deprecated/server/router.go
@@ -4,13 +4,16 @@ package server
 
 import (
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"path"
 	"strconv"
+	"syscall"
 	"time"
 
 	// register pprof listener
@@ -26,7 +29,6 @@ import (
 	"github.com/uber/jaeger-client-go/transport"
 	"gopkg.in/Clever/kayvee-go.v6/logger"
 	kvMiddleware "gopkg.in/Clever/kayvee-go.v6/middleware"
-	"gopkg.in/tylerb/graceful.v1"
 )
 
 const (
@@ -146,7 +148,35 @@ func (s *Server) Serve() error {
 	s.l.Counter("server-started")
 
 	// Give the sever 30 seconds to shut down
-	return graceful.RunWithErr(s.addr, 30*time.Second, s.Handler)
+	server := &http.Server{
+		Addr:        s.addr,
+		Handler:     s.Handler,
+		IdleTimeout: 3 * time.Minute,
+	}
+	server.SetKeepAlivesEnabled(true)
+
+	// Give the server 30 seconds to shut down gracefully after it receives a signal
+	shutdown := make(chan struct{})
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt, os.Signal(syscall.SIGTERM))
+		sig := <-c
+		s.l.CriticalD("shutdown-initiated", logger.M{"signal": sig.String()})
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		defer close(shutdown)
+		if err := server.Shutdown(ctx); err != nil {
+			s.l.CriticalD("error-during-shutdown", logger.M{"error": err.Error()})
+		}
+	}()
+
+	if err := server.ListenAndServe(); err != http.ErrServerClosed {
+		return err
+	}
+	// ensure we wait for graceful shutdown
+	<-shutdown
+
+	return nil
 }
 
 type handler struct {

--- a/samples/gen-go-errors/server/router.go
+++ b/samples/gen-go-errors/server/router.go
@@ -4,13 +4,16 @@ package server
 
 import (
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"path"
 	"strconv"
+	"syscall"
 	"time"
 
 	// register pprof listener
@@ -26,7 +29,6 @@ import (
 	"github.com/uber/jaeger-client-go/transport"
 	"gopkg.in/Clever/kayvee-go.v6/logger"
 	kvMiddleware "gopkg.in/Clever/kayvee-go.v6/middleware"
-	"gopkg.in/tylerb/graceful.v1"
 )
 
 const (
@@ -146,7 +148,35 @@ func (s *Server) Serve() error {
 	s.l.Counter("server-started")
 
 	// Give the sever 30 seconds to shut down
-	return graceful.RunWithErr(s.addr, 30*time.Second, s.Handler)
+	server := &http.Server{
+		Addr:        s.addr,
+		Handler:     s.Handler,
+		IdleTimeout: 3 * time.Minute,
+	}
+	server.SetKeepAlivesEnabled(true)
+
+	// Give the server 30 seconds to shut down gracefully after it receives a signal
+	shutdown := make(chan struct{})
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt, os.Signal(syscall.SIGTERM))
+		sig := <-c
+		s.l.CriticalD("shutdown-initiated", logger.M{"signal": sig.String()})
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		defer close(shutdown)
+		if err := server.Shutdown(ctx); err != nil {
+			s.l.CriticalD("error-during-shutdown", logger.M{"error": err.Error()})
+		}
+	}()
+
+	if err := server.ListenAndServe(); err != http.ErrServerClosed {
+		return err
+	}
+	// ensure we wait for graceful shutdown
+	<-shutdown
+
+	return nil
 }
 
 type handler struct {

--- a/samples/gen-go-nils/server/router.go
+++ b/samples/gen-go-nils/server/router.go
@@ -4,13 +4,16 @@ package server
 
 import (
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"path"
 	"strconv"
+	"syscall"
 	"time"
 
 	// register pprof listener
@@ -26,7 +29,6 @@ import (
 	"github.com/uber/jaeger-client-go/transport"
 	"gopkg.in/Clever/kayvee-go.v6/logger"
 	kvMiddleware "gopkg.in/Clever/kayvee-go.v6/middleware"
-	"gopkg.in/tylerb/graceful.v1"
 )
 
 const (
@@ -146,7 +148,35 @@ func (s *Server) Serve() error {
 	s.l.Counter("server-started")
 
 	// Give the sever 30 seconds to shut down
-	return graceful.RunWithErr(s.addr, 30*time.Second, s.Handler)
+	server := &http.Server{
+		Addr:        s.addr,
+		Handler:     s.Handler,
+		IdleTimeout: 3 * time.Minute,
+	}
+	server.SetKeepAlivesEnabled(true)
+
+	// Give the server 30 seconds to shut down gracefully after it receives a signal
+	shutdown := make(chan struct{})
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt, os.Signal(syscall.SIGTERM))
+		sig := <-c
+		s.l.CriticalD("shutdown-initiated", logger.M{"signal": sig.String()})
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		defer close(shutdown)
+		if err := server.Shutdown(ctx); err != nil {
+			s.l.CriticalD("error-during-shutdown", logger.M{"error": err.Error()})
+		}
+	}()
+
+	if err := server.ListenAndServe(); err != http.ErrServerClosed {
+		return err
+	}
+	// ensure we wait for graceful shutdown
+	<-shutdown
+
+	return nil
 }
 
 type handler struct {

--- a/samples/gen-go/server/router.go
+++ b/samples/gen-go/server/router.go
@@ -4,13 +4,16 @@ package server
 
 import (
 	"compress/gzip"
+	"context"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
 	"path"
 	"strconv"
+	"syscall"
 	"time"
 
 	// register pprof listener
@@ -26,7 +29,6 @@ import (
 	"github.com/uber/jaeger-client-go/transport"
 	"gopkg.in/Clever/kayvee-go.v6/logger"
 	kvMiddleware "gopkg.in/Clever/kayvee-go.v6/middleware"
-	"gopkg.in/tylerb/graceful.v1"
 )
 
 const (
@@ -146,7 +148,35 @@ func (s *Server) Serve() error {
 	s.l.Counter("server-started")
 
 	// Give the sever 30 seconds to shut down
-	return graceful.RunWithErr(s.addr, 30*time.Second, s.Handler)
+	server := &http.Server{
+		Addr:        s.addr,
+		Handler:     s.Handler,
+		IdleTimeout: 3 * time.Minute,
+	}
+	server.SetKeepAlivesEnabled(true)
+
+	// Give the server 30 seconds to shut down gracefully after it receives a signal
+	shutdown := make(chan struct{})
+	go func() {
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt, os.Signal(syscall.SIGTERM))
+		sig := <-c
+		s.l.CriticalD("shutdown-initiated", logger.M{"signal": sig.String()})
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		defer close(shutdown)
+		if err := server.Shutdown(ctx); err != nil {
+			s.l.CriticalD("error-during-shutdown", logger.M{"error": err.Error()})
+		}
+	}()
+
+	if err := server.ListenAndServe(); err != http.ErrServerClosed {
+		return err
+	}
+	// ensure we wait for graceful shutdown
+	<-shutdown
+
+	return nil
 }
 
 type handler struct {


### PR DESCRIPTION
**Overview:**
the graceful library we are currently using has been deprecated for
quite some time now in favor of the native support delivered in golang
1.8

this implementation is a very minor rewrite of the example provided in
godocs: https://golang.org/pkg/net/http/#example_Server_Shutdown

**TODO:**
- [x] Run `make build`
- [x] Run `make generate`
- [x] Update the current version in the `/VERSION` file.