### PR TITLE
Support binary server handler

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,5 @@
-v6.3.0
+v6.4.0
+- v6.4.0: Generate server handler with binary request body
 - v6.3.0: Generate client with binary request body
 - v6.2.0: Add --dynamo-only and --dynamo-path flags
 - v6.1.0: Add --client-only and --client-language flags to generate only client code

--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -234,11 +234,16 @@ func generateClient(packageName, packagePath string, s spec.Swagger) error {
 func IsBinaryBody(op *spec.Operation, definitions map[string]spec.Schema) bool {
 	for _, param := range op.Parameters {
 		if param.In == "body" {
-			definitionName := path.Base(param.Schema.Ref.Ref.GetURL().String())
-			return definitions[definitionName].Format == "binary"
+			return IsBinaryParam(param, definitions)
 		}
 	}
 	return false
+}
+
+// IsBinaryParam returns true of the format of the parameter is binary
+func IsBinaryParam(param spec.Parameter, definitions map[string]spec.Schema) bool {
+	definitionName := path.Base(param.Schema.Ref.Ref.GetURL().String())
+	return definitions[definitionName].Format == "binary"
 }
 
 func generateInterface(packageName, packagePath string, s *spec.Swagger, serviceName string, paths *spec.Paths) error {

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/Clever/go-process-metrics v0.0.0-20171109172046-76790fe7fd86 h1:zVsjy
 github.com/Clever/go-process-metrics v0.0.0-20171109172046-76790fe7fd86/go.mod h1:Aemel1It05GRZlIfbxbTLl0TwgFaaAALkqfyzuTDk7s=
 github.com/Clever/go-utils v0.0.0-20150501165843-abc25366fa8e h1:mwYZTFK3HvBY5zqwtxezWFnQOdL8VWhOSXjrBnMngAI=
 github.com/Clever/go-utils v0.0.0-20150501165843-abc25366fa8e/go.mod h1:XXTA9F/953CGhnDRslFaBp7S0560745gMZSDm+C4ebw=
-github.com/Clever/wag v1.14.2 h1:OdUsbefl9l/N1iOwePPuBEK22bcotw7acq0g80OwfHE=
-github.com/Clever/wag v4.1.0+incompatible h1:/7y61nKf6d3VKYk+/XFw1e7tmXG6tu4AO3UmFhROfa0=
 github.com/PuerkitoBio/purell v1.1.0 h1:rmGxhojJlM0tuKtfdvliR84CFHljx9ag64t2xmVkjK4=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
@@ -28,6 +26,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/donovanhide/eventsource v0.0.0-20171031113327-3ed64d21fb0b h1:eR1P/A4QMYF2/LpHRhYAts9wyYEtF7qNk/tVNiYCWc8=
 github.com/donovanhide/eventsource v0.0.0-20171031113327-3ed64d21fb0b/go.mod h1:56wL82FO0bfMU5RvfXoIwSOP2ggqqxT+tAfNEIyxuHw=
+github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -70,8 +69,7 @@ github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gorilla/handlers v1.4.2 h1:0QniY0USkHQ1RGCLfKxeNHK9bkDHGRYGNDFBCS+YARg=
-github.com/gorilla/handlers v1.4.2/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
 github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
@@ -193,8 +191,7 @@ golang.org/x/tools v0.0.0-20190328211700-ab21143f2384 h1:TFlARGu6Czu1z7q93HTxcP1
 golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gopkg.in/Clever/kayvee-go.v6 v6.17.0 h1:jTr+aHRmBJo7FUCAFEBP47F/dqwpVYv6mkmB1teATW0=
-gopkg.in/Clever/kayvee-go.v6 v6.17.0/go.mod h1:G0m6nBZj7Kdz+w2hiIaawmhXl5zp7E/K0ashol3Kb2A=
+gopkg.in/Clever/kayvee-go.v6 v6.24.1 h1:lHxjlTFj57mfrq06PiCKIAJ0QuHHEqsyvSYvzb+gSFg=
 gopkg.in/Clever/kayvee-go.v6 v6.24.1/go.mod h1:G0m6nBZj7Kdz+w2hiIaawmhXl5zp7E/K0ashol3Kb2A=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/samples/gen-go-blog/server/handlers.go
+++ b/samples/gen-go-blog/server/handlers.go
@@ -160,20 +160,7 @@ func newPostGradeFileForStudentInput(r *http.Request) (*models.PostGradeFileForS
 		input.StudentID = studentIDTmp
 	}
 
-	data, err := ioutil.ReadAll(r.Body)
-
-	sp.LogFields(log.Int("request-size-bytes", len(data)))
-
-	if len(data) > 0 {
-		jsonSpan, _ := opentracing.StartSpanFromContext(r.Context(), "json-request-marshaling")
-		defer jsonSpan.Finish()
-
-		input.File = &models.GradeFile{}
-		if err := json.NewDecoder(bytes.NewReader(data)).Decode(input.File); err != nil {
-			return nil, err
-		}
-
-	}
+	input.File = (*models.GradeFile)(&r.Body)
 
 	return &input, nil
 }


### PR DESCRIPTION
* similar to https://github.com/Clever/wag/pull/340
* support generating server handlers with binary request body

- [x] Run `make build`
- [x] Run `make generate`
- [x] Update the current version in the `/VERSION` file.
