### PR TITLE
Fix common initialisms for batch deletes

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,6 @@
-v8.1.6
+v8.1.7
+
+v8.1.7: Fix for dynamo batch deletes when using common initialisms in composite index
 
 v8.1.6: Add dynamodb codegen support for batch deleting arrays of objects
 

--- a/samples/db.yml
+++ b/samples/db.yml
@@ -241,24 +241,24 @@ definitions:
       AllowPrimaryIndexScan: true
       AllowBatchwrites: true
       CompositeAttributes:
-      - AttributeName: name_branch
-        Properties: [ name, branch ]
+      - AttributeName: name_id
+        Properties: [ name, id ]
         Separator: "@"
       DynamoDB:
         KeySchema:
-        - AttributeName: name_branch
+        - AttributeName: name_id
           KeyType: HASH
         - AttributeName: date
           KeyType: RANGE
     type: object
     required:
     - name
-    - branch
+    - id
     - date
     properties:
       name:
         type: string
-      branch:
+      id:
         type: string
       date:
         type: string

--- a/samples/gen-go-db-custom-path/db/dynamodb/dynamodb.go
+++ b/samples/gen-go-db-custom-path/db/dynamodb/dynamodb.go
@@ -745,8 +745,8 @@ func (d DB) DeleteArrayOfThingAllowingBatchWritesWithCompositeAttributes(ctx con
 }
 
 // GetThingAllowingBatchWritesWithCompositeAttributes retrieves a ThingAllowingBatchWritesWithCompositeAttributes from the database.
-func (d DB) GetThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, branch string, date strfmt.DateTime) (*models.ThingAllowingBatchWritesWithCompositeAttributes, error) {
-	return d.thingAllowingBatchWritesWithCompositeAttributesTable.getThingAllowingBatchWritesWithCompositeAttributes(ctx, name, branch, date)
+func (d DB) GetThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, id string, date strfmt.DateTime) (*models.ThingAllowingBatchWritesWithCompositeAttributes, error) {
+	return d.thingAllowingBatchWritesWithCompositeAttributesTable.getThingAllowingBatchWritesWithCompositeAttributes(ctx, name, id, date)
 }
 
 // ScanThingAllowingBatchWritesWithCompositeAttributess runs a scan on the ThingAllowingBatchWritesWithCompositeAttributess table.
@@ -754,14 +754,14 @@ func (d DB) ScanThingAllowingBatchWritesWithCompositeAttributess(ctx context.Con
 	return d.thingAllowingBatchWritesWithCompositeAttributesTable.scanThingAllowingBatchWritesWithCompositeAttributess(ctx, input, fn)
 }
 
-// GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate retrieves a page of ThingAllowingBatchWritesWithCompositeAttributess from the database.
-func (d DB) GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(ctx context.Context, input db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput, fn func(m *models.ThingAllowingBatchWritesWithCompositeAttributes, lastThingAllowingBatchWritesWithCompositeAttributes bool) bool) error {
-	return d.thingAllowingBatchWritesWithCompositeAttributesTable.getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(ctx, input, fn)
+// GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate retrieves a page of ThingAllowingBatchWritesWithCompositeAttributess from the database.
+func (d DB) GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(ctx context.Context, input db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput, fn func(m *models.ThingAllowingBatchWritesWithCompositeAttributes, lastThingAllowingBatchWritesWithCompositeAttributes bool) bool) error {
+	return d.thingAllowingBatchWritesWithCompositeAttributesTable.getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(ctx, input, fn)
 }
 
 // DeleteThingAllowingBatchWritesWithCompositeAttributes deletes a ThingAllowingBatchWritesWithCompositeAttributes from the database.
-func (d DB) DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, branch string, date strfmt.DateTime) error {
-	return d.thingAllowingBatchWritesWithCompositeAttributesTable.deleteThingAllowingBatchWritesWithCompositeAttributes(ctx, name, branch, date)
+func (d DB) DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, id string, date strfmt.DateTime) error {
+	return d.thingAllowingBatchWritesWithCompositeAttributesTable.deleteThingAllowingBatchWritesWithCompositeAttributes(ctx, name, id, date)
 }
 
 // SaveThingWithCompositeAttributes saves a ThingWithCompositeAttributes to the database.

--- a/samples/gen-go-db-custom-path/db/interface.go
+++ b/samples/gen-go-db-custom-path/db/interface.go
@@ -132,13 +132,13 @@ type Interface interface {
 	// DeleteArrayOfThingAllowingBatchWritesWithCompositeAttributes batch deletes all items in []ThingAllowingBatchWritesWithCompositeAttributes in the database.
 	DeleteArrayOfThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, ms []models.ThingAllowingBatchWritesWithCompositeAttributes) error
 	// GetThingAllowingBatchWritesWithCompositeAttributes retrieves a ThingAllowingBatchWritesWithCompositeAttributes from the database.
-	GetThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, branch string, date strfmt.DateTime) (*models.ThingAllowingBatchWritesWithCompositeAttributes, error)
+	GetThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, id string, date strfmt.DateTime) (*models.ThingAllowingBatchWritesWithCompositeAttributes, error)
 	// ScanThingAllowingBatchWritesWithCompositeAttributess runs a scan on the ThingAllowingBatchWritesWithCompositeAttributess table.
 	ScanThingAllowingBatchWritesWithCompositeAttributess(ctx context.Context, input ScanThingAllowingBatchWritesWithCompositeAttributessInput, fn func(m *models.ThingAllowingBatchWritesWithCompositeAttributes, lastThingAllowingBatchWritesWithCompositeAttributes bool) bool) error
-	// GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate retrieves a page of ThingAllowingBatchWritesWithCompositeAttributess from the database.
-	GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(ctx context.Context, input GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput, fn func(m *models.ThingAllowingBatchWritesWithCompositeAttributes, lastThingAllowingBatchWritesWithCompositeAttributes bool) bool) error
+	// GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate retrieves a page of ThingAllowingBatchWritesWithCompositeAttributess from the database.
+	GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(ctx context.Context, input GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput, fn func(m *models.ThingAllowingBatchWritesWithCompositeAttributes, lastThingAllowingBatchWritesWithCompositeAttributes bool) bool) error
 	// DeleteThingAllowingBatchWritesWithCompositeAttributes deletes a ThingAllowingBatchWritesWithCompositeAttributes from the database.
-	DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, branch string, date strfmt.DateTime) error
+	DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, id string, date strfmt.DateTime) error
 
 	// SaveThingWithCompositeAttributes saves a ThingWithCompositeAttributes to the database.
 	SaveThingWithCompositeAttributes(ctx context.Context, m models.ThingWithCompositeAttributes) error
@@ -928,12 +928,12 @@ type ScanThingAllowingBatchWritesWithCompositeAttributessInput struct {
 	Limiter *rate.Limiter
 }
 
-// GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput is the query input to GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate.
-type GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput struct {
+// GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput is the query input to GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate.
+type GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput struct {
 	// Name is required
 	Name string
-	// Branch is required
-	Branch         string
+	// ID is required
+	ID             string
 	DateStartingAt *strfmt.DateTime
 	// StartingAfter is a required specification of an exclusive starting point.
 	StartingAfter *models.ThingAllowingBatchWritesWithCompositeAttributes
@@ -946,9 +946,9 @@ type GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput
 
 // ErrThingAllowingBatchWritesWithCompositeAttributesNotFound is returned when the database fails to find a ThingAllowingBatchWritesWithCompositeAttributes.
 type ErrThingAllowingBatchWritesWithCompositeAttributesNotFound struct {
-	Name   string
-	Branch string
-	Date   strfmt.DateTime
+	Name string
+	ID   string
+	Date strfmt.DateTime
 }
 
 var _ error = ErrThingAllowingBatchWritesWithCompositeAttributesNotFound{}
@@ -960,8 +960,8 @@ func (e ErrThingAllowingBatchWritesWithCompositeAttributesNotFound) Error() stri
 
 // ErrThingAllowingBatchWritesWithCompositeAttributesAlreadyExists is returned when trying to overwrite a ThingAllowingBatchWritesWithCompositeAttributes.
 type ErrThingAllowingBatchWritesWithCompositeAttributesAlreadyExists struct {
-	NameBranch string
-	Date       strfmt.DateTime
+	NameID string
+	Date   strfmt.DateTime
 }
 
 var _ error = ErrThingAllowingBatchWritesWithCompositeAttributesAlreadyExists{}

--- a/samples/gen-go-db-custom-path/db/mock_db.go
+++ b/samples/gen-go-db-custom-path/db/mock_db.go
@@ -163,17 +163,17 @@ func (mr *MockInterfaceMockRecorder) DeleteThingAllowingBatchWrites(ctx, name, v
 }
 
 // DeleteThingAllowingBatchWritesWithCompositeAttributes mocks base method.
-func (m *MockInterface) DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name, branch string, date strfmt.DateTime) error {
+func (m *MockInterface) DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name, id string, date strfmt.DateTime) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteThingAllowingBatchWritesWithCompositeAttributes", ctx, name, branch, date)
+	ret := m.ctrl.Call(m, "DeleteThingAllowingBatchWritesWithCompositeAttributes", ctx, name, id, date)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteThingAllowingBatchWritesWithCompositeAttributes indicates an expected call of DeleteThingAllowingBatchWritesWithCompositeAttributes.
-func (mr *MockInterfaceMockRecorder) DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx, name, branch, date interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx, name, id, date interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteThingAllowingBatchWritesWithCompositeAttributes", reflect.TypeOf((*MockInterface)(nil).DeleteThingAllowingBatchWritesWithCompositeAttributes), ctx, name, branch, date)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteThingAllowingBatchWritesWithCompositeAttributes", reflect.TypeOf((*MockInterface)(nil).DeleteThingAllowingBatchWritesWithCompositeAttributes), ctx, name, id, date)
 }
 
 // DeleteThingWithCompositeAttributes mocks base method.
