### PR TITLE
Client: Add status code to error when status code not recognized

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,5 @@
-v6.0.0
+v6.0.1
+- v6.0.1: Add the status code to the client's error message when the status code is not recognized.
 - v6.0.0: Revert the breaking changes to go-openapi/swag from 5.0.0.
 - v5.0.0: Convert to modules
 - v4.1.0: Support limiting the number of items returned by DynamoDB scans.

--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -600,7 +600,7 @@ func parseResponseCode(s *spec.Swagger, op *spec.Operation, capOpID string) stri
 	errorType, _ := swagger.OutputType(s, op, 500)
 	buf.WriteString(fmt.Sprintf(`
 	default:
-		return %s&%s{Message: "Unknown response"}
+		return %s&%s{Message: fmt.Sprintf("Unknown status code %%%%%%%%v", resp.StatusCode)}
 	}
 }
 

--- a/samples/gen-go-blog/client/client.go
+++ b/samples/gen-go-blog/client/client.go
@@ -251,7 +251,7 @@ func (c *WagClient) doGetSectionsForStudentRequest(ctx context.Context, req *htt
 		return nil, &output
 
 	default:
-		return nil, &models.InternalError{Message: "Unknown response"}
+		return nil, &models.InternalError{Message: fmt.Sprintf("Unknown status code %v", resp.StatusCode)}
 	}
 }
 
@@ -353,7 +353,7 @@ func (c *WagClient) doPostSectionsForStudentRequest(ctx context.Context, req *ht
 		return nil, &output
 
 	default:
-		return nil, &models.InternalError{Message: "Unknown response"}
+		return nil, &models.InternalError{Message: fmt.Sprintf("Unknown status code %v", resp.StatusCode)}
 	}
 }
 

--- a/samples/gen-go-db/client/client.go
+++ b/samples/gen-go-db/client/client.go
@@ -240,7 +240,7 @@ func (c *WagClient) doHealthCheckRequest(ctx context.Context, req *http.Request,
 		return &output
 
 	default:
-		return &models.InternalError{Message: "Unknown response"}
+		return &models.InternalError{Message: fmt.Sprintf("Unknown status code %v", resp.StatusCode)}
 	}
 }
 

--- a/samples/gen-go-errors/client/client.go
+++ b/samples/gen-go-errors/client/client.go
@@ -255,7 +255,7 @@ func (c *WagClient) doGetBookRequest(ctx context.Context, req *http.Request, hea
 		return &output
 
 	default:
-		return &models.InternalError{Message: "Unknown response"}
+		return &models.InternalError{Message: fmt.Sprintf("Unknown status code %v", resp.StatusCode)}
 	}
 }
 

--- a/samples/gen-go-nils/client/client.go
+++ b/samples/gen-go-nils/client/client.go
@@ -259,7 +259,7 @@ func (c *WagClient) doNilCheckRequest(ctx context.Context, req *http.Request, he
 		return &output
 
 	default:
-		return &models.InternalError{Message: "Unknown response"}
+		return &models.InternalError{Message: fmt.Sprintf("Unknown status code %v", resp.StatusCode)}
 	}
 }
 

--- a/samples/gen-go/client/client.go
+++ b/samples/gen-go/client/client.go
@@ -337,7 +337,7 @@ func (c *WagClient) doGetAuthorsRequest(ctx context.Context, req *http.Request, 
 		return nil, "", &output
 
 	default:
-		return nil, "", &models.InternalError{Message: "Unknown response"}
+		return nil, "", &models.InternalError{Message: fmt.Sprintf("Unknown status code %v", resp.StatusCode)}
 	}
 }
 
@@ -547,7 +547,7 @@ func (c *WagClient) doGetAuthorsWithPutRequest(ctx context.Context, req *http.Re
 		return nil, "", &output
 
 	default:
-		return nil, "", &models.InternalError{Message: "Unknown response"}
+		return nil, "", &models.InternalError{Message: fmt.Sprintf("Unknown status code %v", resp.StatusCode)}
 	}
 }
 
@@ -739,7 +739,7 @@ func (c *WagClient) doGetBooksRequest(ctx context.Context, req *http.Request, he
 		return nil, "", &output
 
 	default:
-		return nil, "", &models.InternalError{Message: "Unknown response"}
+		return nil, "", &models.InternalError{Message: fmt.Sprintf("Unknown status code %v", resp.StatusCode)}
 	}
 }
 
@@ -846,7 +846,7 @@ func (c *WagClient) doCreateBookRequest(ctx context.Context, req *http.Request, 
 		return nil, &output
 
 	default:
-		return nil, &models.InternalError{Message: "Unknown response"}
+		return nil, &models.InternalError{Message: fmt.Sprintf("Unknown status code %v", resp.StatusCode)}
 	}
 }
 
@@ -953,7 +953,7 @@ func (c *WagClient) doPutBookRequest(ctx context.Context, req *http.Request, hea
 		return nil, &output
 
 	default:
-		return nil, &models.InternalError{Message: "Unknown response"}
+		return nil, &models.InternalError{Message: fmt.Sprintf("Unknown status code %v", resp.StatusCode)}
 	}
 }
 
@@ -1077,7 +1077,7 @@ func (c *WagClient) doGetBookByIDRequest(ctx context.Context, req *http.Request,
 		return nil, &output
 
 	default:
-		return nil, &models.InternalError{Message: "Unknown response"}
+		return nil, &models.InternalError{Message: fmt.Sprintf("Unknown status code %v", resp.StatusCode)}
 	}
 }
 
@@ -1188,7 +1188,7 @@ func (c *WagClient) doGetBookByID2Request(ctx context.Context, req *http.Request
 		return nil, &output
 
 	default:
-		return nil, &models.InternalError{Message: "Unknown response"}
+		return nil, &models.InternalError{Message: fmt.Sprintf("Unknown status code %v", resp.StatusCode)}
 	}
 }
 
@@ -1279,7 +1279,7 @@ func (c *WagClient) doHealthCheckRequest(ctx context.Context, req *http.Request,
 		return &output
 
 	default:
-		return &models.InternalError{Message: "Unknown response"}
+		return &models.InternalError{Message: fmt.Sprintf("Unknown status code %v", resp.StatusCode)}
 	}
 }
 


### PR DESCRIPTION
When the status code returned by the server is not recognized, the client classifies the error as a `models.InternalError` with the message `"Unknown response"`

This PR changes the message of the error to include the unrecognized status code. For example, `"Unknown status code 503"`

- [x] Run `make build`
- [x] Run `make generate`
- [x] Update the current version in the `/VERSION` file.
