### PR TITLE
[INFRANG-6029] Fix sync js iterator

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,4 @@
-v9.1.7
+v9.1.8 Bugfix for generated JS client sync forEach method
 
 v9.1.7 Fix a model that's just "type:string" generates invalid code 
 

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -501,7 +501,7 @@ const methodTmplStr = `
                     }
                   }
                 } else {
-                  body.forEach(f)
+                  body{{$.IterResourceAccessString}}.forEach(f)
                 }
               }
               {{- else -}}

--- a/samples/gen-js-client-only/index.js
+++ b/samples/gen-js-client-only/index.js
@@ -449,7 +449,7 @@ class SwaggerTest {
                     }
                   }
                 } else {
-                  body.forEach(f)
+                  body.authorSet.results.forEach(f)
                 }
               }
               break;
@@ -714,7 +714,7 @@ class SwaggerTest {
                     }
                   }
                 } else {
-                  body.forEach(f)
+                  body.authorSet.results.forEach(f)
                 }
               }
               break;

--- a/samples/gen-js/index.js
+++ b/samples/gen-js/index.js
@@ -449,7 +449,7 @@ class SwaggerTest {
                     }
                   }
                 } else {
-                  body.forEach(f)
+                  body.authorSet.results.forEach(f)
                 }
               }
               break;
@@ -714,7 +714,7 @@ class SwaggerTest {
                     }
                   }
                 } else {
-                  body.forEach(f)
+                  body.authorSet.results.forEach(f)
                 }
               }
               break;


### PR DESCRIPTION
## Jira

https://clever.atlassian.net/browse/INFRANG-6029

## Overview

When we first split the JS iterator into a `forEach` and a `forEachAsync`, we missed a spot in putting the correct template for the sync version. See https://github.com/Clever/wag/pull/303 . You can compare the edited line to the (functional) lines a few lines above it.

## Testing

(Internal Clever notes - hard to create an isolated reproduction) I checked out sd2 at commit  ef6a858be - one before https://github.com/Clever/sd2/pull/7767 and reproduced FLARE-1630. Then I did the following:
1. Ran this branch of wag on app-view-service to generate a JS client
2. Copied that index.js file into sd2's node_modules
3. Tried the repro again

And the issue no longer reproduced (the desired behavior actually worked).