### PR TITLE
Update wag go client creation API

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,6 @@
-v9.0.3
+v9.1.0
+
+v9.1.0 Introduce new API for generated go client creation
 
 v9.0.3 Fixed missing include in generated client.
 

--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -46,7 +46,6 @@ import (
 		"strconv"
 		"time"
 		"fmt"
-		"os"
 		"io/ioutil"
 		"crypto/md5"
 
@@ -57,13 +56,6 @@ import (
 
 
 		"github.com/afex/hystrix-go/hystrix"
-
-		"go.opentelemetry.io/otel"
-		"go.opentelemetry.io/otel/propagation"
-		"go.opentelemetry.io/otel/sdk/trace/tracetest"
-		"go.opentelemetry.io/otel/sdk/resource"
-		sdktrace "go.opentelemetry.io/otel/sdk/trace"
-		semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 		
 )
 
@@ -93,205 +85,23 @@ type WagClient struct {
 
 var _ Client = (*WagClient)(nil)
 
+// New creates a new client. The base path, logger, and http transport are configurable.
+// The logger provided should be specifically created for this wag client. If tracing is required,
+// provide an instrumented transport using the wag clientconfig module. If no tracing is required, pass nil to use
+// the default transport.
+func New(basePath string, logger wcl.WagClientLogger, transport *http.RoundTripper) *WagClient {
 
-//This pattern is used instead of using closures for greater transparency and the ability to implement additional interfaces.
-type options struct {
-	transport    http.RoundTripper
-	logger       wcl.WagClientLogger
-	instrumentor Instrumentor
-	exporter     sdktrace.SpanExporter
-}
-
-type Option interface {
-	apply(*options)
-}
-
-
-//WithLogger sets client logger option.
-func WithLogger(log wcl.WagClientLogger) Option {
-	return loggerOption{Log: log}
-}
-
-type loggerOption struct {
-	Log wcl.WagClientLogger
-}
-
-func (l loggerOption) apply(opts *options) {
-	opts.logger = l.Log
-}
-
-
-type roundTripperOption struct {
-	rt http.RoundTripper
-}
-
-func (t roundTripperOption) apply(opts *options) {
-	opts.transport = t.rt
-}
-
-// WithRoundTripper allows you to pass in intrumented/custom roundtrippers which will then wrap the
-// transport roundtripper
-func WithRoundTripper(t http.RoundTripper) Option {
-	return roundTripperOption{rt: t}
-}
-
-// Instrumentor is a function that creates an instrumented round tripper
-type Instrumentor func(baseTransport http.RoundTripper, spanNameCtxValue interface{}, tp sdktrace.TracerProvider) http.RoundTripper
-
-// WithInstrumentor sets a instrumenting function that will be used to wrap the roundTripper for tracing.
-// For standard instrumentation with tracing use tracing.InstrumentedTransport, default is non-instrumented.
-
-func WithInstrumentor(fn Instrumentor) Option {
-	return instrumentorOption{instrumentor: fn}
-}
-
-type instrumentorOption struct {
-	instrumentor Instrumentor
-}
-
-func (i instrumentorOption) apply(opts *options) {
-	opts.instrumentor = i.instrumentor
-}
-
-// WithExporter sets client span exporter option.
-func WithExporter(se sdktrace.SpanExporter) Option {
-	return exporterOption{exporter: se}
-}
-
-type exporterOption struct {
-	exporter sdktrace.SpanExporter
-}
-
-func (se exporterOption) apply(opts *options) {
-	opts.exporter = se.exporter
-}
-
-//----------------------BEGIN LOGGING RELATED FUNCTIONS----------------------
-
-
-// NewLogger creates a logger for id that produces logs at and below the indicated level.
-// level here indicates the level at and below which logs are created.
-func NewLogger(id string, level wcl.LogLevel) PrintlnLogger {
-	return PrintlnLogger{id: id, level: level}
-}
-
-type PrintlnLogger struct {
-	level wcl.LogLevel
-	id    string
-}
-
-func (w PrintlnLogger) Log(level wcl.LogLevel, message string, m map[string]interface{}) {
-
-	if level >= level {
-		m["id"] = w.id
-		jsonLog, err := json.Marshal(m)
-		if err != nil {
-			jsonLog, err = json.Marshal(map[string]interface{}{"Error Marshalling Log": err})
-		}
-		fmt.Println(string(jsonLog))
+	t := http.DefaultTransport
+	if transport != nil {
+		t = *transport
 	}
-}
-
-//----------------------END LOGGING RELATED FUNCTIONS------------------------
-
-//----------------------BEGIN TRACING RELATED FUNCTIONS----------------------
-
-
-// newResource returns a resource describing this application.
-// Used for setting up tracer provider
-func newResource() *resource.Resource {
-	r, _ := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("{{.ServiceName}}"),
-			semconv.ServiceVersionKey.String("{{ .Version }}"),
-		),
-	)
-	return r
-}
-
-func newTracerProvider(exporter sdktrace.SpanExporter, samplingProbability float64) *sdktrace.TracerProvider {
-
-	tp:= sdktrace.NewTracerProvider(
-		// We use the default ID generator. In order for sampling to work (at least with this sampler)
-		// the ID generator must generate trace IDs uniformly at random from the entire space of uint64.
-		// For example, the default x-ray ID generator does not do this.
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		// These maximums are to guard against something going wrong and sending a ton of data unexpectedly
-		sdktrace.WithSpanLimits(sdktrace.SpanLimits{
-			AttributeCountLimit: 100,
-			EventCountLimit:     100,
-			LinkCountLimit:      100,
-		}),
-		//Batcher is more efficient, switch to it after testing
-		// sdktrace.WithSyncer(exporter),
-		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(newResource()),
-		
-	)
-	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
-	return tp
-}
-
-func doNothing(baseTransport http.RoundTripper, spanNameCtxValue interface{}, tp sdktrace.TracerProvider) http.RoundTripper {
-	return baseTransport
-}
-
-func determineSampling() (samplingProbability float64, err error) {
-
-		// If we're running locally, then turn off sampling. Otherwise sample
-		// 1%% or whatever TRACING_SAMPLING_PROBABILITY specifies.
-		samplingProbability = 0.01
-		isLocal := os.Getenv("_IS_LOCAL") == "true"
-		if isLocal {
-			fmt.Println("Set to Local")
-			samplingProbability = 1.0
-		} else if v := os.Getenv("TRACING_SAMPLING_PROBABILITY"); v != "" {
-			samplingProbabilityFromEnv, err := strconv.ParseFloat(v, 64)
-			if err != nil {
-				return 0, fmt.Errorf("could not parse '%%s' to float", v)
-			}
-			samplingProbability = samplingProbabilityFromEnv
-		}
-		return
-	}
-
-//----------------------END TRACING RELATEDFUNCTIONS----------------------
-
-// New creates a new client. The base path and http transport are configurable.
-func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
-
-	defaultTransport := http.DefaultTransport
-	defaultLogger := NewLogger("{{.ServiceName}}-wagclient", wcl.Info)
-	defaultExporter := tracetest.NewNoopExporter()
-	defaultInstrumentor := doNothing
-
 
 	basePath = strings.TrimSuffix(basePath, "/")
 	base := baseDoer{}
+	
 	// For the short-term don't use the default retry policy since its 5 retries can 5X
 	// the traffic. Once we've enabled circuit breakers by default we can turn it on.
 	retry := retryDoer{d: base, retryPolicy: SingleRetryPolicy{}}
-	options := options{
-		transport:    defaultTransport,
-		logger:       defaultLogger,
-		exporter:     defaultExporter,
-		instrumentor: defaultInstrumentor,
-	}
-
-	for _, o := range opts {
-		o.apply(&options)
-	}
-
-
-	samplingProbability := 1.0 // Hard setting this to one for now, because right now 
-	// it is essentially ignored as the sidecar is determining the sample rate it forwards on to DD.
-	// Thus the prefered approach is to sample locally with the sidecar.
-
-	tp := newTracerProvider(options.exporter, samplingProbability)
-	options.transport = options.instrumentor(options.transport, ctx, *tp)
 
 	circuit := &circuitBreakerDoer{
 		d:     &retry,
@@ -299,19 +109,20 @@ func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
 		debug: true,
 		// one circuit for each service + url pair
 		circuitName: fmt.Sprintf("{{.ServiceName}}-%%s", shortHash(basePath)),
-		logger: options.logger,
+		logger: logger,
 	}
 	circuit.init()
+
 	client := &WagClient{
 		basePath: basePath,
 		requestDoer: circuit,
 		client: &http.Client{
-			Transport: options.transport,
+			Transport: t,
 		},
 		retryDoer: &retry,
 		circuitDoer: circuit,
 		defaultTimeout: 5 * time.Second,
-		 logger: options.logger,
+		logger: logger,
 	}
 	client.SetCircuitBreakerSettings(DefaultCircuitBreakerSettings)
 	return client
@@ -319,7 +130,10 @@ func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
 
 // NewFromDiscovery creates a client from the discovery environment variables. This method requires
 // the three env vars: SERVICE_{{.FormattedServiceName}}_HTTP_(HOST/PORT/PROTO) to be set. Otherwise it returns an error.
-func NewFromDiscovery(opts ...Option) (*WagClient, error) {
+// The logger provided should be specifically created for this wag client. If tracing is required,
+// provide an instrumented transport using the wag clientconfig module. If no tracing is required, pass nil to use
+// the default transport.
+func NewFromDiscovery(logger wcl.WagClientLogger, transport *http.RoundTripper) (*WagClient, error) {
 	url, err := discovery.URL("{{.ServiceName}}", "default")
 	if err != nil {
 		url, err = discovery.URL("{{.ServiceName}}", "http") // Added fallback to maintain reverse compatibility
@@ -327,7 +141,7 @@ func NewFromDiscovery(opts ...Option) (*WagClient, error) {
 			return nil, err
 		}
 	}
-	return New(context.Background(), url, opts...), nil
+	return New(url, logger, transport), nil
 }
 
 // SetRetryPolicy sets a the given retry policy for all requests.
@@ -468,9 +282,6 @@ require (
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
 	github.com/donovanhide/eventsource v0.0.0-20171031113327-3ed64d21fb0b
 	github.com/smartystreets/goconvey v1.7.2 // indirect
-	go.opentelemetry.io/otel v1.9.0
-	go.opentelemetry.io/otel/sdk v1.9.0
-
 )
 //Replace directives will work locally but mess up imports.
 replace ` + codeTemplate.ModuleName + codeTemplate.OutputPath + `/models` + codeTemplate.VersionSuffix + ` => ../models `

--- a/samples/gen-go-basic/client/client.go
+++ b/samples/gen-go-basic/client/client.go
@@ -1,6 +1,5 @@
 package client
 
-// Using Alpha version of WAG Yay!
 import (
 	"bytes"
 	"context"
@@ -9,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -20,13 +18,6 @@ import (
 	wcl "github.com/Clever/wag/logging/wagclientlogger"
 
 	"github.com/afex/hystrix-go/hystrix"
-
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 )
 
 var _ = json.Marshal
@@ -55,197 +46,23 @@ type WagClient struct {
 
 var _ Client = (*WagClient)(nil)
 
-//This pattern is used instead of using closures for greater transparency and the ability to implement additional interfaces.
-type options struct {
-	transport    http.RoundTripper
-	logger       wcl.WagClientLogger
-	instrumentor Instrumentor
-	exporter     sdktrace.SpanExporter
-}
+// New creates a new client. The base path, logger, and http transport are configurable.
+// The logger provided should be specifically created for this wag client. If tracing is required,
+// provide an instrumented transport using the wag clientconfig module. If no tracing is required, pass nil to use
+// the default transport.
+func New(basePath string, logger wcl.WagClientLogger, transport *http.RoundTripper) *WagClient {
 
-type Option interface {
-	apply(*options)
-}
-
-//WithLogger sets client logger option.
-func WithLogger(log wcl.WagClientLogger) Option {
-	return loggerOption{Log: log}
-}
-
-type loggerOption struct {
-	Log wcl.WagClientLogger
-}
-
-func (l loggerOption) apply(opts *options) {
-	opts.logger = l.Log
-}
-
-type roundTripperOption struct {
-	rt http.RoundTripper
-}
-
-func (t roundTripperOption) apply(opts *options) {
-	opts.transport = t.rt
-}
-
-// WithRoundTripper allows you to pass in intrumented/custom roundtrippers which will then wrap the
-// transport roundtripper
-func WithRoundTripper(t http.RoundTripper) Option {
-	return roundTripperOption{rt: t}
-}
-
-// Instrumentor is a function that creates an instrumented round tripper
-type Instrumentor func(baseTransport http.RoundTripper, spanNameCtxValue interface{}, tp sdktrace.TracerProvider) http.RoundTripper
-
-// WithInstrumentor sets a instrumenting function that will be used to wrap the roundTripper for tracing.
-// For standard instrumentation with tracing use tracing.InstrumentedTransport, default is non-instrumented.
-
-func WithInstrumentor(fn Instrumentor) Option {
-	return instrumentorOption{instrumentor: fn}
-}
-
-type instrumentorOption struct {
-	instrumentor Instrumentor
-}
-
-func (i instrumentorOption) apply(opts *options) {
-	opts.instrumentor = i.instrumentor
-}
-
-// WithExporter sets client span exporter option.
-func WithExporter(se sdktrace.SpanExporter) Option {
-	return exporterOption{exporter: se}
-}
-
-type exporterOption struct {
-	exporter sdktrace.SpanExporter
-}
-
-func (se exporterOption) apply(opts *options) {
-	opts.exporter = se.exporter
-}
-
-//----------------------BEGIN LOGGING RELATED FUNCTIONS----------------------
-
-// NewLogger creates a logger for id that produces logs at and below the indicated level.
-// level here indicates the level at and below which logs are created.
-func NewLogger(id string, level wcl.LogLevel) PrintlnLogger {
-	return PrintlnLogger{id: id, level: level}
-}
-
-type PrintlnLogger struct {
-	level wcl.LogLevel
-	id    string
-}
-
-func (w PrintlnLogger) Log(level wcl.LogLevel, message string, m map[string]interface{}) {
-
-	if level >= level {
-		m["id"] = w.id
-		jsonLog, err := json.Marshal(m)
-		if err != nil {
-			jsonLog, err = json.Marshal(map[string]interface{}{"Error Marshalling Log": err})
-		}
-		fmt.Println(string(jsonLog))
+	t := http.DefaultTransport
+	if transport != nil {
+		t = *transport
 	}
-}
-
-//----------------------END LOGGING RELATED FUNCTIONS------------------------
-
-//----------------------BEGIN TRACING RELATED FUNCTIONS----------------------
-
-// newResource returns a resource describing this application.
-// Used for setting up tracer provider
-func newResource() *resource.Resource {
-	r, _ := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("swagger-test"),
-			semconv.ServiceVersionKey.String("9.0.0"),
-		),
-	)
-	return r
-}
-
-func newTracerProvider(exporter sdktrace.SpanExporter, samplingProbability float64) *sdktrace.TracerProvider {
-
-	tp := sdktrace.NewTracerProvider(
-		// We use the default ID generator. In order for sampling to work (at least with this sampler)
-		// the ID generator must generate trace IDs uniformly at random from the entire space of uint64.
-		// For example, the default x-ray ID generator does not do this.
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		// These maximums are to guard against something going wrong and sending a ton of data unexpectedly
-		sdktrace.WithSpanLimits(sdktrace.SpanLimits{
-			AttributeCountLimit: 100,
-			EventCountLimit:     100,
-			LinkCountLimit:      100,
-		}),
-		//Batcher is more efficient, switch to it after testing
-		// sdktrace.WithSyncer(exporter),
-		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(newResource()),
-	)
-	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
-	return tp
-}
-
-func doNothing(baseTransport http.RoundTripper, spanNameCtxValue interface{}, tp sdktrace.TracerProvider) http.RoundTripper {
-	return baseTransport
-}
-
-func determineSampling() (samplingProbability float64, err error) {
-
-	// If we're running locally, then turn off sampling. Otherwise sample
-	// 1% or whatever TRACING_SAMPLING_PROBABILITY specifies.
-	samplingProbability = 0.01
-	isLocal := os.Getenv("_IS_LOCAL") == "true"
-	if isLocal {
-		fmt.Println("Set to Local")
-		samplingProbability = 1.0
-	} else if v := os.Getenv("TRACING_SAMPLING_PROBABILITY"); v != "" {
-		samplingProbabilityFromEnv, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			return 0, fmt.Errorf("could not parse '%s' to float", v)
-		}
-		samplingProbability = samplingProbabilityFromEnv
-	}
-	return
-}
-
-//----------------------END TRACING RELATEDFUNCTIONS----------------------
-
-// New creates a new client. The base path and http transport are configurable.
-func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
-
-	defaultTransport := http.DefaultTransport
-	defaultLogger := NewLogger("swagger-test-wagclient", wcl.Info)
-	defaultExporter := tracetest.NewNoopExporter()
-	defaultInstrumentor := doNothing
 
 	basePath = strings.TrimSuffix(basePath, "/")
 	base := baseDoer{}
+
 	// For the short-term don't use the default retry policy since its 5 retries can 5X
 	// the traffic. Once we've enabled circuit breakers by default we can turn it on.
 	retry := retryDoer{d: base, retryPolicy: SingleRetryPolicy{}}
-	options := options{
-		transport:    defaultTransport,
-		logger:       defaultLogger,
-		exporter:     defaultExporter,
-		instrumentor: defaultInstrumentor,
-	}
-
-	for _, o := range opts {
-		o.apply(&options)
-	}
-
-	samplingProbability := 1.0 // Hard setting this to one for now, because right now
-	// it is essentially ignored as the sidecar is determining the sample rate it forwards on to DD.
-	// Thus the prefered approach is to sample locally with the sidecar.
-
-	tp := newTracerProvider(options.exporter, samplingProbability)
-	options.transport = options.instrumentor(options.transport, ctx, *tp)
 
 	circuit := &circuitBreakerDoer{
 		d: &retry,
@@ -253,19 +70,20 @@ func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
 		debug: true,
 		// one circuit for each service + url pair
 		circuitName: fmt.Sprintf("swagger-test-%s", shortHash(basePath)),
-		logger:      options.logger,
+		logger:      logger,
 	}
 	circuit.init()
+
 	client := &WagClient{
 		basePath:    basePath,
 		requestDoer: circuit,
 		client: &http.Client{
-			Transport: options.transport,
+			Transport: t,
 		},
 		retryDoer:      &retry,
 		circuitDoer:    circuit,
 		defaultTimeout: 5 * time.Second,
-		logger:         options.logger,
+		logger:         logger,
 	}
 	client.SetCircuitBreakerSettings(DefaultCircuitBreakerSettings)
 	return client
@@ -273,7 +91,10 @@ func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
 
 // NewFromDiscovery creates a client from the discovery environment variables. This method requires
 // the three env vars: SERVICE_SWAGGER_TEST_HTTP_(HOST/PORT/PROTO) to be set. Otherwise it returns an error.
-func NewFromDiscovery(opts ...Option) (*WagClient, error) {
+// The logger provided should be specifically created for this wag client. If tracing is required,
+// provide an instrumented transport using the wag clientconfig module. If no tracing is required, pass nil to use
+// the default transport.
+func NewFromDiscovery(logger wcl.WagClientLogger, transport *http.RoundTripper) (*WagClient, error) {
 	url, err := discovery.URL("swagger-test", "default")
 	if err != nil {
 		url, err = discovery.URL("swagger-test", "http") // Added fallback to maintain reverse compatibility
@@ -281,7 +102,7 @@ func NewFromDiscovery(opts ...Option) (*WagClient, error) {
 			return nil, err
 		}
 	}
-	return New(context.Background(), url, opts...), nil
+	return New(url, logger, transport), nil
 }
 
 // SetRetryPolicy sets a the given retry policy for all requests.

--- a/samples/gen-go-basic/client/go.mod
+++ b/samples/gen-go-basic/client/go.mod
@@ -9,9 +9,6 @@ require (
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
 	github.com/donovanhide/eventsource v0.0.0-20171031113327-3ed64d21fb0b
 	github.com/smartystreets/goconvey v1.7.2 // indirect
-	go.opentelemetry.io/otel v1.9.0
-	go.opentelemetry.io/otel/sdk v1.9.0
-
 )
 //Replace directives will work locally but mess up imports.
 replace github.com/Clever/wag/samples/gen-go-basic/models/v9 => ../models 

--- a/samples/gen-go-blog/client/client.go
+++ b/samples/gen-go-blog/client/client.go
@@ -1,6 +1,5 @@
 package client
 
-// Using Alpha version of WAG Yay!
 import (
 	"bytes"
 	"context"
@@ -9,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -20,13 +18,6 @@ import (
 	wcl "github.com/Clever/wag/logging/wagclientlogger"
 
 	"github.com/afex/hystrix-go/hystrix"
-
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 )
 
 var _ = json.Marshal
@@ -55,197 +46,23 @@ type WagClient struct {
 
 var _ Client = (*WagClient)(nil)
 
-//This pattern is used instead of using closures for greater transparency and the ability to implement additional interfaces.
-type options struct {
-	transport    http.RoundTripper
-	logger       wcl.WagClientLogger
-	instrumentor Instrumentor
-	exporter     sdktrace.SpanExporter
-}
+// New creates a new client. The base path, logger, and http transport are configurable.
+// The logger provided should be specifically created for this wag client. If tracing is required,
+// provide an instrumented transport using the wag clientconfig module. If no tracing is required, pass nil to use
+// the default transport.
+func New(basePath string, logger wcl.WagClientLogger, transport *http.RoundTripper) *WagClient {
 
-type Option interface {
-	apply(*options)
-}
-
-//WithLogger sets client logger option.
-func WithLogger(log wcl.WagClientLogger) Option {
-	return loggerOption{Log: log}
-}
-
-type loggerOption struct {
-	Log wcl.WagClientLogger
-}
-
-func (l loggerOption) apply(opts *options) {
-	opts.logger = l.Log
-}
-
-type roundTripperOption struct {
-	rt http.RoundTripper
-}
-
-func (t roundTripperOption) apply(opts *options) {
-	opts.transport = t.rt
-}
-
-// WithRoundTripper allows you to pass in intrumented/custom roundtrippers which will then wrap the
-// transport roundtripper
-func WithRoundTripper(t http.RoundTripper) Option {
-	return roundTripperOption{rt: t}
-}
-
-// Instrumentor is a function that creates an instrumented round tripper
-type Instrumentor func(baseTransport http.RoundTripper, spanNameCtxValue interface{}, tp sdktrace.TracerProvider) http.RoundTripper
-
-// WithInstrumentor sets a instrumenting function that will be used to wrap the roundTripper for tracing.
-// For standard instrumentation with tracing use tracing.InstrumentedTransport, default is non-instrumented.
-
-func WithInstrumentor(fn Instrumentor) Option {
-	return instrumentorOption{instrumentor: fn}
-}
-
-type instrumentorOption struct {
-	instrumentor Instrumentor
-}
-
-func (i instrumentorOption) apply(opts *options) {
-	opts.instrumentor = i.instrumentor
-}
-
-// WithExporter sets client span exporter option.
-func WithExporter(se sdktrace.SpanExporter) Option {
-	return exporterOption{exporter: se}
-}
-
-type exporterOption struct {
-	exporter sdktrace.SpanExporter
-}
-
-func (se exporterOption) apply(opts *options) {
-	opts.exporter = se.exporter
-}
-
-//----------------------BEGIN LOGGING RELATED FUNCTIONS----------------------
-
-// NewLogger creates a logger for id that produces logs at and below the indicated level.
-// level here indicates the level at and below which logs are created.
-func NewLogger(id string, level wcl.LogLevel) PrintlnLogger {
-	return PrintlnLogger{id: id, level: level}
-}
-
-type PrintlnLogger struct {
-	level wcl.LogLevel
-	id    string
-}
-
-func (w PrintlnLogger) Log(level wcl.LogLevel, message string, m map[string]interface{}) {
-
-	if level >= level {
-		m["id"] = w.id
-		jsonLog, err := json.Marshal(m)
-		if err != nil {
-			jsonLog, err = json.Marshal(map[string]interface{}{"Error Marshalling Log": err})
-		}
-		fmt.Println(string(jsonLog))
+	t := http.DefaultTransport
+	if transport != nil {
+		t = *transport
 	}
-}
-
-//----------------------END LOGGING RELATED FUNCTIONS------------------------
-
-//----------------------BEGIN TRACING RELATED FUNCTIONS----------------------
-
-// newResource returns a resource describing this application.
-// Used for setting up tracer provider
-func newResource() *resource.Resource {
-	r, _ := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("blog"),
-			semconv.ServiceVersionKey.String("9.0.0"),
-		),
-	)
-	return r
-}
-
-func newTracerProvider(exporter sdktrace.SpanExporter, samplingProbability float64) *sdktrace.TracerProvider {
-
-	tp := sdktrace.NewTracerProvider(
-		// We use the default ID generator. In order for sampling to work (at least with this sampler)
-		// the ID generator must generate trace IDs uniformly at random from the entire space of uint64.
-		// For example, the default x-ray ID generator does not do this.
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		// These maximums are to guard against something going wrong and sending a ton of data unexpectedly
-		sdktrace.WithSpanLimits(sdktrace.SpanLimits{
-			AttributeCountLimit: 100,
-			EventCountLimit:     100,
-			LinkCountLimit:      100,
-		}),
-		//Batcher is more efficient, switch to it after testing
-		// sdktrace.WithSyncer(exporter),
-		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(newResource()),
-	)
-	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
-	return tp
-}
-
-func doNothing(baseTransport http.RoundTripper, spanNameCtxValue interface{}, tp sdktrace.TracerProvider) http.RoundTripper {
-	return baseTransport
-}
-
-func determineSampling() (samplingProbability float64, err error) {
-
-	// If we're running locally, then turn off sampling. Otherwise sample
-	// 1% or whatever TRACING_SAMPLING_PROBABILITY specifies.
-	samplingProbability = 0.01
-	isLocal := os.Getenv("_IS_LOCAL") == "true"
-	if isLocal {
-		fmt.Println("Set to Local")
-		samplingProbability = 1.0
-	} else if v := os.Getenv("TRACING_SAMPLING_PROBABILITY"); v != "" {
-		samplingProbabilityFromEnv, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			return 0, fmt.Errorf("could not parse '%s' to float", v)
-		}
-		samplingProbability = samplingProbabilityFromEnv
-	}
-	return
-}
-
-//----------------------END TRACING RELATEDFUNCTIONS----------------------
-
-// New creates a new client. The base path and http transport are configurable.
-func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
-
-	defaultTransport := http.DefaultTransport
-	defaultLogger := NewLogger("blog-wagclient", wcl.Info)
-	defaultExporter := tracetest.NewNoopExporter()
-	defaultInstrumentor := doNothing
 
 	basePath = strings.TrimSuffix(basePath, "/")
 	base := baseDoer{}
+
 	// For the short-term don't use the default retry policy since its 5 retries can 5X
 	// the traffic. Once we've enabled circuit breakers by default we can turn it on.
 	retry := retryDoer{d: base, retryPolicy: SingleRetryPolicy{}}
-	options := options{
-		transport:    defaultTransport,
-		logger:       defaultLogger,
-		exporter:     defaultExporter,
-		instrumentor: defaultInstrumentor,
-	}
-
-	for _, o := range opts {
-		o.apply(&options)
-	}
-
-	samplingProbability := 1.0 // Hard setting this to one for now, because right now
-	// it is essentially ignored as the sidecar is determining the sample rate it forwards on to DD.
-	// Thus the prefered approach is to sample locally with the sidecar.
-
-	tp := newTracerProvider(options.exporter, samplingProbability)
-	options.transport = options.instrumentor(options.transport, ctx, *tp)
 
 	circuit := &circuitBreakerDoer{
 		d: &retry,
@@ -253,19 +70,20 @@ func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
 		debug: true,
 		// one circuit for each service + url pair
 		circuitName: fmt.Sprintf("blog-%s", shortHash(basePath)),
-		logger:      options.logger,
+		logger:      logger,
 	}
 	circuit.init()
+
 	client := &WagClient{
 		basePath:    basePath,
 		requestDoer: circuit,
 		client: &http.Client{
-			Transport: options.transport,
+			Transport: t,
 		},
 		retryDoer:      &retry,
 		circuitDoer:    circuit,
 		defaultTimeout: 5 * time.Second,
-		logger:         options.logger,
+		logger:         logger,
 	}
 	client.SetCircuitBreakerSettings(DefaultCircuitBreakerSettings)
 	return client
@@ -273,7 +91,10 @@ func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
 
 // NewFromDiscovery creates a client from the discovery environment variables. This method requires
 // the three env vars: SERVICE_BLOG_HTTP_(HOST/PORT/PROTO) to be set. Otherwise it returns an error.
-func NewFromDiscovery(opts ...Option) (*WagClient, error) {
+// The logger provided should be specifically created for this wag client. If tracing is required,
+// provide an instrumented transport using the wag clientconfig module. If no tracing is required, pass nil to use
+// the default transport.
+func NewFromDiscovery(logger wcl.WagClientLogger, transport *http.RoundTripper) (*WagClient, error) {
 	url, err := discovery.URL("blog", "default")
 	if err != nil {
 		url, err = discovery.URL("blog", "http") // Added fallback to maintain reverse compatibility
@@ -281,7 +102,7 @@ func NewFromDiscovery(opts ...Option) (*WagClient, error) {
 			return nil, err
 		}
 	}
-	return New(context.Background(), url, opts...), nil
+	return New(url, logger, transport), nil
 }
 
 // SetRetryPolicy sets a the given retry policy for all requests.

--- a/samples/gen-go-blog/client/go.mod
+++ b/samples/gen-go-blog/client/go.mod
@@ -9,9 +9,6 @@ require (
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
 	github.com/donovanhide/eventsource v0.0.0-20171031113327-3ed64d21fb0b
 	github.com/smartystreets/goconvey v1.7.2 // indirect
-	go.opentelemetry.io/otel v1.9.0
-	go.opentelemetry.io/otel/sdk v1.9.0
-
 )
 //Replace directives will work locally but mess up imports.
 replace github.com/Clever/wag/samples/gen-go-blog/models/v9 => ../models 

--- a/samples/gen-go-client-only/client/client.go
+++ b/samples/gen-go-client-only/client/client.go
@@ -1,6 +1,5 @@
 package client
 
-// Using Alpha version of WAG Yay!
 import (
 	"bytes"
 	"context"
@@ -9,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -20,13 +18,6 @@ import (
 	wcl "github.com/Clever/wag/logging/wagclientlogger"
 
 	"github.com/afex/hystrix-go/hystrix"
-
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 )
 
 var _ = json.Marshal
@@ -55,197 +46,23 @@ type WagClient struct {
 
 var _ Client = (*WagClient)(nil)
 
-//This pattern is used instead of using closures for greater transparency and the ability to implement additional interfaces.
-type options struct {
-	transport    http.RoundTripper
-	logger       wcl.WagClientLogger
-	instrumentor Instrumentor
-	exporter     sdktrace.SpanExporter
-}
+// New creates a new client. The base path, logger, and http transport are configurable.
+// The logger provided should be specifically created for this wag client. If tracing is required,
+// provide an instrumented transport using the wag clientconfig module. If no tracing is required, pass nil to use
+// the default transport.
+func New(basePath string, logger wcl.WagClientLogger, transport *http.RoundTripper) *WagClient {
 
-type Option interface {
-	apply(*options)
-}
-
-//WithLogger sets client logger option.
-func WithLogger(log wcl.WagClientLogger) Option {
-	return loggerOption{Log: log}
-}
-
-type loggerOption struct {
-	Log wcl.WagClientLogger
-}
-
-func (l loggerOption) apply(opts *options) {
-	opts.logger = l.Log
-}
-
-type roundTripperOption struct {
-	rt http.RoundTripper
-}
-
-func (t roundTripperOption) apply(opts *options) {
-	opts.transport = t.rt
-}
-
-// WithRoundTripper allows you to pass in intrumented/custom roundtrippers which will then wrap the
-// transport roundtripper
-func WithRoundTripper(t http.RoundTripper) Option {
-	return roundTripperOption{rt: t}
-}
-
-// Instrumentor is a function that creates an instrumented round tripper
-type Instrumentor func(baseTransport http.RoundTripper, spanNameCtxValue interface{}, tp sdktrace.TracerProvider) http.RoundTripper
-
-// WithInstrumentor sets a instrumenting function that will be used to wrap the roundTripper for tracing.
-// For standard instrumentation with tracing use tracing.InstrumentedTransport, default is non-instrumented.
-
-func WithInstrumentor(fn Instrumentor) Option {
-	return instrumentorOption{instrumentor: fn}
-}
-
-type instrumentorOption struct {
-	instrumentor Instrumentor
-}
-
-func (i instrumentorOption) apply(opts *options) {
-	opts.instrumentor = i.instrumentor
-}
-
-// WithExporter sets client span exporter option.
-func WithExporter(se sdktrace.SpanExporter) Option {
-	return exporterOption{exporter: se}
-}
-
-type exporterOption struct {
-	exporter sdktrace.SpanExporter
-}
-
-func (se exporterOption) apply(opts *options) {
-	opts.exporter = se.exporter
-}
-
-//----------------------BEGIN LOGGING RELATED FUNCTIONS----------------------
-
-// NewLogger creates a logger for id that produces logs at and below the indicated level.
-// level here indicates the level at and below which logs are created.
-func NewLogger(id string, level wcl.LogLevel) PrintlnLogger {
-	return PrintlnLogger{id: id, level: level}
-}
-
-type PrintlnLogger struct {
-	level wcl.LogLevel
-	id    string
-}
-
-func (w PrintlnLogger) Log(level wcl.LogLevel, message string, m map[string]interface{}) {
-
-	if level >= level {
-		m["id"] = w.id
-		jsonLog, err := json.Marshal(m)
-		if err != nil {
-			jsonLog, err = json.Marshal(map[string]interface{}{"Error Marshalling Log": err})
-		}
-		fmt.Println(string(jsonLog))
+	t := http.DefaultTransport
+	if transport != nil {
+		t = *transport
 	}
-}
-
-//----------------------END LOGGING RELATED FUNCTIONS------------------------
-
-//----------------------BEGIN TRACING RELATED FUNCTIONS----------------------
-
-// newResource returns a resource describing this application.
-// Used for setting up tracer provider
-func newResource() *resource.Resource {
-	r, _ := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("swagger-test"),
-			semconv.ServiceVersionKey.String("9.0.0"),
-		),
-	)
-	return r
-}
-
-func newTracerProvider(exporter sdktrace.SpanExporter, samplingProbability float64) *sdktrace.TracerProvider {
-
-	tp := sdktrace.NewTracerProvider(
-		// We use the default ID generator. In order for sampling to work (at least with this sampler)
-		// the ID generator must generate trace IDs uniformly at random from the entire space of uint64.
-		// For example, the default x-ray ID generator does not do this.
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		// These maximums are to guard against something going wrong and sending a ton of data unexpectedly
-		sdktrace.WithSpanLimits(sdktrace.SpanLimits{
-			AttributeCountLimit: 100,
-			EventCountLimit:     100,
-			LinkCountLimit:      100,
-		}),
-		//Batcher is more efficient, switch to it after testing
-		// sdktrace.WithSyncer(exporter),
-		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(newResource()),
-	)
-	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
-	return tp
-}
-
-func doNothing(baseTransport http.RoundTripper, spanNameCtxValue interface{}, tp sdktrace.TracerProvider) http.RoundTripper {
-	return baseTransport
-}
-
-func determineSampling() (samplingProbability float64, err error) {
-
-	// If we're running locally, then turn off sampling. Otherwise sample
-	// 1% or whatever TRACING_SAMPLING_PROBABILITY specifies.
-	samplingProbability = 0.01
-	isLocal := os.Getenv("_IS_LOCAL") == "true"
-	if isLocal {
-		fmt.Println("Set to Local")
-		samplingProbability = 1.0
-	} else if v := os.Getenv("TRACING_SAMPLING_PROBABILITY"); v != "" {
-		samplingProbabilityFromEnv, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			return 0, fmt.Errorf("could not parse '%s' to float", v)
-		}
-		samplingProbability = samplingProbabilityFromEnv
-	}
-	return
-}
-
-//----------------------END TRACING RELATEDFUNCTIONS----------------------
-
-// New creates a new client. The base path and http transport are configurable.
-func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
-
-	defaultTransport := http.DefaultTransport
-	defaultLogger := NewLogger("swagger-test-wagclient", wcl.Info)
-	defaultExporter := tracetest.NewNoopExporter()
-	defaultInstrumentor := doNothing
 
 	basePath = strings.TrimSuffix(basePath, "/")
 	base := baseDoer{}
+
 	// For the short-term don't use the default retry policy since its 5 retries can 5X
 	// the traffic. Once we've enabled circuit breakers by default we can turn it on.
 	retry := retryDoer{d: base, retryPolicy: SingleRetryPolicy{}}
-	options := options{
-		transport:    defaultTransport,
-		logger:       defaultLogger,
-		exporter:     defaultExporter,
-		instrumentor: defaultInstrumentor,
-	}
-
-	for _, o := range opts {
-		o.apply(&options)
-	}
-
-	samplingProbability := 1.0 // Hard setting this to one for now, because right now
-	// it is essentially ignored as the sidecar is determining the sample rate it forwards on to DD.
-	// Thus the prefered approach is to sample locally with the sidecar.
-
-	tp := newTracerProvider(options.exporter, samplingProbability)
-	options.transport = options.instrumentor(options.transport, ctx, *tp)
 
 	circuit := &circuitBreakerDoer{
 		d: &retry,
@@ -253,19 +70,20 @@ func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
 		debug: true,
 		// one circuit for each service + url pair
 		circuitName: fmt.Sprintf("swagger-test-%s", shortHash(basePath)),
-		logger:      options.logger,
+		logger:      logger,
 	}
 	circuit.init()
+
 	client := &WagClient{
 		basePath:    basePath,
 		requestDoer: circuit,
 		client: &http.Client{
-			Transport: options.transport,
+			Transport: t,
 		},
 		retryDoer:      &retry,
 		circuitDoer:    circuit,
 		defaultTimeout: 5 * time.Second,
-		logger:         options.logger,
+		logger:         logger,
 	}
 	client.SetCircuitBreakerSettings(DefaultCircuitBreakerSettings)
 	return client
@@ -273,7 +91,10 @@ func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
 
 // NewFromDiscovery creates a client from the discovery environment variables. This method requires
 // the three env vars: SERVICE_SWAGGER_TEST_HTTP_(HOST/PORT/PROTO) to be set. Otherwise it returns an error.
-func NewFromDiscovery(opts ...Option) (*WagClient, error) {
+// The logger provided should be specifically created for this wag client. If tracing is required,
+// provide an instrumented transport using the wag clientconfig module. If no tracing is required, pass nil to use
+// the default transport.
+func NewFromDiscovery(logger wcl.WagClientLogger, transport *http.RoundTripper) (*WagClient, error) {
 	url, err := discovery.URL("swagger-test", "default")
 	if err != nil {
 		url, err = discovery.URL("swagger-test", "http") // Added fallback to maintain reverse compatibility
@@ -281,7 +102,7 @@ func NewFromDiscovery(opts ...Option) (*WagClient, error) {
 			return nil, err
 		}
 	}
-	return New(context.Background(), url, opts...), nil
+	return New(url, logger, transport), nil
 }
 
 // SetRetryPolicy sets a the given retry policy for all requests.

--- a/samples/gen-go-client-only/client/go.mod
+++ b/samples/gen-go-client-only/client/go.mod
@@ -9,9 +9,6 @@ require (
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
 	github.com/donovanhide/eventsource v0.0.0-20171031113327-3ed64d21fb0b
 	github.com/smartystreets/goconvey v1.7.2 // indirect
-	go.opentelemetry.io/otel v1.9.0
-	go.opentelemetry.io/otel/sdk v1.9.0
-
 )
 //Replace directives will work locally but mess up imports.
 replace github.com/Clever/wag/samples/gen-go-client-only/models/v9 => ../models 

--- a/samples/gen-go-db-custom-path/client/client.go
+++ b/samples/gen-go-db-custom-path/client/client.go
@@ -1,6 +1,5 @@
 package client
 
-// Using Alpha version of WAG Yay!
 import (
 	"bytes"
 	"context"
@@ -9,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -20,13 +18,6 @@ import (
 	wcl "github.com/Clever/wag/logging/wagclientlogger"
 
 	"github.com/afex/hystrix-go/hystrix"
-
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 )
 
 var _ = json.Marshal
@@ -55,197 +46,23 @@ type WagClient struct {
 
 var _ Client = (*WagClient)(nil)
 
-//This pattern is used instead of using closures for greater transparency and the ability to implement additional interfaces.
-type options struct {
-	transport    http.RoundTripper
-	logger       wcl.WagClientLogger
-	instrumentor Instrumentor
-	exporter     sdktrace.SpanExporter
-}
+// New creates a new client. The base path, logger, and http transport are configurable.
+// The logger provided should be specifically created for this wag client. If tracing is required,
+// provide an instrumented transport using the wag clientconfig module. If no tracing is required, pass nil to use
+// the default transport.
+func New(basePath string, logger wcl.WagClientLogger, transport *http.RoundTripper) *WagClient {
 
-type Option interface {
-	apply(*options)
-}
-
-//WithLogger sets client logger option.
-func WithLogger(log wcl.WagClientLogger) Option {
-	return loggerOption{Log: log}
-}
-
-type loggerOption struct {
-	Log wcl.WagClientLogger
-}
-
-func (l loggerOption) apply(opts *options) {
-	opts.logger = l.Log
-}
-
-type roundTripperOption struct {
-	rt http.RoundTripper
-}
-
-func (t roundTripperOption) apply(opts *options) {
-	opts.transport = t.rt
-}
-
-// WithRoundTripper allows you to pass in intrumented/custom roundtrippers which will then wrap the
-// transport roundtripper
-func WithRoundTripper(t http.RoundTripper) Option {
-	return roundTripperOption{rt: t}
-}
-
-// Instrumentor is a function that creates an instrumented round tripper
-type Instrumentor func(baseTransport http.RoundTripper, spanNameCtxValue interface{}, tp sdktrace.TracerProvider) http.RoundTripper
-
-// WithInstrumentor sets a instrumenting function that will be used to wrap the roundTripper for tracing.
-// For standard instrumentation with tracing use tracing.InstrumentedTransport, default is non-instrumented.
-
-func WithInstrumentor(fn Instrumentor) Option {
-	return instrumentorOption{instrumentor: fn}
-}
-
-type instrumentorOption struct {
-	instrumentor Instrumentor
-}
-
-func (i instrumentorOption) apply(opts *options) {
-	opts.instrumentor = i.instrumentor
-}
-
-// WithExporter sets client span exporter option.
-func WithExporter(se sdktrace.SpanExporter) Option {
-	return exporterOption{exporter: se}
-}
-
-type exporterOption struct {
-	exporter sdktrace.SpanExporter
-}
-
-func (se exporterOption) apply(opts *options) {
-	opts.exporter = se.exporter
-}
-
-//----------------------BEGIN LOGGING RELATED FUNCTIONS----------------------
-
-// NewLogger creates a logger for id that produces logs at and below the indicated level.
-// level here indicates the level at and below which logs are created.
-func NewLogger(id string, level wcl.LogLevel) PrintlnLogger {
-	return PrintlnLogger{id: id, level: level}
-}
-
-type PrintlnLogger struct {
-	level wcl.LogLevel
-	id    string
-}
-
-func (w PrintlnLogger) Log(level wcl.LogLevel, message string, m map[string]interface{}) {
-
-	if level >= level {
-		m["id"] = w.id
-		jsonLog, err := json.Marshal(m)
-		if err != nil {
-			jsonLog, err = json.Marshal(map[string]interface{}{"Error Marshalling Log": err})
-		}
-		fmt.Println(string(jsonLog))
+	t := http.DefaultTransport
+	if transport != nil {
+		t = *transport
 	}
-}
-
-//----------------------END LOGGING RELATED FUNCTIONS------------------------
-
-//----------------------BEGIN TRACING RELATED FUNCTIONS----------------------
-
-// newResource returns a resource describing this application.
-// Used for setting up tracer provider
-func newResource() *resource.Resource {
-	r, _ := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("swagger-test"),
-			semconv.ServiceVersionKey.String("9.0.0"),
-		),
-	)
-	return r
-}
-
-func newTracerProvider(exporter sdktrace.SpanExporter, samplingProbability float64) *sdktrace.TracerProvider {
-
-	tp := sdktrace.NewTracerProvider(
-		// We use the default ID generator. In order for sampling to work (at least with this sampler)
-		// the ID generator must generate trace IDs uniformly at random from the entire space of uint64.
-		// For example, the default x-ray ID generator does not do this.
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		// These maximums are to guard against something going wrong and sending a ton of data unexpectedly
-		sdktrace.WithSpanLimits(sdktrace.SpanLimits{
-			AttributeCountLimit: 100,
-			EventCountLimit:     100,
-			LinkCountLimit:      100,
-		}),
-		//Batcher is more efficient, switch to it after testing
-		// sdktrace.WithSyncer(exporter),
-		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(newResource()),
-	)
-	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
-	return tp
-}
-
-func doNothing(baseTransport http.RoundTripper, spanNameCtxValue interface{}, tp sdktrace.TracerProvider) http.RoundTripper {
-	return baseTransport
-}
-
-func determineSampling() (samplingProbability float64, err error) {
-
-	// If we're running locally, then turn off sampling. Otherwise sample
-	// 1% or whatever TRACING_SAMPLING_PROBABILITY specifies.
-	samplingProbability = 0.01
-	isLocal := os.Getenv("_IS_LOCAL") == "true"
-	if isLocal {
-		fmt.Println("Set to Local")
-		samplingProbability = 1.0
-	} else if v := os.Getenv("TRACING_SAMPLING_PROBABILITY"); v != "" {
-		samplingProbabilityFromEnv, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			return 0, fmt.Errorf("could not parse '%s' to float", v)
-		}
-		samplingProbability = samplingProbabilityFromEnv
-	}
-	return
-}
-
-//----------------------END TRACING RELATEDFUNCTIONS----------------------
-
-// New creates a new client. The base path and http transport are configurable.
-func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
-
-	defaultTransport := http.DefaultTransport
-	defaultLogger := NewLogger("swagger-test-wagclient", wcl.Info)
-	defaultExporter := tracetest.NewNoopExporter()
-	defaultInstrumentor := doNothing
 
 	basePath = strings.TrimSuffix(basePath, "/")
 	base := baseDoer{}
+
 	// For the short-term don't use the default retry policy since its 5 retries can 5X
 	// the traffic. Once we've enabled circuit breakers by default we can turn it on.
 	retry := retryDoer{d: base, retryPolicy: SingleRetryPolicy{}}
-	options := options{
-		transport:    defaultTransport,
-		logger:       defaultLogger,
-		exporter:     defaultExporter,
-		instrumentor: defaultInstrumentor,
-	}
-
-	for _, o := range opts {
-		o.apply(&options)
-	}
-
-	samplingProbability := 1.0 // Hard setting this to one for now, because right now
-	// it is essentially ignored as the sidecar is determining the sample rate it forwards on to DD.
-	// Thus the prefered approach is to sample locally with the sidecar.
-
-	tp := newTracerProvider(options.exporter, samplingProbability)
-	options.transport = options.instrumentor(options.transport, ctx, *tp)
 
 	circuit := &circuitBreakerDoer{
 		d: &retry,
@@ -253,19 +70,20 @@ func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
 		debug: true,
 		// one circuit for each service + url pair
 		circuitName: fmt.Sprintf("swagger-test-%s", shortHash(basePath)),
-		logger:      options.logger,
+		logger:      logger,
 	}
 	circuit.init()
+
 	client := &WagClient{
 		basePath:    basePath,
 		requestDoer: circuit,
 		client: &http.Client{
-			Transport: options.transport,
+			Transport: t,
 		},
 		retryDoer:      &retry,
 		circuitDoer:    circuit,
 		defaultTimeout: 5 * time.Second,
-		logger:         options.logger,
+		logger:         logger,
 	}
 	client.SetCircuitBreakerSettings(DefaultCircuitBreakerSettings)
 	return client
@@ -273,7 +91,10 @@ func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
 
 // NewFromDiscovery creates a client from the discovery environment variables. This method requires
 // the three env vars: SERVICE_SWAGGER_TEST_HTTP_(HOST/PORT/PROTO) to be set. Otherwise it returns an error.
-func NewFromDiscovery(opts ...Option) (*WagClient, error) {
+// The logger provided should be specifically created for this wag client. If tracing is required,
+// provide an instrumented transport using the wag clientconfig module. If no tracing is required, pass nil to use
+// the default transport.
+func NewFromDiscovery(logger wcl.WagClientLogger, transport *http.RoundTripper) (*WagClient, error) {
 	url, err := discovery.URL("swagger-test", "default")
 	if err != nil {
 		url, err = discovery.URL("swagger-test", "http") // Added fallback to maintain reverse compatibility
@@ -281,7 +102,7 @@ func NewFromDiscovery(opts ...Option) (*WagClient, error) {
 			return nil, err
 		}
 	}
-	return New(context.Background(), url, opts...), nil
+	return New(url, logger, transport), nil
 }
 
 // SetRetryPolicy sets a the given retry policy for all requests.

--- a/samples/gen-go-db-custom-path/client/go.mod
+++ b/samples/gen-go-db-custom-path/client/go.mod
@@ -9,9 +9,6 @@ require (
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
 	github.com/donovanhide/eventsource v0.0.0-20171031113327-3ed64d21fb0b
 	github.com/smartystreets/goconvey v1.7.2 // indirect
-	go.opentelemetry.io/otel v1.9.0
-	go.opentelemetry.io/otel/sdk v1.9.0
-
 )
 //Replace directives will work locally but mess up imports.
 replace github.com/Clever/wag/samples/gen-go-db-custom-path/models/v9 => ../models 

--- a/samples/gen-go-db/client/client.go
+++ b/samples/gen-go-db/client/client.go
@@ -1,6 +1,5 @@
 package client
 
-// Using Alpha version of WAG Yay!
 import (
 	"bytes"
 	"context"
@@ -9,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -20,13 +18,6 @@ import (
 	wcl "github.com/Clever/wag/logging/wagclientlogger"
 
 	"github.com/afex/hystrix-go/hystrix"
-
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 )
 
 var _ = json.Marshal
@@ -55,197 +46,23 @@ type WagClient struct {
 
 var _ Client = (*WagClient)(nil)
 
-//This pattern is used instead of using closures for greater transparency and the ability to implement additional interfaces.
-type options struct {
-	transport    http.RoundTripper
-	logger       wcl.WagClientLogger
-	instrumentor Instrumentor
-	exporter     sdktrace.SpanExporter
-}
+// New creates a new client. The base path, logger, and http transport are configurable.
+// The logger provided should be specifically created for this wag client. If tracing is required,
+// provide an instrumented transport using the wag clientconfig module. If no tracing is required, pass nil to use
+// the default transport.
+func New(basePath string, logger wcl.WagClientLogger, transport *http.RoundTripper) *WagClient {
 
-type Option interface {
-	apply(*options)
-}
-
-//WithLogger sets client logger option.
-func WithLogger(log wcl.WagClientLogger) Option {
-	return loggerOption{Log: log}
-}
-
-type loggerOption struct {
-	Log wcl.WagClientLogger
-}
-
-func (l loggerOption) apply(opts *options) {
-	opts.logger = l.Log
-}
-
-type roundTripperOption struct {
-	rt http.RoundTripper
-}
-
-func (t roundTripperOption) apply(opts *options) {
-	opts.transport = t.rt
-}
-
-// WithRoundTripper allows you to pass in intrumented/custom roundtrippers which will then wrap the
-// transport roundtripper
-func WithRoundTripper(t http.RoundTripper) Option {
-	return roundTripperOption{rt: t}
-}
-
-// Instrumentor is a function that creates an instrumented round tripper
-type Instrumentor func(baseTransport http.RoundTripper, spanNameCtxValue interface{}, tp sdktrace.TracerProvider) http.RoundTripper
-
-// WithInstrumentor sets a instrumenting function that will be used to wrap the roundTripper for tracing.
-// For standard instrumentation with tracing use tracing.InstrumentedTransport, default is non-instrumented.
-
-func WithInstrumentor(fn Instrumentor) Option {
-	return instrumentorOption{instrumentor: fn}
-}
-
-type instrumentorOption struct {
-	instrumentor Instrumentor
-}
-
-func (i instrumentorOption) apply(opts *options) {
-	opts.instrumentor = i.instrumentor
-}
-
-// WithExporter sets client span exporter option.
-func WithExporter(se sdktrace.SpanExporter) Option {
-	return exporterOption{exporter: se}
-}
-
-type exporterOption struct {
-	exporter sdktrace.SpanExporter
-}
-
-func (se exporterOption) apply(opts *options) {
-	opts.exporter = se.exporter
-}
-
-//----------------------BEGIN LOGGING RELATED FUNCTIONS----------------------
-
-// NewLogger creates a logger for id that produces logs at and below the indicated level.
-// level here indicates the level at and below which logs are created.
-func NewLogger(id string, level wcl.LogLevel) PrintlnLogger {
-	return PrintlnLogger{id: id, level: level}
-}
-
-type PrintlnLogger struct {
-	level wcl.LogLevel
-	id    string
-}
-
-func (w PrintlnLogger) Log(level wcl.LogLevel, message string, m map[string]interface{}) {
-
-	if level >= level {
-		m["id"] = w.id
-		jsonLog, err := json.Marshal(m)
-		if err != nil {
-			jsonLog, err = json.Marshal(map[string]interface{}{"Error Marshalling Log": err})
-		}
-		fmt.Println(string(jsonLog))
+	t := http.DefaultTransport
+	if transport != nil {
+		t = *transport
 	}
-}
-
-//----------------------END LOGGING RELATED FUNCTIONS------------------------
-
-//----------------------BEGIN TRACING RELATED FUNCTIONS----------------------
-
-// newResource returns a resource describing this application.
-// Used for setting up tracer provider
-func newResource() *resource.Resource {
-	r, _ := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("swagger-test"),
-			semconv.ServiceVersionKey.String("9.0.0"),
-		),
-	)
-	return r
-}
-
-func newTracerProvider(exporter sdktrace.SpanExporter, samplingProbability float64) *sdktrace.TracerProvider {
-
-	tp := sdktrace.NewTracerProvider(
-		// We use the default ID generator. In order for sampling to work (at least with this sampler)
-		// the ID generator must generate trace IDs uniformly at random from the entire space of uint64.
-		// For example, the default x-ray ID generator does not do this.
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		// These maximums are to guard against something going wrong and sending a ton of data unexpectedly
-		sdktrace.WithSpanLimits(sdktrace.SpanLimits{
-			AttributeCountLimit: 100,
-			EventCountLimit:     100,
-			LinkCountLimit:      100,
-		}),
-		//Batcher is more efficient, switch to it after testing
-		// sdktrace.WithSyncer(exporter),
-		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(newResource()),
-	)
-	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
-	return tp
-}
-
-func doNothing(baseTransport http.RoundTripper, spanNameCtxValue interface{}, tp sdktrace.TracerProvider) http.RoundTripper {
-	return baseTransport
-}
-
-func determineSampling() (samplingProbability float64, err error) {
-
-	// If we're running locally, then turn off sampling. Otherwise sample
-	// 1% or whatever TRACING_SAMPLING_PROBABILITY specifies.
-	samplingProbability = 0.01
-	isLocal := os.Getenv("_IS_LOCAL") == "true"
-	if isLocal {
-		fmt.Println("Set to Local")
-		samplingProbability = 1.0
-	} else if v := os.Getenv("TRACING_SAMPLING_PROBABILITY"); v != "" {
-		samplingProbabilityFromEnv, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			return 0, fmt.Errorf("could not parse '%s' to float", v)
-		}
-		samplingProbability = samplingProbabilityFromEnv
-	}
-	return
-}
-
-//----------------------END TRACING RELATEDFUNCTIONS----------------------
-
-// New creates a new client. The base path and http transport are configurable.
-func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
-
-	defaultTransport := http.DefaultTransport
-	defaultLogger := NewLogger("swagger-test-wagclient", wcl.Info)
-	defaultExporter := tracetest.NewNoopExporter()
-	defaultInstrumentor := doNothing
 
 	basePath = strings.TrimSuffix(basePath, "/")
 	base := baseDoer{}
+
 	// For the short-term don't use the default retry policy since its 5 retries can 5X
 	// the traffic. Once we've enabled circuit breakers by default we can turn it on.
 	retry := retryDoer{d: base, retryPolicy: SingleRetryPolicy{}}
-	options := options{
-		transport:    defaultTransport,
-		logger:       defaultLogger,
-		exporter:     defaultExporter,
-		instrumentor: defaultInstrumentor,
-	}
-
-	for _, o := range opts {
-		o.apply(&options)
-	}
-
-	samplingProbability := 1.0 // Hard setting this to one for now, because right now
-	// it is essentially ignored as the sidecar is determining the sample rate it forwards on to DD.
-	// Thus the prefered approach is to sample locally with the sidecar.
-
-	tp := newTracerProvider(options.exporter, samplingProbability)
-	options.transport = options.instrumentor(options.transport, ctx, *tp)
 
 	circuit := &circuitBreakerDoer{
 		d: &retry,
@@ -253,19 +70,20 @@ func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
 		debug: true,
 		// one circuit for each service + url pair
 		circuitName: fmt.Sprintf("swagger-test-%s", shortHash(basePath)),
-		logger:      options.logger,
+		logger:      logger,
 	}
 	circuit.init()
+
 	client := &WagClient{
 		basePath:    basePath,
 		requestDoer: circuit,
 		client: &http.Client{
-			Transport: options.transport,
+			Transport: t,
 		},
 		retryDoer:      &retry,
 		circuitDoer:    circuit,
 		defaultTimeout: 5 * time.Second,
-		logger:         options.logger,
+		logger:         logger,
 	}
 	client.SetCircuitBreakerSettings(DefaultCircuitBreakerSettings)
 	return client
@@ -273,7 +91,10 @@ func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
 
 // NewFromDiscovery creates a client from the discovery environment variables. This method requires
 // the three env vars: SERVICE_SWAGGER_TEST_HTTP_(HOST/PORT/PROTO) to be set. Otherwise it returns an error.
-func NewFromDiscovery(opts ...Option) (*WagClient, error) {
+// The logger provided should be specifically created for this wag client. If tracing is required,
+// provide an instrumented transport using the wag clientconfig module. If no tracing is required, pass nil to use
+// the default transport.
+func NewFromDiscovery(logger wcl.WagClientLogger, transport *http.RoundTripper) (*WagClient, error) {
 	url, err := discovery.URL("swagger-test", "default")
 	if err != nil {
 		url, err = discovery.URL("swagger-test", "http") // Added fallback to maintain reverse compatibility
@@ -281,7 +102,7 @@ func NewFromDiscovery(opts ...Option) (*WagClient, error) {
 			return nil, err
 		}
 	}
-	return New(context.Background(), url, opts...), nil
+	return New(url, logger, transport), nil
 }
 
 // SetRetryPolicy sets a the given retry policy for all requests.

--- a/samples/gen-go-db/client/go.mod
+++ b/samples/gen-go-db/client/go.mod
@@ -9,9 +9,6 @@ require (
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
 	github.com/donovanhide/eventsource v0.0.0-20171031113327-3ed64d21fb0b
 	github.com/smartystreets/goconvey v1.7.2 // indirect
-	go.opentelemetry.io/otel v1.9.0
-	go.opentelemetry.io/otel/sdk v1.9.0
-
 )
 //Replace directives will work locally but mess up imports.
 replace github.com/Clever/wag/samples/gen-go-db/models/v9 => ../models 

--- a/samples/gen-go-deprecated/client/client.go
+++ b/samples/gen-go-deprecated/client/client.go
@@ -1,6 +1,5 @@
 package client
 
-// Using Alpha version of WAG Yay!
 import (
 	"bytes"
 	"context"
@@ -9,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -20,13 +18,6 @@ import (
 	wcl "github.com/Clever/wag/logging/wagclientlogger"
 
 	"github.com/afex/hystrix-go/hystrix"
-
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 )
 
 var _ = json.Marshal
@@ -55,197 +46,23 @@ type WagClient struct {
 
 var _ Client = (*WagClient)(nil)
 
-//This pattern is used instead of using closures for greater transparency and the ability to implement additional interfaces.
-type options struct {
-	transport    http.RoundTripper
-	logger       wcl.WagClientLogger
-	instrumentor Instrumentor
-	exporter     sdktrace.SpanExporter
-}
+// New creates a new client. The base path, logger, and http transport are configurable.
+// The logger provided should be specifically created for this wag client. If tracing is required,
+// provide an instrumented transport using the wag clientconfig module. If no tracing is required, pass nil to use
+// the default transport.
+func New(basePath string, logger wcl.WagClientLogger, transport *http.RoundTripper) *WagClient {
 
-type Option interface {
-	apply(*options)
-}
-
-//WithLogger sets client logger option.
-func WithLogger(log wcl.WagClientLogger) Option {
-	return loggerOption{Log: log}
-}
-
-type loggerOption struct {
-	Log wcl.WagClientLogger
-}
-
-func (l loggerOption) apply(opts *options) {
-	opts.logger = l.Log
-}
-
-type roundTripperOption struct {
-	rt http.RoundTripper
-}
-
-func (t roundTripperOption) apply(opts *options) {
-	opts.transport = t.rt
-}
-
-// WithRoundTripper allows you to pass in intrumented/custom roundtrippers which will then wrap the
-// transport roundtripper
-func WithRoundTripper(t http.RoundTripper) Option {
-	return roundTripperOption{rt: t}
-}
-
-// Instrumentor is a function that creates an instrumented round tripper
-type Instrumentor func(baseTransport http.RoundTripper, spanNameCtxValue interface{}, tp sdktrace.TracerProvider) http.RoundTripper
-
-// WithInstrumentor sets a instrumenting function that will be used to wrap the roundTripper for tracing.
-// For standard instrumentation with tracing use tracing.InstrumentedTransport, default is non-instrumented.
-
-func WithInstrumentor(fn Instrumentor) Option {
-	return instrumentorOption{instrumentor: fn}
-}
-
-type instrumentorOption struct {
-	instrumentor Instrumentor
-}
-
-func (i instrumentorOption) apply(opts *options) {
-	opts.instrumentor = i.instrumentor
-}
-
-// WithExporter sets client span exporter option.
-func WithExporter(se sdktrace.SpanExporter) Option {
-	return exporterOption{exporter: se}
-}
-
-type exporterOption struct {
-	exporter sdktrace.SpanExporter
-}
-
-func (se exporterOption) apply(opts *options) {
-	opts.exporter = se.exporter
-}
-
-//----------------------BEGIN LOGGING RELATED FUNCTIONS----------------------
-
-// NewLogger creates a logger for id that produces logs at and below the indicated level.
-// level here indicates the level at and below which logs are created.
-func NewLogger(id string, level wcl.LogLevel) PrintlnLogger {
-	return PrintlnLogger{id: id, level: level}
-}
-
-type PrintlnLogger struct {
-	level wcl.LogLevel
-	id    string
-}
-
-func (w PrintlnLogger) Log(level wcl.LogLevel, message string, m map[string]interface{}) {
-
-	if level >= level {
-		m["id"] = w.id
-		jsonLog, err := json.Marshal(m)
-		if err != nil {
-			jsonLog, err = json.Marshal(map[string]interface{}{"Error Marshalling Log": err})
-		}
-		fmt.Println(string(jsonLog))
+	t := http.DefaultTransport
+	if transport != nil {
+		t = *transport
 	}
-}
-
-//----------------------END LOGGING RELATED FUNCTIONS------------------------
-
-//----------------------BEGIN TRACING RELATED FUNCTIONS----------------------
-
-// newResource returns a resource describing this application.
-// Used for setting up tracer provider
-func newResource() *resource.Resource {
-	r, _ := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("swagger-test"),
-			semconv.ServiceVersionKey.String("9.0.0"),
-		),
-	)
-	return r
-}
-
-func newTracerProvider(exporter sdktrace.SpanExporter, samplingProbability float64) *sdktrace.TracerProvider {
-
-	tp := sdktrace.NewTracerProvider(
-		// We use the default ID generator. In order for sampling to work (at least with this sampler)
-		// the ID generator must generate trace IDs uniformly at random from the entire space of uint64.
-		// For example, the default x-ray ID generator does not do this.
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		// These maximums are to guard against something going wrong and sending a ton of data unexpectedly
-		sdktrace.WithSpanLimits(sdktrace.SpanLimits{
-			AttributeCountLimit: 100,
-			EventCountLimit:     100,
-			LinkCountLimit:      100,
-		}),
-		//Batcher is more efficient, switch to it after testing
-		// sdktrace.WithSyncer(exporter),
-		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(newResource()),
-	)
-	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
-	return tp
-}
-
-func doNothing(baseTransport http.RoundTripper, spanNameCtxValue interface{}, tp sdktrace.TracerProvider) http.RoundTripper {
-	return baseTransport
-}
-
-func determineSampling() (samplingProbability float64, err error) {
-
-	// If we're running locally, then turn off sampling. Otherwise sample
-	// 1% or whatever TRACING_SAMPLING_PROBABILITY specifies.
-	samplingProbability = 0.01
-	isLocal := os.Getenv("_IS_LOCAL") == "true"
-	if isLocal {
-		fmt.Println("Set to Local")
-		samplingProbability = 1.0
-	} else if v := os.Getenv("TRACING_SAMPLING_PROBABILITY"); v != "" {
-		samplingProbabilityFromEnv, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			return 0, fmt.Errorf("could not parse '%s' to float", v)
-		}
-		samplingProbability = samplingProbabilityFromEnv
-	}
-	return
-}
-
-//----------------------END TRACING RELATEDFUNCTIONS----------------------
-
-// New creates a new client. The base path and http transport are configurable.
-func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
-
-	defaultTransport := http.DefaultTransport
-	defaultLogger := NewLogger("swagger-test-wagclient", wcl.Info)
-	defaultExporter := tracetest.NewNoopExporter()
-	defaultInstrumentor := doNothing
 
 	basePath = strings.TrimSuffix(basePath, "/")
 	base := baseDoer{}
+
 	// For the short-term don't use the default retry policy since its 5 retries can 5X
 	// the traffic. Once we've enabled circuit breakers by default we can turn it on.
 	retry := retryDoer{d: base, retryPolicy: SingleRetryPolicy{}}
-	options := options{
-		transport:    defaultTransport,
-		logger:       defaultLogger,
-		exporter:     defaultExporter,
-		instrumentor: defaultInstrumentor,
-	}
-
-	for _, o := range opts {
-		o.apply(&options)
-	}
-
-	samplingProbability := 1.0 // Hard setting this to one for now, because right now
-	// it is essentially ignored as the sidecar is determining the sample rate it forwards on to DD.
-	// Thus the prefered approach is to sample locally with the sidecar.
-
-	tp := newTracerProvider(options.exporter, samplingProbability)
-	options.transport = options.instrumentor(options.transport, ctx, *tp)
 
 	circuit := &circuitBreakerDoer{
 		d: &retry,
@@ -253,19 +70,20 @@ func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
 		debug: true,
 		// one circuit for each service + url pair
 		circuitName: fmt.Sprintf("swagger-test-%s", shortHash(basePath)),
-		logger:      options.logger,
+		logger:      logger,
 	}
 	circuit.init()
+
 	client := &WagClient{
 		basePath:    basePath,
 		requestDoer: circuit,
 		client: &http.Client{
-			Transport: options.transport,
+			Transport: t,
 		},
 		retryDoer:      &retry,
 		circuitDoer:    circuit,
 		defaultTimeout: 5 * time.Second,
-		logger:         options.logger,
+		logger:         logger,
 	}
 	client.SetCircuitBreakerSettings(DefaultCircuitBreakerSettings)
 	return client
@@ -273,7 +91,10 @@ func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
 
 // NewFromDiscovery creates a client from the discovery environment variables. This method requires
 // the three env vars: SERVICE_SWAGGER_TEST_HTTP_(HOST/PORT/PROTO) to be set. Otherwise it returns an error.
-func NewFromDiscovery(opts ...Option) (*WagClient, error) {
+// The logger provided should be specifically created for this wag client. If tracing is required,
+// provide an instrumented transport using the wag clientconfig module. If no tracing is required, pass nil to use
+// the default transport.
+func NewFromDiscovery(logger wcl.WagClientLogger, transport *http.RoundTripper) (*WagClient, error) {
 	url, err := discovery.URL("swagger-test", "default")
 	if err != nil {
 		url, err = discovery.URL("swagger-test", "http") // Added fallback to maintain reverse compatibility
@@ -281,7 +102,7 @@ func NewFromDiscovery(opts ...Option) (*WagClient, error) {
 			return nil, err
 		}
 	}
-	return New(context.Background(), url, opts...), nil
+	return New(url, logger, transport), nil
 }
 
 // SetRetryPolicy sets a the given retry policy for all requests.

--- a/samples/gen-go-deprecated/client/go.mod
+++ b/samples/gen-go-deprecated/client/go.mod
@@ -9,9 +9,6 @@ require (
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
 	github.com/donovanhide/eventsource v0.0.0-20171031113327-3ed64d21fb0b
 	github.com/smartystreets/goconvey v1.7.2 // indirect
-	go.opentelemetry.io/otel v1.9.0
-	go.opentelemetry.io/otel/sdk v1.9.0
-
 )
 //Replace directives will work locally but mess up imports.
 replace github.com/Clever/wag/samples/gen-go-deprecated/models/v9 => ../models 

--- a/samples/gen-go-errors/client/client.go
+++ b/samples/gen-go-errors/client/client.go
@@ -1,6 +1,5 @@
 package client
 
-// Using Alpha version of WAG Yay!
 import (
 	"bytes"
 	"context"
@@ -9,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -20,13 +18,6 @@ import (
 	wcl "github.com/Clever/wag/logging/wagclientlogger"
 
 	"github.com/afex/hystrix-go/hystrix"
-
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 )
 
 var _ = json.Marshal
@@ -55,197 +46,23 @@ type WagClient struct {
 
 var _ Client = (*WagClient)(nil)
 
-//This pattern is used instead of using closures for greater transparency and the ability to implement additional interfaces.
-type options struct {
-	transport    http.RoundTripper
-	logger       wcl.WagClientLogger
-	instrumentor Instrumentor
-	exporter     sdktrace.SpanExporter
-}
+// New creates a new client. The base path, logger, and http transport are configurable.
+// The logger provided should be specifically created for this wag client. If tracing is required,
+// provide an instrumented transport using the wag clientconfig module. If no tracing is required, pass nil to use
+// the default transport.
+func New(basePath string, logger wcl.WagClientLogger, transport *http.RoundTripper) *WagClient {
 
-type Option interface {
-	apply(*options)
-}
-
-//WithLogger sets client logger option.
-func WithLogger(log wcl.WagClientLogger) Option {
-	return loggerOption{Log: log}
-}
-
-type loggerOption struct {
-	Log wcl.WagClientLogger
-}
-
-func (l loggerOption) apply(opts *options) {
-	opts.logger = l.Log
-}
-
-type roundTripperOption struct {
-	rt http.RoundTripper
-}
-
-func (t roundTripperOption) apply(opts *options) {
-	opts.transport = t.rt
-}
-
-// WithRoundTripper allows you to pass in intrumented/custom roundtrippers which will then wrap the
-// transport roundtripper
-func WithRoundTripper(t http.RoundTripper) Option {
-	return roundTripperOption{rt: t}
-}
-
-// Instrumentor is a function that creates an instrumented round tripper
-type Instrumentor func(baseTransport http.RoundTripper, spanNameCtxValue interface{}, tp sdktrace.TracerProvider) http.RoundTripper
-
-// WithInstrumentor sets a instrumenting function that will be used to wrap the roundTripper for tracing.
-// For standard instrumentation with tracing use tracing.InstrumentedTransport, default is non-instrumented.
-
-func WithInstrumentor(fn Instrumentor) Option {
-	return instrumentorOption{instrumentor: fn}
-}
-
-type instrumentorOption struct {
-	instrumentor Instrumentor
-}
-
-func (i instrumentorOption) apply(opts *options) {
-	opts.instrumentor = i.instrumentor
-}
-
-// WithExporter sets client span exporter option.
-func WithExporter(se sdktrace.SpanExporter) Option {
-	return exporterOption{exporter: se}
-}
-
-type exporterOption struct {
-	exporter sdktrace.SpanExporter
-}
-
-func (se exporterOption) apply(opts *options) {
-	opts.exporter = se.exporter
-}
-
-//----------------------BEGIN LOGGING RELATED FUNCTIONS----------------------
-
-// NewLogger creates a logger for id that produces logs at and below the indicated level.
-// level here indicates the level at and below which logs are created.
-func NewLogger(id string, level wcl.LogLevel) PrintlnLogger {
-	return PrintlnLogger{id: id, level: level}
-}
-
-type PrintlnLogger struct {
-	level wcl.LogLevel
-	id    string
-}
-
-func (w PrintlnLogger) Log(level wcl.LogLevel, message string, m map[string]interface{}) {
-
-	if level >= level {
-		m["id"] = w.id
-		jsonLog, err := json.Marshal(m)
-		if err != nil {
-			jsonLog, err = json.Marshal(map[string]interface{}{"Error Marshalling Log": err})
-		}
-		fmt.Println(string(jsonLog))
+	t := http.DefaultTransport
+	if transport != nil {
+		t = *transport
 	}
-}
-
-//----------------------END LOGGING RELATED FUNCTIONS------------------------
-
-//----------------------BEGIN TRACING RELATED FUNCTIONS----------------------
-
-// newResource returns a resource describing this application.
-// Used for setting up tracer provider
-func newResource() *resource.Resource {
-	r, _ := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("swagger-test"),
-			semconv.ServiceVersionKey.String("9.0.0"),
-		),
-	)
-	return r
-}
-
-func newTracerProvider(exporter sdktrace.SpanExporter, samplingProbability float64) *sdktrace.TracerProvider {
-
-	tp := sdktrace.NewTracerProvider(
-		// We use the default ID generator. In order for sampling to work (at least with this sampler)
-		// the ID generator must generate trace IDs uniformly at random from the entire space of uint64.
-		// For example, the default x-ray ID generator does not do this.
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		// These maximums are to guard against something going wrong and sending a ton of data unexpectedly
-		sdktrace.WithSpanLimits(sdktrace.SpanLimits{
-			AttributeCountLimit: 100,
-			EventCountLimit:     100,
-			LinkCountLimit:      100,
-		}),
-		//Batcher is more efficient, switch to it after testing
-		// sdktrace.WithSyncer(exporter),
-		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(newResource()),
-	)
-	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
-	return tp
-}
-
-func doNothing(baseTransport http.RoundTripper, spanNameCtxValue interface{}, tp sdktrace.TracerProvider) http.RoundTripper {
-	return baseTransport
-}
-
-func determineSampling() (samplingProbability float64, err error) {
-
-	// If we're running locally, then turn off sampling. Otherwise sample
-	// 1% or whatever TRACING_SAMPLING_PROBABILITY specifies.
-	samplingProbability = 0.01
-	isLocal := os.Getenv("_IS_LOCAL") == "true"
-	if isLocal {
-		fmt.Println("Set to Local")
-		samplingProbability = 1.0
-	} else if v := os.Getenv("TRACING_SAMPLING_PROBABILITY"); v != "" {
-		samplingProbabilityFromEnv, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			return 0, fmt.Errorf("could not parse '%s' to float", v)
-		}
-		samplingProbability = samplingProbabilityFromEnv
-	}
-	return
-}
-
-//----------------------END TRACING RELATEDFUNCTIONS----------------------
-
-// New creates a new client. The base path and http transport are configurable.
-func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
-
-	defaultTransport := http.DefaultTransport
-	defaultLogger := NewLogger("swagger-test-wagclient", wcl.Info)
-	defaultExporter := tracetest.NewNoopExporter()
-	defaultInstrumentor := doNothing
 
 	basePath = strings.TrimSuffix(basePath, "/")
 	base := baseDoer{}
+
 	// For the short-term don't use the default retry policy since its 5 retries can 5X
 	// the traffic. Once we've enabled circuit breakers by default we can turn it on.
 	retry := retryDoer{d: base, retryPolicy: SingleRetryPolicy{}}
-	options := options{
-		transport:    defaultTransport,
-		logger:       defaultLogger,
-		exporter:     defaultExporter,
-		instrumentor: defaultInstrumentor,
-	}
-
-	for _, o := range opts {
-		o.apply(&options)
-	}
-
-	samplingProbability := 1.0 // Hard setting this to one for now, because right now
-	// it is essentially ignored as the sidecar is determining the sample rate it forwards on to DD.
-	// Thus the prefered approach is to sample locally with the sidecar.
-
-	tp := newTracerProvider(options.exporter, samplingProbability)
-	options.transport = options.instrumentor(options.transport, ctx, *tp)
 
 	circuit := &circuitBreakerDoer{
 		d: &retry,
@@ -253,19 +70,20 @@ func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
 		debug: true,
 		// one circuit for each service + url pair
 		circuitName: fmt.Sprintf("swagger-test-%s", shortHash(basePath)),
-		logger:      options.logger,
+		logger:      logger,
 	}
 	circuit.init()
+
 	client := &WagClient{
 		basePath:    basePath,
 		requestDoer: circuit,
 		client: &http.Client{
-			Transport: options.transport,
+			Transport: t,
 		},
 		retryDoer:      &retry,
 		circuitDoer:    circuit,
 		defaultTimeout: 5 * time.Second,
-		logger:         options.logger,
+		logger:         logger,
 	}
 	client.SetCircuitBreakerSettings(DefaultCircuitBreakerSettings)
 	return client
@@ -273,7 +91,10 @@ func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
 
 // NewFromDiscovery creates a client from the discovery environment variables. This method requires
 // the three env vars: SERVICE_SWAGGER_TEST_HTTP_(HOST/PORT/PROTO) to be set. Otherwise it returns an error.
-func NewFromDiscovery(opts ...Option) (*WagClient, error) {
+// The logger provided should be specifically created for this wag client. If tracing is required,
+// provide an instrumented transport using the wag clientconfig module. If no tracing is required, pass nil to use
+// the default transport.
+func NewFromDiscovery(logger wcl.WagClientLogger, transport *http.RoundTripper) (*WagClient, error) {
 	url, err := discovery.URL("swagger-test", "default")
 	if err != nil {
 		url, err = discovery.URL("swagger-test", "http") // Added fallback to maintain reverse compatibility
@@ -281,7 +102,7 @@ func NewFromDiscovery(opts ...Option) (*WagClient, error) {
 			return nil, err
 		}
 	}
-	return New(context.Background(), url, opts...), nil
+	return New(url, logger, transport), nil
 }
 
 // SetRetryPolicy sets a the given retry policy for all requests.

--- a/samples/gen-go-errors/client/go.mod
+++ b/samples/gen-go-errors/client/go.mod
@@ -9,9 +9,6 @@ require (
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
 	github.com/donovanhide/eventsource v0.0.0-20171031113327-3ed64d21fb0b
 	github.com/smartystreets/goconvey v1.7.2 // indirect
-	go.opentelemetry.io/otel v1.9.0
-	go.opentelemetry.io/otel/sdk v1.9.0
-
 )
 //Replace directives will work locally but mess up imports.
 replace github.com/Clever/wag/samples/gen-go-errors/models/v9 => ../models 

--- a/samples/gen-go-nils/client/client.go
+++ b/samples/gen-go-nils/client/client.go
@@ -1,6 +1,5 @@
 package client
 
-// Using Alpha version of WAG Yay!
 import (
 	"bytes"
 	"context"
@@ -9,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -20,13 +18,6 @@ import (
 	wcl "github.com/Clever/wag/logging/wagclientlogger"
 
 	"github.com/afex/hystrix-go/hystrix"
-
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/propagation"
-	"go.opentelemetry.io/otel/sdk/resource"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	"go.opentelemetry.io/otel/sdk/trace/tracetest"
-	semconv "go.opentelemetry.io/otel/semconv/v1.10.0"
 )
 
 var _ = json.Marshal
@@ -55,197 +46,23 @@ type WagClient struct {
 
 var _ Client = (*WagClient)(nil)
 
-//This pattern is used instead of using closures for greater transparency and the ability to implement additional interfaces.
-type options struct {
-	transport    http.RoundTripper
-	logger       wcl.WagClientLogger
-	instrumentor Instrumentor
-	exporter     sdktrace.SpanExporter
-}
+// New creates a new client. The base path, logger, and http transport are configurable.
+// The logger provided should be specifically created for this wag client. If tracing is required,
+// provide an instrumented transport using the wag clientconfig module. If no tracing is required, pass nil to use
+// the default transport.
+func New(basePath string, logger wcl.WagClientLogger, transport *http.RoundTripper) *WagClient {
 
-type Option interface {
-	apply(*options)
-}
-
-//WithLogger sets client logger option.
-func WithLogger(log wcl.WagClientLogger) Option {
-	return loggerOption{Log: log}
-}
-
-type loggerOption struct {
-	Log wcl.WagClientLogger
-}
-
-func (l loggerOption) apply(opts *options) {
-	opts.logger = l.Log
-}
-
-type roundTripperOption struct {
-	rt http.RoundTripper
-}
-
-func (t roundTripperOption) apply(opts *options) {
-	opts.transport = t.rt
-}
-
-// WithRoundTripper allows you to pass in intrumented/custom roundtrippers which will then wrap the
-// transport roundtripper
-func WithRoundTripper(t http.RoundTripper) Option {
-	return roundTripperOption{rt: t}
-}
-
-// Instrumentor is a function that creates an instrumented round tripper
-type Instrumentor func(baseTransport http.RoundTripper, spanNameCtxValue interface{}, tp sdktrace.TracerProvider) http.RoundTripper
-
-// WithInstrumentor sets a instrumenting function that will be used to wrap the roundTripper for tracing.
-// For standard instrumentation with tracing use tracing.InstrumentedTransport, default is non-instrumented.
-
-func WithInstrumentor(fn Instrumentor) Option {
-	return instrumentorOption{instrumentor: fn}
-}
-
-type instrumentorOption struct {
-	instrumentor Instrumentor
-}
-
-func (i instrumentorOption) apply(opts *options) {
-	opts.instrumentor = i.instrumentor
-}
-
-// WithExporter sets client span exporter option.
-func WithExporter(se sdktrace.SpanExporter) Option {
-	return exporterOption{exporter: se}
-}
-
-type exporterOption struct {
-	exporter sdktrace.SpanExporter
-}
-
-func (se exporterOption) apply(opts *options) {
-	opts.exporter = se.exporter
-}
-
-//----------------------BEGIN LOGGING RELATED FUNCTIONS----------------------
-
-// NewLogger creates a logger for id that produces logs at and below the indicated level.
-// level here indicates the level at and below which logs are created.
-func NewLogger(id string, level wcl.LogLevel) PrintlnLogger {
-	return PrintlnLogger{id: id, level: level}
-}
-
-type PrintlnLogger struct {
-	level wcl.LogLevel
-	id    string
-}
-
-func (w PrintlnLogger) Log(level wcl.LogLevel, message string, m map[string]interface{}) {
-
-	if level >= level {
-		m["id"] = w.id
-		jsonLog, err := json.Marshal(m)
-		if err != nil {
-			jsonLog, err = json.Marshal(map[string]interface{}{"Error Marshalling Log": err})
-		}
-		fmt.Println(string(jsonLog))
+	t := http.DefaultTransport
+	if transport != nil {
+		t = *transport
 	}
-}
-
-//----------------------END LOGGING RELATED FUNCTIONS------------------------
-
-//----------------------BEGIN TRACING RELATED FUNCTIONS----------------------
-
-// newResource returns a resource describing this application.
-// Used for setting up tracer provider
-func newResource() *resource.Resource {
-	r, _ := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceNameKey.String("nil-test"),
-			semconv.ServiceVersionKey.String("9.0.0"),
-		),
-	)
-	return r
-}
-
-func newTracerProvider(exporter sdktrace.SpanExporter, samplingProbability float64) *sdktrace.TracerProvider {
-
-	tp := sdktrace.NewTracerProvider(
-		// We use the default ID generator. In order for sampling to work (at least with this sampler)
-		// the ID generator must generate trace IDs uniformly at random from the entire space of uint64.
-		// For example, the default x-ray ID generator does not do this.
-		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		// These maximums are to guard against something going wrong and sending a ton of data unexpectedly
-		sdktrace.WithSpanLimits(sdktrace.SpanLimits{
-			AttributeCountLimit: 100,
-			EventCountLimit:     100,
-			LinkCountLimit:      100,
-		}),
-		//Batcher is more efficient, switch to it after testing
-		// sdktrace.WithSyncer(exporter),
-		sdktrace.WithBatcher(exporter),
-		sdktrace.WithResource(newResource()),
-	)
-	otel.SetTracerProvider(tp)
-	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))
-	return tp
-}
-
-func doNothing(baseTransport http.RoundTripper, spanNameCtxValue interface{}, tp sdktrace.TracerProvider) http.RoundTripper {
-	return baseTransport
-}
-
-func determineSampling() (samplingProbability float64, err error) {
-
-	// If we're running locally, then turn off sampling. Otherwise sample
-	// 1% or whatever TRACING_SAMPLING_PROBABILITY specifies.
-	samplingProbability = 0.01
-	isLocal := os.Getenv("_IS_LOCAL") == "true"
-	if isLocal {
-		fmt.Println("Set to Local")
-		samplingProbability = 1.0
-	} else if v := os.Getenv("TRACING_SAMPLING_PROBABILITY"); v != "" {
-		samplingProbabilityFromEnv, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			return 0, fmt.Errorf("could not parse '%s' to float", v)
-		}
-		samplingProbability = samplingProbabilityFromEnv
-	}
-	return
-}
-
-//----------------------END TRACING RELATEDFUNCTIONS----------------------
-
-// New creates a new client. The base path and http transport are configurable.
-func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
-
-	defaultTransport := http.DefaultTransport
-	defaultLogger := NewLogger("nil-test-wagclient", wcl.Info)
-	defaultExporter := tracetest.NewNoopExporter()
-	defaultInstrumentor := doNothing
 
 	basePath = strings.TrimSuffix(basePath, "/")
 	base := baseDoer{}
+
 	// For the short-term don't use the default retry policy since its 5 retries can 5X
 	// the traffic. Once we've enabled circuit breakers by default we can turn it on.
 	retry := retryDoer{d: base, retryPolicy: SingleRetryPolicy{}}
-	options := options{
-		transport:    defaultTransport,
-		logger:       defaultLogger,
-		exporter:     defaultExporter,
-		instrumentor: defaultInstrumentor,
-	}
-
-	for _, o := range opts {
-		o.apply(&options)
-	}
-
-	samplingProbability := 1.0 // Hard setting this to one for now, because right now
-	// it is essentially ignored as the sidecar is determining the sample rate it forwards on to DD.
-	// Thus the prefered approach is to sample locally with the sidecar.
-
-	tp := newTracerProvider(options.exporter, samplingProbability)
-	options.transport = options.instrumentor(options.transport, ctx, *tp)
 
 	circuit := &circuitBreakerDoer{
 		d: &retry,
@@ -253,19 +70,20 @@ func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
 		debug: true,
 		// one circuit for each service + url pair
 		circuitName: fmt.Sprintf("nil-test-%s", shortHash(basePath)),
-		logger:      options.logger,
+		logger:      logger,
 	}
 	circuit.init()
+
 	client := &WagClient{
 		basePath:    basePath,
 		requestDoer: circuit,
 		client: &http.Client{
-			Transport: options.transport,
+			Transport: t,
 		},
 		retryDoer:      &retry,
 		circuitDoer:    circuit,
 		defaultTimeout: 5 * time.Second,
-		logger:         options.logger,
+		logger:         logger,
 	}
 	client.SetCircuitBreakerSettings(DefaultCircuitBreakerSettings)
 	return client
@@ -273,7 +91,10 @@ func New(ctx context.Context, basePath string, opts ...Option) *WagClient {
 
 // NewFromDiscovery creates a client from the discovery environment variables. This method requires
 // the three env vars: SERVICE_NIL_TEST_HTTP_(HOST/PORT/PROTO) to be set. Otherwise it returns an error.
-func NewFromDiscovery(opts ...Option) (*WagClient, error) {
+// The logger provided should be specifically created for this wag client. If tracing is required,
+// provide an instrumented transport using the wag clientconfig module. If no tracing is required, pass nil to use
+// the default transport.
+func NewFromDiscovery(logger wcl.WagClientLogger, transport *http.RoundTripper) (*WagClient, error) {
 	url, err := discovery.URL("nil-test", "default")
 	if err != nil {
 		url, err = discovery.URL("nil-test", "http") // Added fallback to maintain reverse compatibility
@@ -281,7 +102,7 @@ func NewFromDiscovery(opts ...Option) (*WagClient, error) {
 			return nil, err
 		}
 	}
-	return New(context.Background(), url, opts...), nil
+	return New(url, logger, transport), nil
 }
 
 // SetRetryPolicy sets a the given retry policy for all requests.

--- a/samples/gen-go-nils/client/go.mod
+++ b/samples/gen-go-nils/client/go.mod
@@ -9,9 +9,6 @@ require (
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
 	github.com/donovanhide/eventsource v0.0.0-20171031113327-3ed64d21fb0b
 	github.com/smartystreets/goconvey v1.7.2 // indirect
-	go.opentelemetry.io/otel v1.9.0
-	go.opentelemetry.io/otel/sdk v1.9.0
-
 )
 //Replace directives will work locally but mess up imports.
 replace github.com/Clever/wag/samples/gen-go-nils/models/v9 => ../models 


### PR DESCRIPTION
This PR updates the wag client creation API to require a logger and transport, as discussed in this [spec](https://docs.google.com/document/d/19eNjVWxx7xAJ1RWzfdli4CN0vaMuwoEXX-3fNlHAnto/edit). 

Look at this[ branch of messaging-service ](https://github.com/Clever/messaging-service/compare/test-new-wag-client?expand=1#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R81)to see what it would look like to create a client in this new world.

This[ file is an example](https://github.com/Clever/messaging-service/blob/29d5194f25e16f4403987ca23904547addf6e91e/gen-go/client/client.go) of what a new generated client will look like.

- [ ] Run `make build`
- [ ] Run `make generate`
- [ ] Update the current version in the `/VERSION` file. WILL DO BEFORE MERGING
