### PR TITLE
Wag nightly build

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,6 @@
-v9.0.2
+v9.0.3
+
+v9.0.3 Fixed missing include in generated client.
 
 v9.0.2 Separated client and models modules, reduced kv and otel deps.
 

--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -48,6 +48,7 @@ import (
 		"time"
 		"fmt"
 		"os"
+		"io/ioutil"
 		"crypto/md5"
 
 		"{{.ModuleName}}{{.OutputPath}}/models{{.VersionSuffix}}"

--- a/samples/gen-go-basic/client/client.go
+++ b/samples/gen-go-basic/client/client.go
@@ -7,6 +7,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"

--- a/samples/gen-go-blog/client/client.go
+++ b/samples/gen-go-blog/client/client.go
@@ -7,6 +7,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"

--- a/samples/gen-go-client-only/client/client.go
+++ b/samples/gen-go-client-only/client/client.go
@@ -7,6 +7,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"

--- a/samples/gen-go-db-custom-path/client/client.go
+++ b/samples/gen-go-db-custom-path/client/client.go
@@ -7,6 +7,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"

--- a/samples/gen-go-db/client/client.go
+++ b/samples/gen-go-db/client/client.go
@@ -7,6 +7,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"

--- a/samples/gen-go-deprecated/client/client.go
+++ b/samples/gen-go-deprecated/client/client.go
@@ -7,6 +7,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"

--- a/samples/gen-go-errors/client/client.go
+++ b/samples/gen-go-errors/client/client.go
@@ -7,6 +7,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"

--- a/samples/gen-go-nils/client/client.go
+++ b/samples/gen-go-nils/client/client.go
@@ -7,6 +7,7 @@ import (
 	"crypto/md5"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"


### PR DESCRIPTION
[JIRA Link
](https://clever.atlassian.net/browse/INFRANG-5196)

Required import wasn't included in generated client. Still curious as to why we are just now seeing this error and only in one place so far. This should have errored much earlier and everywhere. 

[Relevant Slack Thread
](https://clever.slack.com/archives/C02DNBUGHDH/p1674668363050299)

- [x] Run `make build`
- [x] Run `make generate`
- [x] Update the current version in the `/VERSION` file.