@@ -563,32 +563,32 @@ func (mr *MockInterfaceMockRecorder) GetThingAllowingBatchWrites(ctx, name, vers
 }
 
 // GetThingAllowingBatchWritesWithCompositeAttributes mocks base method.
-func (m *MockInterface) GetThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name, branch string, date strfmt.DateTime) (*models.ThingAllowingBatchWritesWithCompositeAttributes, error) {
+func (m *MockInterface) GetThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name, id string, date strfmt.DateTime) (*models.ThingAllowingBatchWritesWithCompositeAttributes, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetThingAllowingBatchWritesWithCompositeAttributes", ctx, name, branch, date)
+	ret := m.ctrl.Call(m, "GetThingAllowingBatchWritesWithCompositeAttributes", ctx, name, id, date)
 	ret0, _ := ret[0].(*models.ThingAllowingBatchWritesWithCompositeAttributes)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetThingAllowingBatchWritesWithCompositeAttributes indicates an expected call of GetThingAllowingBatchWritesWithCompositeAttributes.
-func (mr *MockInterfaceMockRecorder) GetThingAllowingBatchWritesWithCompositeAttributes(ctx, name, branch, date interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) GetThingAllowingBatchWritesWithCompositeAttributes(ctx, name, id, date interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThingAllowingBatchWritesWithCompositeAttributes", reflect.TypeOf((*MockInterface)(nil).GetThingAllowingBatchWritesWithCompositeAttributes), ctx, name, branch, date)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThingAllowingBatchWritesWithCompositeAttributes", reflect.TypeOf((*MockInterface)(nil).GetThingAllowingBatchWritesWithCompositeAttributes), ctx, name, id, date)
 }
 
-// GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate mocks base method.
-func (m *MockInterface) GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(ctx context.Context, input GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput, fn func(*models.ThingAllowingBatchWritesWithCompositeAttributes, bool) bool) error {
+// GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate mocks base method.
+func (m *MockInterface) GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(ctx context.Context, input GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput, fn func(*models.ThingAllowingBatchWritesWithCompositeAttributes, bool) bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate", ctx, input, fn)
+	ret := m.ctrl.Call(m, "GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate", ctx, input, fn)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate indicates an expected call of GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate.
-func (mr *MockInterfaceMockRecorder) GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(ctx, input, fn interface{}) *gomock.Call {
+// GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate indicates an expected call of GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate.
+func (mr *MockInterfaceMockRecorder) GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(ctx, input, fn interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate", reflect.TypeOf((*MockInterface)(nil).GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate), ctx, input, fn)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate", reflect.TypeOf((*MockInterface)(nil).GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate), ctx, input, fn)
 }
 
 // GetThingAllowingBatchWritessByNameAndVersion mocks base method.

--- a/samples/gen-go-db-custom-path/db/tests/tests.go
+++ b/samples/gen-go-db-custom-path/db/tests/tests.go
@@ -74,7 +74,7 @@ func RunDBTests(t *testing.T, dbFactory func() db.Interface) {
 	t.Run("DeleteThingAllowingBatchWrites", DeleteThingAllowingBatchWrites(dbFactory(), t))
 	t.Run("GetThingAllowingBatchWritesWithCompositeAttributes", GetThingAllowingBatchWritesWithCompositeAttributes(dbFactory(), t))
 	t.Run("ScanThingAllowingBatchWritesWithCompositeAttributess", ScanThingAllowingBatchWritesWithCompositeAttributess(dbFactory(), t))
-	t.Run("GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate", GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(dbFactory(), t))
+	t.Run("GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate", GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(dbFactory(), t))
 	t.Run("SaveThingAllowingBatchWritesWithCompositeAttributes", SaveThingAllowingBatchWritesWithCompositeAttributes(dbFactory(), t))
 	t.Run("DeleteThingAllowingBatchWritesWithCompositeAttributes", DeleteThingAllowingBatchWritesWithCompositeAttributes(dbFactory(), t))
 	t.Run("GetThingWithCompositeAttributes", GetThingWithCompositeAttributes(dbFactory(), t))
@@ -5047,15 +5047,15 @@ func GetThingAllowingBatchWritesWithCompositeAttributes(s db.Interface, t *testi
 	return func(t *testing.T) {
 		ctx := context.Background()
 		m := models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
-			Name:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+			ID:   db.String("string1"),
+			Name: db.String("string1"),
 		}
 		require.Nil(t, s.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, m))
-		m2, err := s.GetThingAllowingBatchWritesWithCompositeAttributes(ctx, *m.Name, *m.Branch, *m.Date)
+		m2, err := s.GetThingAllowingBatchWritesWithCompositeAttributes(ctx, *m.Name, *m.ID, *m.Date)
 		require.Nil(t, err)
 		require.Equal(t, *m.Name, *m2.Name)
-		require.Equal(t, *m.Branch, *m2.Branch)
+		require.Equal(t, *m.ID, *m2.ID)
 		require.Equal(t, m.Date.String(), m2.Date.String())
 
 		_, err = s.GetThingAllowingBatchWritesWithCompositeAttributes(ctx, "string2", "string2", mustTime("2018-03-11T15:04:02+07:00"))
@@ -5064,22 +5064,22 @@ func GetThingAllowingBatchWritesWithCompositeAttributes(s db.Interface, t *testi
 	}
 }
 
-type getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput struct {
+type getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput struct {
 	ctx   context.Context
-	input db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput
+	input db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput
 }
-type getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput struct {
+type getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput struct {
 	thingAllowingBatchWritesWithCompositeAttributess []models.ThingAllowingBatchWritesWithCompositeAttributes
 	err                                              error
 }
-type getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateTest struct {
+type getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateTest struct {
 	testName string
 	d        db.Interface
-	input    getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput
-	output   getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput
+	input    getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput
+	output   getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput
 }
 
-func (g getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateTest) run(t *testing.T) {
+func (g getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateTest) run(t *testing.T) {
 	thingAllowingBatchWritesWithCompositeAttributess := []models.ThingAllowingBatchWritesWithCompositeAttributes{}
 	fn := func(m *models.ThingAllowingBatchWritesWithCompositeAttributes, lastThingAllowingBatchWritesWithCompositeAttributes bool) bool {
 		thingAllowingBatchWritesWithCompositeAttributess = append(thingAllowingBatchWritesWithCompositeAttributess, *m)
@@ -5088,7 +5088,7 @@ func (g getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateTe
 		}
 		return true
 	}
-	err := g.d.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(g.input.ctx, g.input.input, fn)
+	err := g.d.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(g.input.ctx, g.input.input, fn)
 	if err != nil {
 		fmt.Println(err.Error())
 	}
@@ -5096,53 +5096,53 @@ func (g getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateTe
 	require.Equal(t, g.output.thingAllowingBatchWritesWithCompositeAttributess, thingAllowingBatchWritesWithCompositeAttributess)
 }
 
-func GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(d db.Interface, t *testing.T) func(t *testing.T) {
+func GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(d db.Interface, t *testing.T) func(t *testing.T) {
 	return func(t *testing.T) {
 		ctx := context.Background()
 		require.Nil(t, d.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Name:   db.String("string1"),
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+			Name: db.String("string1"),
+			ID:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
 		}))
 		require.Nil(t, d.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Name:   db.String("string1"),
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+			Name: db.String("string1"),
+			ID:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 		}))
 		require.Nil(t, d.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Name:   db.String("string1"),
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+			Name: db.String("string1"),
+			ID:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
 		}))
 		limit := int64(3)
-		tests := []getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateTest{
+		tests := []getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateTest{
 			{
 				testName: "basic",
 				d:        d,
-				input: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+				input: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 					ctx: context.Background(),
-					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
-						Name:   "string1",
-						Branch: "string1",
-						Limit:  &limit,
+					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
+						Name:  "string1",
+						ID:    "string1",
+						Limit: &limit,
 					},
 				},
-				output: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput{
+				output: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput{
 					thingAllowingBatchWritesWithCompositeAttributess: []models.ThingAllowingBatchWritesWithCompositeAttributes{
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
 						},
 					},
 					err: nil,
@@ -5151,30 +5151,30 @@ func GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(d db
 			{
 				testName: "descending",
 				d:        d,
-				input: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+				input: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 					ctx: context.Background(),
-					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 						Name:       "string1",
-						Branch:     "string1",
+						ID:         "string1",
 						Descending: true,
 					},
 				},
-				output: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput{
+				output: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput{
 					thingAllowingBatchWritesWithCompositeAttributess: []models.ThingAllowingBatchWritesWithCompositeAttributes{
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
 						},
 					},
 					err: nil,
@@ -5183,29 +5183,29 @@ func GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(d db
 			{
 				testName: "starting after",
 				d:        d,
-				input: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+				input: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 					ctx: context.Background(),
-					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
-						Name:   "string1",
-						Branch: "string1",
+					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
+						Name: "string1",
+						ID:   "string1",
 						StartingAfter: &models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
 						},
 					},
 				},
-				output: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput{
+				output: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput{
 					thingAllowingBatchWritesWithCompositeAttributess: []models.ThingAllowingBatchWritesWithCompositeAttributes{
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
 						},
 					},
 					err: nil,
@@ -5214,30 +5214,30 @@ func GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(d db
 			{
 				testName: "starting after descending",
 				d:        d,
-				input: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+				input: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 					ctx: context.Background(),
-					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
-						Name:   "string1",
-						Branch: "string1",
+					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
+						Name: "string1",
+						ID:   "string1",
 						StartingAfter: &models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
 						},
 						Descending: true,
 					},
 				},
-				output: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput{
+				output: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput{
 					thingAllowingBatchWritesWithCompositeAttributess: []models.ThingAllowingBatchWritesWithCompositeAttributes{
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
 						},
 					},
 					err: nil,
@@ -5246,25 +5246,25 @@ func GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(d db
 			{
 				testName: "starting at",
 				d:        d,
-				input: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+				input: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 					ctx: context.Background(),
-					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 						Name:           "string1",
-						Branch:         "string1",
+						ID:             "string1",
 						DateStartingAt: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 					},
 				},
-				output: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput{
+				output: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput{
 					thingAllowingBatchWritesWithCompositeAttributess: []models.ThingAllowingBatchWritesWithCompositeAttributes{
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
 						},
 					},
 					err: nil,
@@ -5283,37 +5283,37 @@ func ScanThingAllowingBatchWritesWithCompositeAttributess(d db.Interface, t *tes
 	return func(t *testing.T) {
 		ctx := context.Background()
 		require.Nil(t, d.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
-			Name:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+			ID:   db.String("string1"),
+			Name: db.String("string1"),
 		}))
 		require.Nil(t, d.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Branch: db.String("string2"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
-			Name:   db.String("string2"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+			ID:   db.String("string2"),
+			Name: db.String("string2"),
 		}))
 		require.Nil(t, d.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Branch: db.String("string3"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
-			Name:   db.String("string3"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+			ID:   db.String("string3"),
+			Name: db.String("string3"),
 		}))
 
 		t.Run("basic", func(t *testing.T) {
 			expected := []models.ThingAllowingBatchWritesWithCompositeAttributes{
 				models.ThingAllowingBatchWritesWithCompositeAttributes{
-					Branch: db.String("string1"),
-					Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
-					Name:   db.String("string1"),
+					Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+					ID:   db.String("string1"),
+					Name: db.String("string1"),
 				},
 				models.ThingAllowingBatchWritesWithCompositeAttributes{
-					Branch: db.String("string2"),
-					Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
-					Name:   db.String("string2"),
+					Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+					ID:   db.String("string2"),
+					Name: db.String("string2"),
 				},
 				models.ThingAllowingBatchWritesWithCompositeAttributes{
-					Branch: db.String("string3"),
-					Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
-					Name:   db.String("string3"),
+					Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+					ID:   db.String("string3"),
+					Name: db.String("string3"),
 				},
 			}
 			actual := []models.ThingAllowingBatchWritesWithCompositeAttributes{}
@@ -5348,9 +5348,9 @@ func ScanThingAllowingBatchWritesWithCompositeAttributess(d db.Interface, t *tes
 			// Scan for everything after the first item.
 			scanInput := db.ScanThingAllowingBatchWritesWithCompositeAttributessInput{
 				StartingAfter: &models.ThingAllowingBatchWritesWithCompositeAttributes{
-					Name:   firstItem.Name,
-					Branch: firstItem.Branch,
-					Date:   firstItem.Date,
+					Name: firstItem.Name,
+					ID:   firstItem.ID,
+					Date: firstItem.Date,
 				},
 			}
 			actual := []models.ThingAllowingBatchWritesWithCompositeAttributes{}
@@ -5393,9 +5393,9 @@ func SaveThingAllowingBatchWritesWithCompositeAttributes(s db.Interface, t *test
 	return func(t *testing.T) {
 		ctx := context.Background()
 		m := models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
-			Name:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+			ID:   db.String("string1"),
+			Name: db.String("string1"),
 		}
 		require.Nil(t, s.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, m))
 		require.IsType(t, db.ErrThingAllowingBatchWritesWithCompositeAttributesAlreadyExists{}, s.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, m))
@@ -5406,12 +5406,12 @@ func DeleteThingAllowingBatchWritesWithCompositeAttributes(s db.Interface, t *te
 	return func(t *testing.T) {
 		ctx := context.Background()
 		m := models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
-			Name:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+			ID:   db.String("string1"),
+			Name: db.String("string1"),
 		}
 		require.Nil(t, s.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, m))
-		require.Nil(t, s.DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx, *m.Name, *m.Branch, *m.Date))
+		require.Nil(t, s.DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx, *m.Name, *m.ID, *m.Date))
 	}
 }
 

--- a/samples/gen-go-db-custom-path/models/thing_allowing_batch_writes_with_composite_attributes.go
+++ b/samples/gen-go-db-custom-path/models/thing_allowing_batch_writes_with_composite_attributes.go
@@ -17,14 +17,14 @@ import (
 // swagger:model ThingAllowingBatchWritesWithCompositeAttributes
 type ThingAllowingBatchWritesWithCompositeAttributes struct {
 
-	// branch
-	// Required: true
-	Branch *string `json:"branch"`
-
 	// date
 	// Required: true
 	// Format: date-time
 	Date *strfmt.DateTime `json:"date"`
+
+	// id
+	// Required: true
+	ID *string `json:"id"`
 
 	// name
 	// Required: true
@@ -35,11 +35,11 @@ type ThingAllowingBatchWritesWithCompositeAttributes struct {
 func (m *ThingAllowingBatchWritesWithCompositeAttributes) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateBranch(formats); err != nil {
+	if err := m.validateDate(formats); err != nil {
 		res = append(res, err)
 	}
 
-	if err := m.validateDate(formats); err != nil {
+	if err := m.validateID(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -53,15 +53,6 @@ func (m *ThingAllowingBatchWritesWithCompositeAttributes) Validate(formats strfm
 	return nil
 }
 
-func (m *ThingAllowingBatchWritesWithCompositeAttributes) validateBranch(formats strfmt.Registry) error {
-
-	if err := validate.Required("branch", "body", m.Branch); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (m *ThingAllowingBatchWritesWithCompositeAttributes) validateDate(formats strfmt.Registry) error {
 
 	if err := validate.Required("date", "body", m.Date); err != nil {
@@ -69,6 +60,15 @@ func (m *ThingAllowingBatchWritesWithCompositeAttributes) validateDate(formats s
 	}
 
 	if err := validate.FormatOf("date", "body", "date-time", m.Date.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ThingAllowingBatchWritesWithCompositeAttributes) validateID(formats strfmt.Registry) error {
+
+	if err := validate.Required("id", "body", m.ID); err != nil {
 		return err
 	}
 

--- a/samples/gen-go-db-only/db/dynamodb/dynamodb.go
+++ b/samples/gen-go-db-only/db/dynamodb/dynamodb.go
@@ -745,8 +745,8 @@ func (d DB) DeleteArrayOfThingAllowingBatchWritesWithCompositeAttributes(ctx con
 }
 
 // GetThingAllowingBatchWritesWithCompositeAttributes retrieves a ThingAllowingBatchWritesWithCompositeAttributes from the database.
-func (d DB) GetThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, branch string, date strfmt.DateTime) (*models.ThingAllowingBatchWritesWithCompositeAttributes, error) {
-	return d.thingAllowingBatchWritesWithCompositeAttributesTable.getThingAllowingBatchWritesWithCompositeAttributes(ctx, name, branch, date)
+func (d DB) GetThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, id string, date strfmt.DateTime) (*models.ThingAllowingBatchWritesWithCompositeAttributes, error) {
+	return d.thingAllowingBatchWritesWithCompositeAttributesTable.getThingAllowingBatchWritesWithCompositeAttributes(ctx, name, id, date)
 }
 
 // ScanThingAllowingBatchWritesWithCompositeAttributess runs a scan on the ThingAllowingBatchWritesWithCompositeAttributess table.
@@ -754,14 +754,14 @@ func (d DB) ScanThingAllowingBatchWritesWithCompositeAttributess(ctx context.Con
 	return d.thingAllowingBatchWritesWithCompositeAttributesTable.scanThingAllowingBatchWritesWithCompositeAttributess(ctx, input, fn)
 }
 
-// GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate retrieves a page of ThingAllowingBatchWritesWithCompositeAttributess from the database.
-func (d DB) GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(ctx context.Context, input db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput, fn func(m *models.ThingAllowingBatchWritesWithCompositeAttributes, lastThingAllowingBatchWritesWithCompositeAttributes bool) bool) error {
-	return d.thingAllowingBatchWritesWithCompositeAttributesTable.getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(ctx, input, fn)
+// GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate retrieves a page of ThingAllowingBatchWritesWithCompositeAttributess from the database.
+func (d DB) GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(ctx context.Context, input db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput, fn func(m *models.ThingAllowingBatchWritesWithCompositeAttributes, lastThingAllowingBatchWritesWithCompositeAttributes bool) bool) error {
+	return d.thingAllowingBatchWritesWithCompositeAttributesTable.getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(ctx, input, fn)
 }
 
 // DeleteThingAllowingBatchWritesWithCompositeAttributes deletes a ThingAllowingBatchWritesWithCompositeAttributes from the database.
-func (d DB) DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, branch string, date strfmt.DateTime) error {
-	return d.thingAllowingBatchWritesWithCompositeAttributesTable.deleteThingAllowingBatchWritesWithCompositeAttributes(ctx, name, branch, date)
+func (d DB) DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, id string, date strfmt.DateTime) error {
+	return d.thingAllowingBatchWritesWithCompositeAttributesTable.deleteThingAllowingBatchWritesWithCompositeAttributes(ctx, name, id, date)
 }
 
 // SaveThingWithCompositeAttributes saves a ThingWithCompositeAttributes to the database.

--- a/samples/gen-go-db-only/db/interface.go
+++ b/samples/gen-go-db-only/db/interface.go
@@ -132,13 +132,13 @@ type Interface interface {
 	// DeleteArrayOfThingAllowingBatchWritesWithCompositeAttributes batch deletes all items in []ThingAllowingBatchWritesWithCompositeAttributes in the database.
 	DeleteArrayOfThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, ms []models.ThingAllowingBatchWritesWithCompositeAttributes) error
 	// GetThingAllowingBatchWritesWithCompositeAttributes retrieves a ThingAllowingBatchWritesWithCompositeAttributes from the database.
-	GetThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, branch string, date strfmt.DateTime) (*models.ThingAllowingBatchWritesWithCompositeAttributes, error)
+	GetThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, id string, date strfmt.DateTime) (*models.ThingAllowingBatchWritesWithCompositeAttributes, error)
 	// ScanThingAllowingBatchWritesWithCompositeAttributess runs a scan on the ThingAllowingBatchWritesWithCompositeAttributess table.
 	ScanThingAllowingBatchWritesWithCompositeAttributess(ctx context.Context, input ScanThingAllowingBatchWritesWithCompositeAttributessInput, fn func(m *models.ThingAllowingBatchWritesWithCompositeAttributes, lastThingAllowingBatchWritesWithCompositeAttributes bool) bool) error
-	// GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate retrieves a page of ThingAllowingBatchWritesWithCompositeAttributess from the database.
-	GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(ctx context.Context, input GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput, fn func(m *models.ThingAllowingBatchWritesWithCompositeAttributes, lastThingAllowingBatchWritesWithCompositeAttributes bool) bool) error
+	// GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate retrieves a page of ThingAllowingBatchWritesWithCompositeAttributess from the database.
+	GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(ctx context.Context, input GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput, fn func(m *models.ThingAllowingBatchWritesWithCompositeAttributes, lastThingAllowingBatchWritesWithCompositeAttributes bool) bool) error
 	// DeleteThingAllowingBatchWritesWithCompositeAttributes deletes a ThingAllowingBatchWritesWithCompositeAttributes from the database.
-	DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, branch string, date strfmt.DateTime) error
+	DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, id string, date strfmt.DateTime) error
 
 	// SaveThingWithCompositeAttributes saves a ThingWithCompositeAttributes to the database.
 	SaveThingWithCompositeAttributes(ctx context.Context, m models.ThingWithCompositeAttributes) error
@@ -928,12 +928,12 @@ type ScanThingAllowingBatchWritesWithCompositeAttributessInput struct {
 	Limiter *rate.Limiter
 }
 
-// GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput is the query input to GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate.
-type GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput struct {
+// GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput is the query input to GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate.
+type GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput struct {
 	// Name is required
 	Name string
-	// Branch is required
-	Branch         string
+	// ID is required
+	ID             string
 	DateStartingAt *strfmt.DateTime
 	// StartingAfter is a required specification of an exclusive starting point.
 	StartingAfter *models.ThingAllowingBatchWritesWithCompositeAttributes
@@ -946,9 +946,9 @@ type GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput
 
 // ErrThingAllowingBatchWritesWithCompositeAttributesNotFound is returned when the database fails to find a ThingAllowingBatchWritesWithCompositeAttributes.
 type ErrThingAllowingBatchWritesWithCompositeAttributesNotFound struct {
-	Name   string
-	Branch string
-	Date   strfmt.DateTime
+	Name string
+	ID   string
+	Date strfmt.DateTime
 }
 
 var _ error = ErrThingAllowingBatchWritesWithCompositeAttributesNotFound{}
@@ -960,8 +960,8 @@ func (e ErrThingAllowingBatchWritesWithCompositeAttributesNotFound) Error() stri
 
 // ErrThingAllowingBatchWritesWithCompositeAttributesAlreadyExists is returned when trying to overwrite a ThingAllowingBatchWritesWithCompositeAttributes.
 type ErrThingAllowingBatchWritesWithCompositeAttributesAlreadyExists struct {
-	NameBranch string
-	Date       strfmt.DateTime
+	NameID string
+	Date   strfmt.DateTime
 }
 
 var _ error = ErrThingAllowingBatchWritesWithCompositeAttributesAlreadyExists{}

--- a/samples/gen-go-db-only/db/mock_db.go
+++ b/samples/gen-go-db-only/db/mock_db.go
@@ -163,17 +163,17 @@ func (mr *MockInterfaceMockRecorder) DeleteThingAllowingBatchWrites(ctx, name, v
 }
 
 // DeleteThingAllowingBatchWritesWithCompositeAttributes mocks base method.
-func (m *MockInterface) DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name, branch string, date strfmt.DateTime) error {
+func (m *MockInterface) DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name, id string, date strfmt.DateTime) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteThingAllowingBatchWritesWithCompositeAttributes", ctx, name, branch, date)
+	ret := m.ctrl.Call(m, "DeleteThingAllowingBatchWritesWithCompositeAttributes", ctx, name, id, date)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteThingAllowingBatchWritesWithCompositeAttributes indicates an expected call of DeleteThingAllowingBatchWritesWithCompositeAttributes.
-func (mr *MockInterfaceMockRecorder) DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx, name, branch, date interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx, name, id, date interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteThingAllowingBatchWritesWithCompositeAttributes", reflect.TypeOf((*MockInterface)(nil).DeleteThingAllowingBatchWritesWithCompositeAttributes), ctx, name, branch, date)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteThingAllowingBatchWritesWithCompositeAttributes", reflect.TypeOf((*MockInterface)(nil).DeleteThingAllowingBatchWritesWithCompositeAttributes), ctx, name, id, date)
 }
 
 // DeleteThingWithCompositeAttributes mocks base method.
@@ -563,32 +563,32 @@ func (mr *MockInterfaceMockRecorder) GetThingAllowingBatchWrites(ctx, name, vers
 }
 
 // GetThingAllowingBatchWritesWithCompositeAttributes mocks base method.
-func (m *MockInterface) GetThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name, branch string, date strfmt.DateTime) (*models.ThingAllowingBatchWritesWithCompositeAttributes, error) {
+func (m *MockInterface) GetThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name, id string, date strfmt.DateTime) (*models.ThingAllowingBatchWritesWithCompositeAttributes, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetThingAllowingBatchWritesWithCompositeAttributes", ctx, name, branch, date)
+	ret := m.ctrl.Call(m, "GetThingAllowingBatchWritesWithCompositeAttributes", ctx, name, id, date)
 	ret0, _ := ret[0].(*models.ThingAllowingBatchWritesWithCompositeAttributes)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetThingAllowingBatchWritesWithCompositeAttributes indicates an expected call of GetThingAllowingBatchWritesWithCompositeAttributes.
-func (mr *MockInterfaceMockRecorder) GetThingAllowingBatchWritesWithCompositeAttributes(ctx, name, branch, date interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) GetThingAllowingBatchWritesWithCompositeAttributes(ctx, name, id, date interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThingAllowingBatchWritesWithCompositeAttributes", reflect.TypeOf((*MockInterface)(nil).GetThingAllowingBatchWritesWithCompositeAttributes), ctx, name, branch, date)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThingAllowingBatchWritesWithCompositeAttributes", reflect.TypeOf((*MockInterface)(nil).GetThingAllowingBatchWritesWithCompositeAttributes), ctx, name, id, date)
 }
 
-// GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate mocks base method.
-func (m *MockInterface) GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(ctx context.Context, input GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput, fn func(*models.ThingAllowingBatchWritesWithCompositeAttributes, bool) bool) error {
+// GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate mocks base method.
+func (m *MockInterface) GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(ctx context.Context, input GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput, fn func(*models.ThingAllowingBatchWritesWithCompositeAttributes, bool) bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate", ctx, input, fn)
+	ret := m.ctrl.Call(m, "GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate", ctx, input, fn)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate indicates an expected call of GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate.
-func (mr *MockInterfaceMockRecorder) GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(ctx, input, fn interface{}) *gomock.Call {
+// GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate indicates an expected call of GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate.
+func (mr *MockInterfaceMockRecorder) GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(ctx, input, fn interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate", reflect.TypeOf((*MockInterface)(nil).GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate), ctx, input, fn)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate", reflect.TypeOf((*MockInterface)(nil).GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate), ctx, input, fn)
 }
 
 // GetThingAllowingBatchWritessByNameAndVersion mocks base method.

--- a/samples/gen-go-db-only/db/tests/tests.go
+++ b/samples/gen-go-db-only/db/tests/tests.go
@@ -74,7 +74,7 @@ func RunDBTests(t *testing.T, dbFactory func() db.Interface) {
 	t.Run("DeleteThingAllowingBatchWrites", DeleteThingAllowingBatchWrites(dbFactory(), t))
 	t.Run("GetThingAllowingBatchWritesWithCompositeAttributes", GetThingAllowingBatchWritesWithCompositeAttributes(dbFactory(), t))
 	t.Run("ScanThingAllowingBatchWritesWithCompositeAttributess", ScanThingAllowingBatchWritesWithCompositeAttributess(dbFactory(), t))
-	t.Run("GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate", GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(dbFactory(), t))
+	t.Run("GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate", GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(dbFactory(), t))
 	t.Run("SaveThingAllowingBatchWritesWithCompositeAttributes", SaveThingAllowingBatchWritesWithCompositeAttributes(dbFactory(), t))
 	t.Run("DeleteThingAllowingBatchWritesWithCompositeAttributes", DeleteThingAllowingBatchWritesWithCompositeAttributes(dbFactory(), t))
 	t.Run("GetThingWithCompositeAttributes", GetThingWithCompositeAttributes(dbFactory(), t))
@@ -5047,15 +5047,15 @@ func GetThingAllowingBatchWritesWithCompositeAttributes(s db.Interface, t *testi
 	return func(t *testing.T) {
 		ctx := context.Background()
 		m := models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
-			Name:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+			ID:   db.String("string1"),
+			Name: db.String("string1"),
 		}
 		require.Nil(t, s.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, m))
-		m2, err := s.GetThingAllowingBatchWritesWithCompositeAttributes(ctx, *m.Name, *m.Branch, *m.Date)
+		m2, err := s.GetThingAllowingBatchWritesWithCompositeAttributes(ctx, *m.Name, *m.ID, *m.Date)
 		require.Nil(t, err)
 		require.Equal(t, *m.Name, *m2.Name)
-		require.Equal(t, *m.Branch, *m2.Branch)
+		require.Equal(t, *m.ID, *m2.ID)
 		require.Equal(t, m.Date.String(), m2.Date.String())
 
 		_, err = s.GetThingAllowingBatchWritesWithCompositeAttributes(ctx, "string2", "string2", mustTime("2018-03-11T15:04:02+07:00"))
@@ -5064,22 +5064,22 @@ func GetThingAllowingBatchWritesWithCompositeAttributes(s db.Interface, t *testi
 	}
 }
 
-type getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput struct {
+type getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput struct {
 	ctx   context.Context
-	input db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput
+	input db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput
 }
-type getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput struct {
+type getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput struct {
 	thingAllowingBatchWritesWithCompositeAttributess []models.ThingAllowingBatchWritesWithCompositeAttributes
 	err                                              error
 }
-type getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateTest struct {
+type getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateTest struct {
 	testName string
 	d        db.Interface
-	input    getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput
-	output   getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput
+	input    getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput
+	output   getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput
 }
 
-func (g getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateTest) run(t *testing.T) {
+func (g getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateTest) run(t *testing.T) {
 	thingAllowingBatchWritesWithCompositeAttributess := []models.ThingAllowingBatchWritesWithCompositeAttributes{}
 	fn := func(m *models.ThingAllowingBatchWritesWithCompositeAttributes, lastThingAllowingBatchWritesWithCompositeAttributes bool) bool {
 		thingAllowingBatchWritesWithCompositeAttributess = append(thingAllowingBatchWritesWithCompositeAttributess, *m)
@@ -5088,7 +5088,7 @@ func (g getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateTe
 		}
 		return true
 	}
-	err := g.d.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(g.input.ctx, g.input.input, fn)
+	err := g.d.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(g.input.ctx, g.input.input, fn)
 	if err != nil {
 		fmt.Println(err.Error())
 	}
@@ -5096,53 +5096,53 @@ func (g getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateTe
 	require.Equal(t, g.output.thingAllowingBatchWritesWithCompositeAttributess, thingAllowingBatchWritesWithCompositeAttributess)
 }
 
-func GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(d db.Interface, t *testing.T) func(t *testing.T) {
+func GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(d db.Interface, t *testing.T) func(t *testing.T) {
 	return func(t *testing.T) {
 		ctx := context.Background()
 		require.Nil(t, d.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Name:   db.String("string1"),
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+			Name: db.String("string1"),
+			ID:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
 		}))
 		require.Nil(t, d.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Name:   db.String("string1"),
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+			Name: db.String("string1"),
+			ID:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 		}))
 		require.Nil(t, d.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Name:   db.String("string1"),
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+			Name: db.String("string1"),
+			ID:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
 		}))
 		limit := int64(3)
-		tests := []getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateTest{
+		tests := []getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateTest{
 			{
 				testName: "basic",
 				d:        d,
-				input: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+				input: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 					ctx: context.Background(),
-					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
-						Name:   "string1",
-						Branch: "string1",
-						Limit:  &limit,
+					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
+						Name:  "string1",
+						ID:    "string1",
+						Limit: &limit,
 					},
 				},
-				output: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput{
+				output: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput{
 					thingAllowingBatchWritesWithCompositeAttributess: []models.ThingAllowingBatchWritesWithCompositeAttributes{
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
 						},
 					},
 					err: nil,
@@ -5151,30 +5151,30 @@ func GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(d db
 			{
 				testName: "descending",
 				d:        d,
-				input: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+				input: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 					ctx: context.Background(),
-					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 						Name:       "string1",
-						Branch:     "string1",
+						ID:         "string1",
 						Descending: true,
 					},
 				},
-				output: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput{
+				output: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput{
 					thingAllowingBatchWritesWithCompositeAttributess: []models.ThingAllowingBatchWritesWithCompositeAttributes{
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
 						},
 					},
 					err: nil,
@@ -5183,29 +5183,29 @@ func GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(d db
 			{
 				testName: "starting after",
 				d:        d,
-				input: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+				input: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 					ctx: context.Background(),
-					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
-						Name:   "string1",
-						Branch: "string1",
+					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
+						Name: "string1",
+						ID:   "string1",
 						StartingAfter: &models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
 						},
 					},
 				},
-				output: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput{
+				output: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput{
 					thingAllowingBatchWritesWithCompositeAttributess: []models.ThingAllowingBatchWritesWithCompositeAttributes{
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
 						},
 					},
 					err: nil,
@@ -5214,30 +5214,30 @@ func GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(d db
 			{
 				testName: "starting after descending",
 				d:        d,
-				input: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+				input: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 					ctx: context.Background(),
-					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
-						Name:   "string1",
-						Branch: "string1",
+					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
+						Name: "string1",
+						ID:   "string1",
 						StartingAfter: &models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
 						},
 						Descending: true,
 					},
 				},
-				output: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput{
+				output: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput{
 					thingAllowingBatchWritesWithCompositeAttributess: []models.ThingAllowingBatchWritesWithCompositeAttributes{
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
 						},
 					},
 					err: nil,
@@ -5246,25 +5246,25 @@ func GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(d db
 			{
 				testName: "starting at",
 				d:        d,
-				input: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+				input: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 					ctx: context.Background(),
-					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 						Name:           "string1",
-						Branch:         "string1",
+						ID:             "string1",
 						DateStartingAt: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 					},
 				},
-				output: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput{
+				output: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput{
 					thingAllowingBatchWritesWithCompositeAttributess: []models.ThingAllowingBatchWritesWithCompositeAttributes{
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
 						},
 					},
 					err: nil,
@@ -5283,37 +5283,37 @@ func ScanThingAllowingBatchWritesWithCompositeAttributess(d db.Interface, t *tes
 	return func(t *testing.T) {
 		ctx := context.Background()
 		require.Nil(t, d.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
-			Name:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+			ID:   db.String("string1"),
+			Name: db.String("string1"),
 		}))
 		require.Nil(t, d.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Branch: db.String("string2"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
-			Name:   db.String("string2"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+			ID:   db.String("string2"),
+			Name: db.String("string2"),
 		}))
 		require.Nil(t, d.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Branch: db.String("string3"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
-			Name:   db.String("string3"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+			ID:   db.String("string3"),
+			Name: db.String("string3"),
 		}))
 
 		t.Run("basic", func(t *testing.T) {
 			expected := []models.ThingAllowingBatchWritesWithCompositeAttributes{
 				models.ThingAllowingBatchWritesWithCompositeAttributes{
-					Branch: db.String("string1"),
-					Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
-					Name:   db.String("string1"),
+					Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+					ID:   db.String("string1"),
+					Name: db.String("string1"),
 				},
 				models.ThingAllowingBatchWritesWithCompositeAttributes{
-					Branch: db.String("string2"),
-					Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
-					Name:   db.String("string2"),
+					Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+					ID:   db.String("string2"),
+					Name: db.String("string2"),
 				},
 				models.ThingAllowingBatchWritesWithCompositeAttributes{
-					Branch: db.String("string3"),
-					Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
-					Name:   db.String("string3"),
+					Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+					ID:   db.String("string3"),
+					Name: db.String("string3"),
 				},
 			}
 			actual := []models.ThingAllowingBatchWritesWithCompositeAttributes{}
@@ -5348,9 +5348,9 @@ func ScanThingAllowingBatchWritesWithCompositeAttributess(d db.Interface, t *tes
 			// Scan for everything after the first item.
 			scanInput := db.ScanThingAllowingBatchWritesWithCompositeAttributessInput{
 				StartingAfter: &models.ThingAllowingBatchWritesWithCompositeAttributes{
-					Name:   firstItem.Name,
-					Branch: firstItem.Branch,
-					Date:   firstItem.Date,
+					Name: firstItem.Name,
+					ID:   firstItem.ID,
+					Date: firstItem.Date,
 				},
 			}
 			actual := []models.ThingAllowingBatchWritesWithCompositeAttributes{}
@@ -5393,9 +5393,9 @@ func SaveThingAllowingBatchWritesWithCompositeAttributes(s db.Interface, t *test
 	return func(t *testing.T) {
 		ctx := context.Background()
 		m := models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
-			Name:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+			ID:   db.String("string1"),
+			Name: db.String("string1"),
 		}
 		require.Nil(t, s.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, m))
 		require.IsType(t, db.ErrThingAllowingBatchWritesWithCompositeAttributesAlreadyExists{}, s.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, m))
@@ -5406,12 +5406,12 @@ func DeleteThingAllowingBatchWritesWithCompositeAttributes(s db.Interface, t *te
 	return func(t *testing.T) {
 		ctx := context.Background()
 		m := models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
-			Name:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+			ID:   db.String("string1"),
+			Name: db.String("string1"),
 		}
 		require.Nil(t, s.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, m))
-		require.Nil(t, s.DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx, *m.Name, *m.Branch, *m.Date))
+		require.Nil(t, s.DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx, *m.Name, *m.ID, *m.Date))
 	}
 }
 

--- a/samples/gen-go-db-only/models/thing_allowing_batch_writes_with_composite_attributes.go
+++ b/samples/gen-go-db-only/models/thing_allowing_batch_writes_with_composite_attributes.go
@@ -17,14 +17,14 @@ import (
 // swagger:model ThingAllowingBatchWritesWithCompositeAttributes
 type ThingAllowingBatchWritesWithCompositeAttributes struct {
 
-	// branch
-	// Required: true
-	Branch *string `json:"branch"`
-
 	// date
 	// Required: true
 	// Format: date-time
 	Date *strfmt.DateTime `json:"date"`
+
+	// id
+	// Required: true
+	ID *string `json:"id"`
 
 	// name
 	// Required: true
@@ -35,11 +35,11 @@ type ThingAllowingBatchWritesWithCompositeAttributes struct {
 func (m *ThingAllowingBatchWritesWithCompositeAttributes) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateBranch(formats); err != nil {
+	if err := m.validateDate(formats); err != nil {
 		res = append(res, err)
 	}
 
-	if err := m.validateDate(formats); err != nil {
+	if err := m.validateID(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -53,15 +53,6 @@ func (m *ThingAllowingBatchWritesWithCompositeAttributes) Validate(formats strfm
 	return nil
 }
 
-func (m *ThingAllowingBatchWritesWithCompositeAttributes) validateBranch(formats strfmt.Registry) error {
-
-	if err := validate.Required("branch", "body", m.Branch); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (m *ThingAllowingBatchWritesWithCompositeAttributes) validateDate(formats strfmt.Registry) error {
 
 	if err := validate.Required("date", "body", m.Date); err != nil {
@@ -69,6 +60,15 @@ func (m *ThingAllowingBatchWritesWithCompositeAttributes) validateDate(formats s
 	}
 
 	if err := validate.FormatOf("date", "body", "date-time", m.Date.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ThingAllowingBatchWritesWithCompositeAttributes) validateID(formats strfmt.Registry) error {
+
+	if err := validate.Required("id", "body", m.ID); err != nil {
 		return err
 	}
 

--- a/samples/gen-go-db/models/thing_allowing_batch_writes_with_composite_attributes.go
+++ b/samples/gen-go-db/models/thing_allowing_batch_writes_with_composite_attributes.go
@@ -17,14 +17,14 @@ import (
 // swagger:model ThingAllowingBatchWritesWithCompositeAttributes
 type ThingAllowingBatchWritesWithCompositeAttributes struct {
 
-	// branch
-	// Required: true
-	Branch *string `json:"branch"`
-
 	// date
 	// Required: true
 	// Format: date-time
 	Date *strfmt.DateTime `json:"date"`
+
+	// id
+	// Required: true
+	ID *string `json:"id"`
 
 	// name
 	// Required: true
@@ -35,11 +35,11 @@ type ThingAllowingBatchWritesWithCompositeAttributes struct {
 func (m *ThingAllowingBatchWritesWithCompositeAttributes) Validate(formats strfmt.Registry) error {
 	var res []error
 
-	if err := m.validateBranch(formats); err != nil {
+	if err := m.validateDate(formats); err != nil {
 		res = append(res, err)
 	}
 
-	if err := m.validateDate(formats); err != nil {
+	if err := m.validateID(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -53,15 +53,6 @@ func (m *ThingAllowingBatchWritesWithCompositeAttributes) Validate(formats strfm
 	return nil
 }
 
-func (m *ThingAllowingBatchWritesWithCompositeAttributes) validateBranch(formats strfmt.Registry) error {
-
-	if err := validate.Required("branch", "body", m.Branch); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (m *ThingAllowingBatchWritesWithCompositeAttributes) validateDate(formats strfmt.Registry) error {
 
 	if err := validate.Required("date", "body", m.Date); err != nil {
@@ -69,6 +60,15 @@ func (m *ThingAllowingBatchWritesWithCompositeAttributes) validateDate(formats s
 	}
 
 	if err := validate.FormatOf("date", "body", "date-time", m.Date.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *ThingAllowingBatchWritesWithCompositeAttributes) validateID(formats strfmt.Registry) error {
+
+	if err := validate.Required("id", "body", m.ID); err != nil {
 		return err
 	}
 

--- a/samples/gen-go-db/server/db/dynamodb/dynamodb.go
+++ b/samples/gen-go-db/server/db/dynamodb/dynamodb.go
@@ -745,8 +745,8 @@ func (d DB) DeleteArrayOfThingAllowingBatchWritesWithCompositeAttributes(ctx con
 }
 
 // GetThingAllowingBatchWritesWithCompositeAttributes retrieves a ThingAllowingBatchWritesWithCompositeAttributes from the database.
-func (d DB) GetThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, branch string, date strfmt.DateTime) (*models.ThingAllowingBatchWritesWithCompositeAttributes, error) {
-	return d.thingAllowingBatchWritesWithCompositeAttributesTable.getThingAllowingBatchWritesWithCompositeAttributes(ctx, name, branch, date)
+func (d DB) GetThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, id string, date strfmt.DateTime) (*models.ThingAllowingBatchWritesWithCompositeAttributes, error) {
+	return d.thingAllowingBatchWritesWithCompositeAttributesTable.getThingAllowingBatchWritesWithCompositeAttributes(ctx, name, id, date)
 }
 
 // ScanThingAllowingBatchWritesWithCompositeAttributess runs a scan on the ThingAllowingBatchWritesWithCompositeAttributess table.
@@ -754,14 +754,14 @@ func (d DB) ScanThingAllowingBatchWritesWithCompositeAttributess(ctx context.Con
 	return d.thingAllowingBatchWritesWithCompositeAttributesTable.scanThingAllowingBatchWritesWithCompositeAttributess(ctx, input, fn)
 }
 
-// GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate retrieves a page of ThingAllowingBatchWritesWithCompositeAttributess from the database.
-func (d DB) GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(ctx context.Context, input db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput, fn func(m *models.ThingAllowingBatchWritesWithCompositeAttributes, lastThingAllowingBatchWritesWithCompositeAttributes bool) bool) error {
-	return d.thingAllowingBatchWritesWithCompositeAttributesTable.getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(ctx, input, fn)
+// GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate retrieves a page of ThingAllowingBatchWritesWithCompositeAttributess from the database.
+func (d DB) GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(ctx context.Context, input db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput, fn func(m *models.ThingAllowingBatchWritesWithCompositeAttributes, lastThingAllowingBatchWritesWithCompositeAttributes bool) bool) error {
+	return d.thingAllowingBatchWritesWithCompositeAttributesTable.getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(ctx, input, fn)
 }
 
 // DeleteThingAllowingBatchWritesWithCompositeAttributes deletes a ThingAllowingBatchWritesWithCompositeAttributes from the database.
-func (d DB) DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, branch string, date strfmt.DateTime) error {
-	return d.thingAllowingBatchWritesWithCompositeAttributesTable.deleteThingAllowingBatchWritesWithCompositeAttributes(ctx, name, branch, date)
+func (d DB) DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, id string, date strfmt.DateTime) error {
+	return d.thingAllowingBatchWritesWithCompositeAttributesTable.deleteThingAllowingBatchWritesWithCompositeAttributes(ctx, name, id, date)
 }
 
 // SaveThingWithCompositeAttributes saves a ThingWithCompositeAttributes to the database.

--- a/samples/gen-go-db/server/db/interface.go
+++ b/samples/gen-go-db/server/db/interface.go
@@ -132,13 +132,13 @@ type Interface interface {
 	// DeleteArrayOfThingAllowingBatchWritesWithCompositeAttributes batch deletes all items in []ThingAllowingBatchWritesWithCompositeAttributes in the database.
 	DeleteArrayOfThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, ms []models.ThingAllowingBatchWritesWithCompositeAttributes) error
 	// GetThingAllowingBatchWritesWithCompositeAttributes retrieves a ThingAllowingBatchWritesWithCompositeAttributes from the database.
-	GetThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, branch string, date strfmt.DateTime) (*models.ThingAllowingBatchWritesWithCompositeAttributes, error)
+	GetThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, id string, date strfmt.DateTime) (*models.ThingAllowingBatchWritesWithCompositeAttributes, error)
 	// ScanThingAllowingBatchWritesWithCompositeAttributess runs a scan on the ThingAllowingBatchWritesWithCompositeAttributess table.
 	ScanThingAllowingBatchWritesWithCompositeAttributess(ctx context.Context, input ScanThingAllowingBatchWritesWithCompositeAttributessInput, fn func(m *models.ThingAllowingBatchWritesWithCompositeAttributes, lastThingAllowingBatchWritesWithCompositeAttributes bool) bool) error
-	// GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate retrieves a page of ThingAllowingBatchWritesWithCompositeAttributess from the database.
-	GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(ctx context.Context, input GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput, fn func(m *models.ThingAllowingBatchWritesWithCompositeAttributes, lastThingAllowingBatchWritesWithCompositeAttributes bool) bool) error
+	// GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate retrieves a page of ThingAllowingBatchWritesWithCompositeAttributess from the database.
+	GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(ctx context.Context, input GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput, fn func(m *models.ThingAllowingBatchWritesWithCompositeAttributes, lastThingAllowingBatchWritesWithCompositeAttributes bool) bool) error
 	// DeleteThingAllowingBatchWritesWithCompositeAttributes deletes a ThingAllowingBatchWritesWithCompositeAttributes from the database.
-	DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, branch string, date strfmt.DateTime) error
+	DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name string, id string, date strfmt.DateTime) error
 
 	// SaveThingWithCompositeAttributes saves a ThingWithCompositeAttributes to the database.
 	SaveThingWithCompositeAttributes(ctx context.Context, m models.ThingWithCompositeAttributes) error
@@ -928,12 +928,12 @@ type ScanThingAllowingBatchWritesWithCompositeAttributessInput struct {
 	Limiter *rate.Limiter
 }
 
-// GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput is the query input to GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate.
-type GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput struct {
+// GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput is the query input to GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate.
+type GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput struct {
 	// Name is required
 	Name string
-	// Branch is required
-	Branch         string
+	// ID is required
+	ID             string
 	DateStartingAt *strfmt.DateTime
 	// StartingAfter is a required specification of an exclusive starting point.
 	StartingAfter *models.ThingAllowingBatchWritesWithCompositeAttributes
@@ -946,9 +946,9 @@ type GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput
 
 // ErrThingAllowingBatchWritesWithCompositeAttributesNotFound is returned when the database fails to find a ThingAllowingBatchWritesWithCompositeAttributes.
 type ErrThingAllowingBatchWritesWithCompositeAttributesNotFound struct {
-	Name   string
-	Branch string
-	Date   strfmt.DateTime
+	Name string
+	ID   string
+	Date strfmt.DateTime
 }
 
 var _ error = ErrThingAllowingBatchWritesWithCompositeAttributesNotFound{}
@@ -960,8 +960,8 @@ func (e ErrThingAllowingBatchWritesWithCompositeAttributesNotFound) Error() stri
 
 // ErrThingAllowingBatchWritesWithCompositeAttributesAlreadyExists is returned when trying to overwrite a ThingAllowingBatchWritesWithCompositeAttributes.
 type ErrThingAllowingBatchWritesWithCompositeAttributesAlreadyExists struct {
-	NameBranch string
-	Date       strfmt.DateTime
+	NameID string
+	Date   strfmt.DateTime
 }
 
 var _ error = ErrThingAllowingBatchWritesWithCompositeAttributesAlreadyExists{}

--- a/samples/gen-go-db/server/db/mock_db.go
+++ b/samples/gen-go-db/server/db/mock_db.go
@@ -163,17 +163,17 @@ func (mr *MockInterfaceMockRecorder) DeleteThingAllowingBatchWrites(ctx, name, v
 }
 
 // DeleteThingAllowingBatchWritesWithCompositeAttributes mocks base method.
-func (m *MockInterface) DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name, branch string, date strfmt.DateTime) error {
+func (m *MockInterface) DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name, id string, date strfmt.DateTime) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteThingAllowingBatchWritesWithCompositeAttributes", ctx, name, branch, date)
+	ret := m.ctrl.Call(m, "DeleteThingAllowingBatchWritesWithCompositeAttributes", ctx, name, id, date)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteThingAllowingBatchWritesWithCompositeAttributes indicates an expected call of DeleteThingAllowingBatchWritesWithCompositeAttributes.
-func (mr *MockInterfaceMockRecorder) DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx, name, branch, date interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx, name, id, date interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteThingAllowingBatchWritesWithCompositeAttributes", reflect.TypeOf((*MockInterface)(nil).DeleteThingAllowingBatchWritesWithCompositeAttributes), ctx, name, branch, date)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteThingAllowingBatchWritesWithCompositeAttributes", reflect.TypeOf((*MockInterface)(nil).DeleteThingAllowingBatchWritesWithCompositeAttributes), ctx, name, id, date)
 }
 
 // DeleteThingWithCompositeAttributes mocks base method.
@@ -563,32 +563,32 @@ func (mr *MockInterfaceMockRecorder) GetThingAllowingBatchWrites(ctx, name, vers
 }
 
 // GetThingAllowingBatchWritesWithCompositeAttributes mocks base method.
-func (m *MockInterface) GetThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name, branch string, date strfmt.DateTime) (*models.ThingAllowingBatchWritesWithCompositeAttributes, error) {
+func (m *MockInterface) GetThingAllowingBatchWritesWithCompositeAttributes(ctx context.Context, name, id string, date strfmt.DateTime) (*models.ThingAllowingBatchWritesWithCompositeAttributes, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetThingAllowingBatchWritesWithCompositeAttributes", ctx, name, branch, date)
+	ret := m.ctrl.Call(m, "GetThingAllowingBatchWritesWithCompositeAttributes", ctx, name, id, date)
 	ret0, _ := ret[0].(*models.ThingAllowingBatchWritesWithCompositeAttributes)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetThingAllowingBatchWritesWithCompositeAttributes indicates an expected call of GetThingAllowingBatchWritesWithCompositeAttributes.
-func (mr *MockInterfaceMockRecorder) GetThingAllowingBatchWritesWithCompositeAttributes(ctx, name, branch, date interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) GetThingAllowingBatchWritesWithCompositeAttributes(ctx, name, id, date interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThingAllowingBatchWritesWithCompositeAttributes", reflect.TypeOf((*MockInterface)(nil).GetThingAllowingBatchWritesWithCompositeAttributes), ctx, name, branch, date)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThingAllowingBatchWritesWithCompositeAttributes", reflect.TypeOf((*MockInterface)(nil).GetThingAllowingBatchWritesWithCompositeAttributes), ctx, name, id, date)
 }
 
-// GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate mocks base method.
-func (m *MockInterface) GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(ctx context.Context, input GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput, fn func(*models.ThingAllowingBatchWritesWithCompositeAttributes, bool) bool) error {
+// GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate mocks base method.
+func (m *MockInterface) GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(ctx context.Context, input GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput, fn func(*models.ThingAllowingBatchWritesWithCompositeAttributes, bool) bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate", ctx, input, fn)
+	ret := m.ctrl.Call(m, "GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate", ctx, input, fn)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate indicates an expected call of GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate.
-func (mr *MockInterfaceMockRecorder) GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(ctx, input, fn interface{}) *gomock.Call {
+// GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate indicates an expected call of GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate.
+func (mr *MockInterfaceMockRecorder) GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(ctx, input, fn interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate", reflect.TypeOf((*MockInterface)(nil).GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate), ctx, input, fn)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate", reflect.TypeOf((*MockInterface)(nil).GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate), ctx, input, fn)
 }
 
 // GetThingAllowingBatchWritessByNameAndVersion mocks base method.

--- a/samples/gen-go-db/server/db/tests/tests.go
+++ b/samples/gen-go-db/server/db/tests/tests.go
@@ -74,7 +74,7 @@ func RunDBTests(t *testing.T, dbFactory func() db.Interface) {
 	t.Run("DeleteThingAllowingBatchWrites", DeleteThingAllowingBatchWrites(dbFactory(), t))
 	t.Run("GetThingAllowingBatchWritesWithCompositeAttributes", GetThingAllowingBatchWritesWithCompositeAttributes(dbFactory(), t))
 	t.Run("ScanThingAllowingBatchWritesWithCompositeAttributess", ScanThingAllowingBatchWritesWithCompositeAttributess(dbFactory(), t))
-	t.Run("GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate", GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(dbFactory(), t))
+	t.Run("GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate", GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(dbFactory(), t))
 	t.Run("SaveThingAllowingBatchWritesWithCompositeAttributes", SaveThingAllowingBatchWritesWithCompositeAttributes(dbFactory(), t))
 	t.Run("DeleteThingAllowingBatchWritesWithCompositeAttributes", DeleteThingAllowingBatchWritesWithCompositeAttributes(dbFactory(), t))
 	t.Run("GetThingWithCompositeAttributes", GetThingWithCompositeAttributes(dbFactory(), t))
@@ -5047,15 +5047,15 @@ func GetThingAllowingBatchWritesWithCompositeAttributes(s db.Interface, t *testi
 	return func(t *testing.T) {
 		ctx := context.Background()
 		m := models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
-			Name:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+			ID:   db.String("string1"),
+			Name: db.String("string1"),
 		}
 		require.Nil(t, s.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, m))
-		m2, err := s.GetThingAllowingBatchWritesWithCompositeAttributes(ctx, *m.Name, *m.Branch, *m.Date)
+		m2, err := s.GetThingAllowingBatchWritesWithCompositeAttributes(ctx, *m.Name, *m.ID, *m.Date)
 		require.Nil(t, err)
 		require.Equal(t, *m.Name, *m2.Name)
-		require.Equal(t, *m.Branch, *m2.Branch)
+		require.Equal(t, *m.ID, *m2.ID)
 		require.Equal(t, m.Date.String(), m2.Date.String())
 
 		_, err = s.GetThingAllowingBatchWritesWithCompositeAttributes(ctx, "string2", "string2", mustTime("2018-03-11T15:04:02+07:00"))
@@ -5064,22 +5064,22 @@ func GetThingAllowingBatchWritesWithCompositeAttributes(s db.Interface, t *testi
 	}
 }
 
-type getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput struct {
+type getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput struct {
 	ctx   context.Context
-	input db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput
+	input db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput
 }
-type getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput struct {
+type getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput struct {
 	thingAllowingBatchWritesWithCompositeAttributess []models.ThingAllowingBatchWritesWithCompositeAttributes
 	err                                              error
 }
-type getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateTest struct {
+type getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateTest struct {
 	testName string
 	d        db.Interface
-	input    getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput
-	output   getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput
+	input    getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput
+	output   getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput
 }
 
-func (g getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateTest) run(t *testing.T) {
+func (g getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateTest) run(t *testing.T) {
 	thingAllowingBatchWritesWithCompositeAttributess := []models.ThingAllowingBatchWritesWithCompositeAttributes{}
 	fn := func(m *models.ThingAllowingBatchWritesWithCompositeAttributes, lastThingAllowingBatchWritesWithCompositeAttributes bool) bool {
 		thingAllowingBatchWritesWithCompositeAttributess = append(thingAllowingBatchWritesWithCompositeAttributess, *m)
@@ -5088,7 +5088,7 @@ func (g getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateTe
 		}
 		return true
 	}
-	err := g.d.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(g.input.ctx, g.input.input, fn)
+	err := g.d.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(g.input.ctx, g.input.input, fn)
 	if err != nil {
 		fmt.Println(err.Error())
 	}
@@ -5096,53 +5096,53 @@ func (g getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateTe
 	require.Equal(t, g.output.thingAllowingBatchWritesWithCompositeAttributess, thingAllowingBatchWritesWithCompositeAttributess)
 }
 
-func GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(d db.Interface, t *testing.T) func(t *testing.T) {
+func GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDate(d db.Interface, t *testing.T) func(t *testing.T) {
 	return func(t *testing.T) {
 		ctx := context.Background()
 		require.Nil(t, d.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Name:   db.String("string1"),
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+			Name: db.String("string1"),
+			ID:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
 		}))
 		require.Nil(t, d.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Name:   db.String("string1"),
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+			Name: db.String("string1"),
+			ID:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 		}))
 		require.Nil(t, d.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Name:   db.String("string1"),
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+			Name: db.String("string1"),
+			ID:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
 		}))
 		limit := int64(3)
-		tests := []getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateTest{
+		tests := []getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateTest{
 			{
 				testName: "basic",
 				d:        d,
-				input: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+				input: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 					ctx: context.Background(),
-					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
-						Name:   "string1",
-						Branch: "string1",
-						Limit:  &limit,
+					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
+						Name:  "string1",
+						ID:    "string1",
+						Limit: &limit,
 					},
 				},
-				output: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput{
+				output: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput{
 					thingAllowingBatchWritesWithCompositeAttributess: []models.ThingAllowingBatchWritesWithCompositeAttributes{
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
 						},
 					},
 					err: nil,
@@ -5151,30 +5151,30 @@ func GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(d db
 			{
 				testName: "descending",
 				d:        d,
-				input: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+				input: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 					ctx: context.Background(),
-					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 						Name:       "string1",
-						Branch:     "string1",
+						ID:         "string1",
 						Descending: true,
 					},
 				},
-				output: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput{
+				output: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput{
 					thingAllowingBatchWritesWithCompositeAttributess: []models.ThingAllowingBatchWritesWithCompositeAttributes{
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
 						},
 					},
 					err: nil,
@@ -5183,29 +5183,29 @@ func GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(d db
 			{
 				testName: "starting after",
 				d:        d,
-				input: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+				input: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 					ctx: context.Background(),
-					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
-						Name:   "string1",
-						Branch: "string1",
+					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
+						Name: "string1",
+						ID:   "string1",
 						StartingAfter: &models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
 						},
 					},
 				},
-				output: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput{
+				output: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput{
 					thingAllowingBatchWritesWithCompositeAttributess: []models.ThingAllowingBatchWritesWithCompositeAttributes{
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
 						},
 					},
 					err: nil,
@@ -5214,30 +5214,30 @@ func GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(d db
 			{
 				testName: "starting after descending",
 				d:        d,
-				input: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+				input: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 					ctx: context.Background(),
-					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
-						Name:   "string1",
-						Branch: "string1",
+					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
+						Name: "string1",
+						ID:   "string1",
 						StartingAfter: &models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
 						},
 						Descending: true,
 					},
 				},
-				output: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput{
+				output: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput{
 					thingAllowingBatchWritesWithCompositeAttributess: []models.ThingAllowingBatchWritesWithCompositeAttributes{
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
 						},
 					},
 					err: nil,
@@ -5246,25 +5246,25 @@ func GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDate(d db
 			{
 				testName: "starting at",
 				d:        d,
-				input: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+				input: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 					ctx: context.Background(),
-					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateInput{
+					input: db.GetThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateInput{
 						Name:           "string1",
-						Branch:         "string1",
+						ID:             "string1",
 						DateStartingAt: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 					},
 				},
-				output: getThingAllowingBatchWritesWithCompositeAttributessByNameBranchAndDateOutput{
+				output: getThingAllowingBatchWritesWithCompositeAttributessByNameIDAndDateOutput{
 					thingAllowingBatchWritesWithCompositeAttributess: []models.ThingAllowingBatchWritesWithCompositeAttributes{
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
 						},
 						models.ThingAllowingBatchWritesWithCompositeAttributes{
-							Name:   db.String("string1"),
-							Branch: db.String("string1"),
-							Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+							Name: db.String("string1"),
+							ID:   db.String("string1"),
+							Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
 						},
 					},
 					err: nil,
@@ -5283,37 +5283,37 @@ func ScanThingAllowingBatchWritesWithCompositeAttributess(d db.Interface, t *tes
 	return func(t *testing.T) {
 		ctx := context.Background()
 		require.Nil(t, d.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
-			Name:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+			ID:   db.String("string1"),
+			Name: db.String("string1"),
 		}))
 		require.Nil(t, d.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Branch: db.String("string2"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
-			Name:   db.String("string2"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+			ID:   db.String("string2"),
+			Name: db.String("string2"),
 		}))
 		require.Nil(t, d.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Branch: db.String("string3"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
-			Name:   db.String("string3"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+			ID:   db.String("string3"),
+			Name: db.String("string3"),
 		}))
 
 		t.Run("basic", func(t *testing.T) {
 			expected := []models.ThingAllowingBatchWritesWithCompositeAttributes{
 				models.ThingAllowingBatchWritesWithCompositeAttributes{
-					Branch: db.String("string1"),
-					Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
-					Name:   db.String("string1"),
+					Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+					ID:   db.String("string1"),
+					Name: db.String("string1"),
 				},
 				models.ThingAllowingBatchWritesWithCompositeAttributes{
-					Branch: db.String("string2"),
-					Date:   db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
-					Name:   db.String("string2"),
+					Date: db.DateTime(mustTime("2018-03-11T15:04:02+07:00")),
+					ID:   db.String("string2"),
+					Name: db.String("string2"),
 				},
 				models.ThingAllowingBatchWritesWithCompositeAttributes{
-					Branch: db.String("string3"),
-					Date:   db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
-					Name:   db.String("string3"),
+					Date: db.DateTime(mustTime("2018-03-11T15:04:03+07:00")),
+					ID:   db.String("string3"),
+					Name: db.String("string3"),
 				},
 			}
 			actual := []models.ThingAllowingBatchWritesWithCompositeAttributes{}
@@ -5348,9 +5348,9 @@ func ScanThingAllowingBatchWritesWithCompositeAttributess(d db.Interface, t *tes
 			// Scan for everything after the first item.
 			scanInput := db.ScanThingAllowingBatchWritesWithCompositeAttributessInput{
 				StartingAfter: &models.ThingAllowingBatchWritesWithCompositeAttributes{
-					Name:   firstItem.Name,
-					Branch: firstItem.Branch,
-					Date:   firstItem.Date,
+					Name: firstItem.Name,
+					ID:   firstItem.ID,
+					Date: firstItem.Date,
 				},
 			}
 			actual := []models.ThingAllowingBatchWritesWithCompositeAttributes{}
@@ -5393,9 +5393,9 @@ func SaveThingAllowingBatchWritesWithCompositeAttributes(s db.Interface, t *test
 	return func(t *testing.T) {
 		ctx := context.Background()
 		m := models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
-			Name:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+			ID:   db.String("string1"),
+			Name: db.String("string1"),
 		}
 		require.Nil(t, s.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, m))
 		require.IsType(t, db.ErrThingAllowingBatchWritesWithCompositeAttributesAlreadyExists{}, s.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, m))
@@ -5406,12 +5406,12 @@ func DeleteThingAllowingBatchWritesWithCompositeAttributes(s db.Interface, t *te
 	return func(t *testing.T) {
 		ctx := context.Background()
 		m := models.ThingAllowingBatchWritesWithCompositeAttributes{
-			Branch: db.String("string1"),
-			Date:   db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
-			Name:   db.String("string1"),
+			Date: db.DateTime(mustTime("2018-03-11T15:04:01+07:00")),
+			ID:   db.String("string1"),
+			Name: db.String("string1"),
 		}
 		require.Nil(t, s.SaveThingAllowingBatchWritesWithCompositeAttributes(ctx, m))
-		require.Nil(t, s.DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx, *m.Name, *m.Branch, *m.Date))
+		require.Nil(t, s.DeleteThingAllowingBatchWritesWithCompositeAttributes(ctx, *m.Name, *m.ID, *m.Date))
 	}
 }
 

--- a/samples/gen-js-db-custom-path/index.d.ts
+++ b/samples/gen-js-db-custom-path/index.d.ts
@@ -157,8 +157,8 @@ declare namespace SwaggerTest {
 };
     
     type ThingAllowingBatchWritesWithCompositeAttributes = {
-  branch: string;
   date: string;
+  id: string;
   name: string;
 };
     

--- a/samples/gen-js-db/index.d.ts
+++ b/samples/gen-js-db/index.d.ts
@@ -157,8 +157,8 @@ declare namespace SwaggerTest {
 };
     
     type ThingAllowingBatchWritesWithCompositeAttributes = {
-  branch: string;
   date: string;
+  id: string;
   name: string;
 };
     

--- a/server/gendb/templatefuncs.go
+++ b/server/gendb/templatefuncs.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/Clever/wag/v8/utils"
 	"github.com/awslabs/goformation/v2/cloudformation/resources"
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/swag"
@@ -258,7 +259,7 @@ var funcMap = template.FuncMap(map[string]interface{}{
 				value += "*"
 			}
 			value += sliceIdentifier + "."
-			value += strings.Title(attributeToModelValueNotPtr(config, prop, ""))
+			value += utils.CamelCase(attributeToModelValueNotPtr(config, prop, ""), true)
 			if i != len(ca.Properties)-1 {
 				value += `, `
 			}


### PR DESCRIPTION
I ran into an issue in the dynamo batch delete code where a composite index wasn't being properly capitalized since it was a common initialism (i.e: it was giving me `ms[i].Id` instead of `ms[i].ID`). Luckily there's a handy `utils` function that handles these initialisms, so we should use it when generating the composite index for batch deletes.

- [x] Run `make build`
- [x] Run `make generate`
- [x] Update the current version in the `/VERSION` file.
