### PR TITLE
Fix TS type for close method on js client

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,6 @@
-v8.1.1
+v8.1.2
+
+v8.1.2: Improve TS type for close method on js client
 
 v8.1.1: Revert update of open-api spec dependency bump
 

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -1370,7 +1370,7 @@ import models = {{.ServiceName}}.Models
 declare class {{.ServiceName}} {
   constructor(options: {{.ServiceName}}Options);
 
-  close();
+  close(): void;
   {{range .MethodDecls}}
   {{.}}
   {{end}}

--- a/samples/gen-js-blog/index.d.ts
+++ b/samples/gen-js-blog/index.d.ts
@@ -54,7 +54,7 @@ import models = Blog.Models
 declare class Blog {
   constructor(options: BlogOptions);
 
-  close();
+  close(): void;
   
   postGradeFileForStudent(params: models.PostGradeFileForStudentParams, options?: RequestOptions, cb?: Callback<void>): Promise<void>
   

--- a/samples/gen-js-client-only/index.d.ts
+++ b/samples/gen-js-client-only/index.d.ts
@@ -54,7 +54,7 @@ import models = SwaggerTest.Models
 declare class SwaggerTest {
   constructor(options: SwaggerTestOptions);
 
-  close();
+  close(): void;
   
   getAuthors(params: models.GetAuthorsParams, options?: RequestOptions, cb?: Callback<models.AuthorsResponse>): Promise<models.AuthorsResponse>
   getAuthorsIter(params: models.GetAuthorsParams, options?: RequestOptions): IterResult<ArrayInner<models.AuthorsResponse["authorSet"]["results"]>>

--- a/samples/gen-js-db-custom-path/index.d.ts
+++ b/samples/gen-js-db-custom-path/index.d.ts
@@ -54,7 +54,7 @@ import models = SwaggerTest.Models
 declare class SwaggerTest {
   constructor(options: SwaggerTestOptions);
 
-  close();
+  close(): void;
   
   healthCheck(options?: RequestOptions, cb?: Callback<void>): Promise<void>
   

--- a/samples/gen-js-db/index.d.ts
+++ b/samples/gen-js-db/index.d.ts
@@ -54,7 +54,7 @@ import models = SwaggerTest.Models
 declare class SwaggerTest {
   constructor(options: SwaggerTestOptions);
 
-  close();
+  close(): void;
   
   healthCheck(options?: RequestOptions, cb?: Callback<void>): Promise<void>
   

--- a/samples/gen-js-deprecated/index.d.ts
+++ b/samples/gen-js-deprecated/index.d.ts
@@ -54,7 +54,7 @@ import models = SwaggerTest.Models
 declare class SwaggerTest {
   constructor(options: SwaggerTestOptions);
 
-  close();
+  close(): void;
   
 }
 

--- a/samples/gen-js-errors/index.d.ts
+++ b/samples/gen-js-errors/index.d.ts
@@ -54,7 +54,7 @@ import models = SwaggerTest.Models
 declare class SwaggerTest {
   constructor(options: SwaggerTestOptions);
 
-  close();
+  close(): void;
   
   getBook(id: number, options?: RequestOptions, cb?: Callback<void>): Promise<void>
   

--- a/samples/gen-js-nils/index.d.ts
+++ b/samples/gen-js-nils/index.d.ts
@@ -54,7 +54,7 @@ import models = NilTest.Models
 declare class NilTest {
   constructor(options: NilTestOptions);
 
-  close();
+  close(): void;
   
   nilCheck(params: models.NilCheckParams, options?: RequestOptions, cb?: Callback<void>): Promise<void>
   

--- a/samples/gen-js/index.d.ts
+++ b/samples/gen-js/index.d.ts
@@ -54,7 +54,7 @@ import models = SwaggerTest.Models
 declare class SwaggerTest {
   constructor(options: SwaggerTestOptions);
 
-  close();
+  close(): void;
   
   getAuthors(params: models.GetAuthorsParams, options?: RequestOptions, cb?: Callback<models.AuthorsResponse>): Promise<models.AuthorsResponse>
   getAuthorsIter(params: models.GetAuthorsParams, options?: RequestOptions): IterResult<ArrayInner<models.AuthorsResponse["authorSet"]["results"]>>


### PR DESCRIPTION
Very minor, but I noticed that the `close` method on the js client is currently typed as `close()` in the TypeScript types. While the intent was that it should have no return value, what this actually means is that the return value is unspecified. In general, it defaults to `any` and will cause a `noImplicitAny` violation, although the violation is largely a non-issue since we usually run the TS compiler with `skipLibCheck`.

This fixes the type to indicate that it returns nothing. It's a minor fix, but I figured I'd make it while I noticed.

Todo:

- [X] Run `make build`
- [X] Run `make generate`
- [X] Update the current version in the `/VERSION` file.
