### PR TITLE
Release ordering fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,6 @@ jobs:
       - run: make build
       - run: sudo npm install -g jsdoc-to-markdown@^4.0.0
       - run: make test
-      - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then make release && $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN release; fi;
       - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then make release && $HOME/ci-scripts/circleci/submodule-github-release $GH_RELEASE_TOKEN clientconfig; fi;
       - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then make release && $HOME/ci-scripts/circleci/submodule-github-release $GH_RELEASE_TOKEN logging/wagclientlogger; fi;
+      - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then make release && $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN release; fi;


### PR DESCRIPTION
## Jira

https://clever.atlassian.net/browse/INFRANG-6597

(Please add a link to a Jira ticket. If you are external to Clever, we can create this for you.)

## Testing

Changing ordering, can confirm after release

## Checklist
- [ ] Run `make build`
- [ ] Run `make generate`
- [ ] Update the current version in the `/VERSION` file. First line should be JUST the version e.g. `v10.13.1`. Then a blank line. Then release notes.
