### PR TITLE
add close() to js client to release handles at the end of client use

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,5 @@
-v7.1.0
+v7.1.1
+- v7.1.1: Add close() to TypeScript clients to release outstanding handles
 - v7.1.0: Properly generate TypeScript types for allOf
 - v7.0.1 bugfix --client-only not generating tracing files
 - v7.0.0

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -300,7 +300,14 @@ class {{.ClassName}} {
       context(this).
       build();
 
-    setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+    this._logCircuitStateInterval = setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+  }
+
+  /**
+  * Releases handles used in client
+  */
+  close() {
+    clearInterval(this._logCircuitStateInterval);
   }
 
   _hystrixCommandErrorHandler(err) {
@@ -1363,6 +1370,7 @@ import models = {{.ServiceName}}.Models
 declare class {{.ServiceName}} {
   constructor(options: {{.ServiceName}}Options);
 
+  close();
   {{range .MethodDecls}}
   {{.}}
   {{end}}

--- a/samples/gen-js-blog/README.md
+++ b/samples/gen-js-blog/README.md
@@ -8,6 +8,7 @@ blog client library.
     * [Blog](#exp_module_blog--Blog) ⏏
         * [new Blog(options)](#new_module_blog--Blog_new)
         * _instance_
+            * [.close()](#module_blog--Blog+close)
             * [.postGradeFileForStudent(params, [options], [cb])](#module_blog--Blog+postGradeFileForStudent) ⇒ <code>Promise</code>
             * [.getSectionsForStudent(studentID, [options], [cb])](#module_blog--Blog+getSectionsForStudent) ⇒ <code>Promise</code>
             * [.postSectionsForStudent(params, [options], [cb])](#module_blog--Blog+postSectionsForStudent) ⇒ <code>Promise</code>
@@ -49,6 +50,12 @@ Create a new client object.
 | [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
 | [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
 
+<a name="module_blog--Blog+close"></a>
+
+#### blog.close()
+Releases handles used in client
+
+**Kind**: instance method of [<code>Blog</code>](#exp_module_blog--Blog)  
 <a name="module_blog--Blog+postGradeFileForStudent"></a>
 
 #### blog.postGradeFileForStudent(params, [options], [cb]) ⇒ <code>Promise</code>

--- a/samples/gen-js-blog/index.d.ts
+++ b/samples/gen-js-blog/index.d.ts
@@ -54,6 +54,7 @@ import models = Blog.Models
 declare class Blog {
   constructor(options: BlogOptions);
 
+  close();
   
   postGradeFileForStudent(params: models.PostGradeFileForStudentParams, options?: RequestOptions, cb?: Callback<void>): Promise<void>
   

--- a/samples/gen-js-blog/index.js
+++ b/samples/gen-js-blog/index.js
@@ -205,7 +205,14 @@ class Blog {
       context(this).
       build();
 
-    setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+    this._logCircuitStateInterval = setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+  }
+
+  /**
+  * Releases handles used in client
+  */
+  close() {
+    clearInterval(this._logCircuitStateInterval);
   }
 
   _hystrixCommandErrorHandler(err) {

--- a/samples/gen-js-client-only/README.md
+++ b/samples/gen-js-client-only/README.md
@@ -8,6 +8,7 @@ swagger-test client library.
     * [SwaggerTest](#exp_module_swagger-test--SwaggerTest) ⏏
         * [new SwaggerTest(options)](#new_module_swagger-test--SwaggerTest_new)
         * _instance_
+            * [.close()](#module_swagger-test--SwaggerTest+close)
             * [.getAuthors(params, [options], [cb])](#module_swagger-test--SwaggerTest+getAuthors) ⇒ <code>Promise</code>
             * [.getAuthorsIter(params, [options])](#module_swagger-test--SwaggerTest+getAuthorsIter) ⇒ <code>Object</code> \| <code>function</code> \| <code>function</code> \| <code>function</code> \| <code>function</code>
             * [.getAuthorsWithPut(params, [options], [cb])](#module_swagger-test--SwaggerTest+getAuthorsWithPut) ⇒ <code>Promise</code>
@@ -59,6 +60,12 @@ Create a new client object.
 | [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
 | [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
 
+<a name="module_swagger-test--SwaggerTest+close"></a>
+
+#### swaggerTest.close()
+Releases handles used in client
+
+**Kind**: instance method of [<code>SwaggerTest</code>](#exp_module_swagger-test--SwaggerTest)  
 <a name="module_swagger-test--SwaggerTest+getAuthors"></a>
 
 #### swaggerTest.getAuthors(params, [options], [cb]) ⇒ <code>Promise</code>

--- a/samples/gen-js-client-only/index.d.ts
+++ b/samples/gen-js-client-only/index.d.ts
@@ -54,6 +54,7 @@ import models = SwaggerTest.Models
 declare class SwaggerTest {
   constructor(options: SwaggerTestOptions);
 
+  close();
   
   getAuthors(params: models.GetAuthorsParams, options?: RequestOptions, cb?: Callback<models.AuthorsResponse>): Promise<models.AuthorsResponse>
   getAuthorsIter(params: models.GetAuthorsParams, options?: RequestOptions): IterResult<ArrayInner<models.AuthorsResponse["authorSet"]["results"]>>

--- a/samples/gen-js-client-only/index.js
+++ b/samples/gen-js-client-only/index.js
@@ -205,7 +205,14 @@ class SwaggerTest {
       context(this).
       build();
 
-    setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+    this._logCircuitStateInterval = setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+  }
+
+  /**
+  * Releases handles used in client
+  */
+  close() {
+    clearInterval(this._logCircuitStateInterval);
   }
 
   _hystrixCommandErrorHandler(err) {

--- a/samples/gen-js-db-custom-path/README.md
+++ b/samples/gen-js-db-custom-path/README.md
@@ -8,6 +8,7 @@ swagger-test client library.
     * [SwaggerTest](#exp_module_swagger-test--SwaggerTest) ⏏
         * [new SwaggerTest(options)](#new_module_swagger-test--SwaggerTest_new)
         * _instance_
+            * [.close()](#module_swagger-test--SwaggerTest+close)
             * [.healthCheck([options], [cb])](#module_swagger-test--SwaggerTest+healthCheck) ⇒ <code>Promise</code>
         * _static_
             * [.RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)
@@ -47,6 +48,12 @@ Create a new client object.
 | [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
 | [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
 
+<a name="module_swagger-test--SwaggerTest+close"></a>
+
+#### swaggerTest.close()
+Releases handles used in client
+
+**Kind**: instance method of [<code>SwaggerTest</code>](#exp_module_swagger-test--SwaggerTest)  
 <a name="module_swagger-test--SwaggerTest+healthCheck"></a>
 
 #### swaggerTest.healthCheck([options], [cb]) ⇒ <code>Promise</code>

--- a/samples/gen-js-db-custom-path/index.d.ts
+++ b/samples/gen-js-db-custom-path/index.d.ts
@@ -54,6 +54,7 @@ import models = SwaggerTest.Models
 declare class SwaggerTest {
   constructor(options: SwaggerTestOptions);
 
+  close();
   
   healthCheck(options?: RequestOptions, cb?: Callback<void>): Promise<void>
   

--- a/samples/gen-js-db-custom-path/index.js
+++ b/samples/gen-js-db-custom-path/index.js
@@ -205,7 +205,14 @@ class SwaggerTest {
       context(this).
       build();
 
-    setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+    this._logCircuitStateInterval = setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+  }
+
+  /**
+  * Releases handles used in client
+  */
+  close() {
+    clearInterval(this._logCircuitStateInterval);
   }
 
   _hystrixCommandErrorHandler(err) {

--- a/samples/gen-js-db/README.md
+++ b/samples/gen-js-db/README.md
@@ -8,6 +8,7 @@ swagger-test client library.
     * [SwaggerTest](#exp_module_swagger-test--SwaggerTest) ⏏
         * [new SwaggerTest(options)](#new_module_swagger-test--SwaggerTest_new)
         * _instance_
+            * [.close()](#module_swagger-test--SwaggerTest+close)
             * [.healthCheck([options], [cb])](#module_swagger-test--SwaggerTest+healthCheck) ⇒ <code>Promise</code>
         * _static_
             * [.RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)
@@ -47,6 +48,12 @@ Create a new client object.
 | [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
 | [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
 
+<a name="module_swagger-test--SwaggerTest+close"></a>
+
+#### swaggerTest.close()
+Releases handles used in client
+
+**Kind**: instance method of [<code>SwaggerTest</code>](#exp_module_swagger-test--SwaggerTest)  
 <a name="module_swagger-test--SwaggerTest+healthCheck"></a>
 
 #### swaggerTest.healthCheck([options], [cb]) ⇒ <code>Promise</code>

--- a/samples/gen-js-db/index.d.ts
+++ b/samples/gen-js-db/index.d.ts
@@ -54,6 +54,7 @@ import models = SwaggerTest.Models
 declare class SwaggerTest {
   constructor(options: SwaggerTestOptions);
 
+  close();
   
   healthCheck(options?: RequestOptions, cb?: Callback<void>): Promise<void>
   

--- a/samples/gen-js-db/index.js
+++ b/samples/gen-js-db/index.js
@@ -205,7 +205,14 @@ class SwaggerTest {
       context(this).
       build();
 
-    setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+    this._logCircuitStateInterval = setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+  }
+
+  /**
+  * Releases handles used in client
+  */
+  close() {
+    clearInterval(this._logCircuitStateInterval);
   }
 
   _hystrixCommandErrorHandler(err) {

--- a/samples/gen-js-deprecated/README.md
+++ b/samples/gen-js-deprecated/README.md
@@ -7,15 +7,18 @@ swagger-test client library.
 * [swagger-test](#module_swagger-test)
     * [SwaggerTest](#exp_module_swagger-test--SwaggerTest) ⏏
         * [new SwaggerTest(options)](#new_module_swagger-test--SwaggerTest_new)
-        * [.RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)
-            * [.Exponential](#module_swagger-test--SwaggerTest.RetryPolicies.Exponential)
-            * [.Single](#module_swagger-test--SwaggerTest.RetryPolicies.Single)
-            * [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
-        * [.Errors](#module_swagger-test--SwaggerTest.Errors)
-            * [.BadRequest](#module_swagger-test--SwaggerTest.Errors.BadRequest) ⇐ <code>Error</code>
-            * [.NotFound](#module_swagger-test--SwaggerTest.Errors.NotFound) ⇐ <code>Error</code>
-            * [.InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError) ⇐ <code>Error</code>
-        * [.DefaultCircuitOptions](#module_swagger-test--SwaggerTest.DefaultCircuitOptions)
+        * _instance_
+            * [.close()](#module_swagger-test--SwaggerTest+close)
+        * _static_
+            * [.RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)
+                * [.Exponential](#module_swagger-test--SwaggerTest.RetryPolicies.Exponential)
+                * [.Single](#module_swagger-test--SwaggerTest.RetryPolicies.Single)
+                * [.None](#module_swagger-test--SwaggerTest.RetryPolicies.None)
+            * [.Errors](#module_swagger-test--SwaggerTest.Errors)
+                * [.BadRequest](#module_swagger-test--SwaggerTest.Errors.BadRequest) ⇐ <code>Error</code>
+                * [.NotFound](#module_swagger-test--SwaggerTest.Errors.NotFound) ⇐ <code>Error</code>
+                * [.InternalError](#module_swagger-test--SwaggerTest.Errors.InternalError) ⇐ <code>Error</code>
+            * [.DefaultCircuitOptions](#module_swagger-test--SwaggerTest.DefaultCircuitOptions)
 
 <a name="exp_module_swagger-test--SwaggerTest"></a>
 
@@ -45,6 +48,12 @@ Create a new client object.
 | [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
 | [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
 
+<a name="module_swagger-test--SwaggerTest+close"></a>
+
+#### swaggerTest.close()
+Releases handles used in client
+
+**Kind**: instance method of [<code>SwaggerTest</code>](#exp_module_swagger-test--SwaggerTest)  
 <a name="module_swagger-test--SwaggerTest.RetryPolicies"></a>
 
 #### SwaggerTest.RetryPolicies

--- a/samples/gen-js-deprecated/index.d.ts
+++ b/samples/gen-js-deprecated/index.d.ts
@@ -54,6 +54,7 @@ import models = SwaggerTest.Models
 declare class SwaggerTest {
   constructor(options: SwaggerTestOptions);
 
+  close();
   
 }
 

--- a/samples/gen-js-deprecated/index.js
+++ b/samples/gen-js-deprecated/index.js
@@ -205,7 +205,14 @@ class SwaggerTest {
       context(this).
       build();
 
-    setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+    this._logCircuitStateInterval = setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+  }
+
+  /**
+  * Releases handles used in client
+  */
+  close() {
+    clearInterval(this._logCircuitStateInterval);
   }
 
   _hystrixCommandErrorHandler(err) {

--- a/samples/gen-js-errors/README.md
+++ b/samples/gen-js-errors/README.md
@@ -8,6 +8,7 @@ swagger-test client library.
     * [SwaggerTest](#exp_module_swagger-test--SwaggerTest) ⏏
         * [new SwaggerTest(options)](#new_module_swagger-test--SwaggerTest_new)
         * _instance_
+            * [.close()](#module_swagger-test--SwaggerTest+close)
             * [.getBook(id, [options], [cb])](#module_swagger-test--SwaggerTest+getBook) ⇒ <code>Promise</code>
         * _static_
             * [.RetryPolicies](#module_swagger-test--SwaggerTest.RetryPolicies)
@@ -48,6 +49,12 @@ Create a new client object.
 | [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
 | [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
 
+<a name="module_swagger-test--SwaggerTest+close"></a>
+
+#### swaggerTest.close()
+Releases handles used in client
+
+**Kind**: instance method of [<code>SwaggerTest</code>](#exp_module_swagger-test--SwaggerTest)  
 <a name="module_swagger-test--SwaggerTest+getBook"></a>
 
 #### swaggerTest.getBook(id, [options], [cb]) ⇒ <code>Promise</code>

--- a/samples/gen-js-errors/index.d.ts
+++ b/samples/gen-js-errors/index.d.ts
@@ -54,6 +54,7 @@ import models = SwaggerTest.Models
 declare class SwaggerTest {
   constructor(options: SwaggerTestOptions);
 
+  close();
   
   getBook(id: number, options?: RequestOptions, cb?: Callback<void>): Promise<void>
   

--- a/samples/gen-js-errors/index.js
+++ b/samples/gen-js-errors/index.js
@@ -205,7 +205,14 @@ class SwaggerTest {
       context(this).
       build();
 
-    setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+    this._logCircuitStateInterval = setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+  }
+
+  /**
+  * Releases handles used in client
+  */
+  close() {
+    clearInterval(this._logCircuitStateInterval);
   }
 
   _hystrixCommandErrorHandler(err) {

--- a/samples/gen-js-nils/README.md
+++ b/samples/gen-js-nils/README.md
@@ -8,6 +8,7 @@ nil-test client library.
     * [NilTest](#exp_module_nil-test--NilTest) ⏏
         * [new NilTest(options)](#new_module_nil-test--NilTest_new)
         * _instance_
+            * [.close()](#module_nil-test--NilTest+close)
             * [.nilCheck(params, [options], [cb])](#module_nil-test--NilTest+nilCheck) ⇒ <code>Promise</code>
         * _static_
             * [.RetryPolicies](#module_nil-test--NilTest.RetryPolicies)
@@ -47,6 +48,12 @@ Create a new client object.
 | [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
 | [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
 
+<a name="module_nil-test--NilTest+close"></a>
+
+#### nilTest.close()
+Releases handles used in client
+
+**Kind**: instance method of [<code>NilTest</code>](#exp_module_nil-test--NilTest)  
 <a name="module_nil-test--NilTest+nilCheck"></a>
 
 #### nilTest.nilCheck(params, [options], [cb]) ⇒ <code>Promise</code>

--- a/samples/gen-js-nils/index.d.ts
+++ b/samples/gen-js-nils/index.d.ts
@@ -54,6 +54,7 @@ import models = NilTest.Models
 declare class NilTest {
   constructor(options: NilTestOptions);
 
+  close();
   
   nilCheck(params: models.NilCheckParams, options?: RequestOptions, cb?: Callback<void>): Promise<void>
   

--- a/samples/gen-js-nils/index.js
+++ b/samples/gen-js-nils/index.js
@@ -205,7 +205,14 @@ class NilTest {
       context(this).
       build();
 
-    setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+    this._logCircuitStateInterval = setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+  }
+
+  /**
+  * Releases handles used in client
+  */
+  close() {
+    clearInterval(this._logCircuitStateInterval);
   }
 
   _hystrixCommandErrorHandler(err) {

--- a/samples/gen-js/README.md
+++ b/samples/gen-js/README.md
@@ -8,6 +8,7 @@ swagger-test client library.
     * [SwaggerTest](#exp_module_swagger-test--SwaggerTest) ⏏
         * [new SwaggerTest(options)](#new_module_swagger-test--SwaggerTest_new)
         * _instance_
+            * [.close()](#module_swagger-test--SwaggerTest+close)
             * [.getAuthors(params, [options], [cb])](#module_swagger-test--SwaggerTest+getAuthors) ⇒ <code>Promise</code>
             * [.getAuthorsIter(params, [options])](#module_swagger-test--SwaggerTest+getAuthorsIter) ⇒ <code>Object</code> \| <code>function</code> \| <code>function</code> \| <code>function</code> \| <code>function</code>
             * [.getAuthorsWithPut(params, [options], [cb])](#module_swagger-test--SwaggerTest+getAuthorsWithPut) ⇒ <code>Promise</code>
@@ -59,6 +60,12 @@ Create a new client object.
 | [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
 | [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
 
+<a name="module_swagger-test--SwaggerTest+close"></a>
+
+#### swaggerTest.close()
+Releases handles used in client
+
+**Kind**: instance method of [<code>SwaggerTest</code>](#exp_module_swagger-test--SwaggerTest)  
 <a name="module_swagger-test--SwaggerTest+getAuthors"></a>
 
 #### swaggerTest.getAuthors(params, [options], [cb]) ⇒ <code>Promise</code>

--- a/samples/gen-js/index.d.ts
+++ b/samples/gen-js/index.d.ts
@@ -54,6 +54,7 @@ import models = SwaggerTest.Models
 declare class SwaggerTest {
   constructor(options: SwaggerTestOptions);
 
+  close();
   
   getAuthors(params: models.GetAuthorsParams, options?: RequestOptions, cb?: Callback<models.AuthorsResponse>): Promise<models.AuthorsResponse>
   getAuthorsIter(params: models.GetAuthorsParams, options?: RequestOptions): IterResult<ArrayInner<models.AuthorsResponse["authorSet"]["results"]>>

--- a/samples/gen-js/index.js
+++ b/samples/gen-js/index.js
@@ -205,7 +205,14 @@ class SwaggerTest {
       context(this).
       build();
 
-    setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+    this._logCircuitStateInterval = setInterval(() => this._logCircuitState(), circuitOptions.logIntervalMs);
+  }
+
+  /**
+  * Releases handles used in client
+  */
+  close() {
+    clearInterval(this._logCircuitStateInterval);
   }
 
   _hystrixCommandErrorHandler(err) {


### PR DESCRIPTION
Todo:

- [x] Run `make build`
- [x] Run `make generate`
- [x] Update the current version in the `/VERSION` file.
