### PR TITLE
Support TS methods with a single hyphenated header variables

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,6 @@
-v8.1.2
+v8.1.3
+
+v8.1.3: Support TS methods with a single hyphenated header variable
 
 v8.1.2: Improve TS type for close method on js client
 

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -1061,7 +1061,7 @@ func methodDecl(s spec.Swagger, op *spec.Operation, path, method string) (string
 	if len(op.Parameters) == 0 {
 		params = ""
 	} else if len(op.Parameters) == 1 {
-		paramName := op.Parameters[0].Name
+		paramName := utils.CamelCase(op.Parameters[0].Name, false)
 		var paramType JSType
 		if op.Parameters[0].ParamProps.Schema != nil {
 			paramType, err = asJSType(op.Parameters[0].ParamProps.Schema, "")

--- a/clients/js/type_script_test.go
+++ b/clients/js/type_script_test.go
@@ -90,3 +90,22 @@ func TestGeneratePropertyDeclaration(t *testing.T) {
 		)
 	})
 }
+
+func TestMethodDeclWithHyphens(t *testing.T) {
+	//variable names with hyphens won't compile in ts, but they're really common in header variables.
+	//Convert x-csrf-token to XCSRFToken: string
+	param := spec.Parameter{}
+	param.Name = "hyphen-y-name"
+	param.Type = "string"
+	param.Required = true
+	param.In = "header"
+
+	op := spec.Operation{}
+	op.ID = "withHyphen"
+	op.Parameters = []spec.Parameter{param}
+	op.Responses = &spec.Responses{}
+
+	result, err := methodDecl(spec.Swagger{}, &op, "", "")
+	assert.NoError(t, err)
+	assert.Regexp(t, `withHyphen\(hyphenYName: string`, result)
+}


### PR DESCRIPTION
Variable names with hyphens won't compile in ts, but they're really
common in header variables.

Convert `x-csrf-token` to `XCSRFToken: string`

If this looks good, I need to backport it to wag7.