### PR TITLE
Fix models attributes for DynamoDB generated tests

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,6 @@
-v9.1.1
+v9.1.2
+
+v9.1.2 Fixes for models attributes for DynamoDB generated tests
 
 v9.1.1 Fixes for unused aws import in DynamoDB tests
 

--- a/server/gendb/templatefuncs.go
+++ b/server/gendb/templatefuncs.go
@@ -610,9 +610,12 @@ func exampleValueNotPtrForAttribute(config XDBConfig, attributeName string, i in
 			if !ok {
 				panic("expected spec.Schema")
 			}
+			ref := propertySchema.Ref.String()
+			refSplit := strings.Split(ref, "/")
+			state := swag.ToGoName(refSplit[len(refSplit)-1])
 			enumVals := schema.SchemaProps.Enum
 			if enumLength := len(enumVals); enumLength > 0 {
-				return fmt.Sprintf(`models.Branch%s`, swag.ToGoName(enumVals[(i-1)%enumLength].(string)))
+				return fmt.Sprintf(`models.%s%s`, state, swag.ToGoName(enumVals[(i-1)%enumLength].(string)))
 			}
 		}
 	} else if ca := findCompositeAttribute(config, attributeName); ca != nil {


### PR DESCRIPTION
**JIRA:** https://clever.atlassian.net/browse/INFRANG-4970

**Overview:**

_What does this change do?_
>This change attempts to fix wrongly generated models attributes(state/branch) for DynamoDB tests. This can be seen in catapult tests 

_Why is this change needed?_
>Previous test file had erroneous models attributes. Current change attempts to fix those.

_How was this change tested?_
> Tested by generating catapult tests using the updated WAG templates and comparing before and after.

**Before:**

		models.DeploymentV2{
			Application: "string1",
			CreatedAt:   mustTime("2018-03-11T15:04:01+07:00"),
			Environment: "string1",
			ID:          "string1",
			State:       models.BranchDeploying,
		}
		
**After:**

		models.DeploymentV2{
			Application: "string1",
			CreatedAt:   mustTime("2018-03-11T15:04:01+07:00"),
			Environment: "string1",
			ID:          "string1",
			State:       models.DeploymentV2StateSummaryDeploying,
		}

Ref doc: https://docs.google.com/document/d/12RNsB3oxNnZA02dHN11CHlCCPk2g2lgibyLESfbpcyo/edit

**Checklist:**

- [x] Run `make build`
- [x] Run `make generate`
- [x] Update the current version in the `/VERSION` file.


