### PR TITLE
Bump to v8.1.3

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,7 @@
-v8.1.2
+v8.1.3
+
+v8.1.3: No changes, we just rely on the most recent (by chronology) release being the actual latest
+version in our build pipelines.
 
 v8.1.2: Improve TS type for close method on js client
 


### PR DESCRIPTION
Clever's build system assumes the latest release (by date released) is also the highest semver
release because they are not that smart.

Todo:

- [x] Run `make build`
- [x] Run `make generate`
- [x] Update the current version in the `/VERSION` file.
