### PR TITLE
add asynclocalstore option to wag-js client

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,4 +1,7 @@
-v9.5.2
+v9.5.3
+
+v9.5.3 wag-js client can now accept an optional asynclocalstore at initialization whose context can
+then be passed on as baggage. 
 
 v9.5.2 Bug fix in baggage options for JS client, wag-js baggage is now always a map. Server propagation now uses clever-request-id provided in baggage if available, and produces a uuid if it is not, instead of defaulting to traceid.
 

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -311,6 +311,7 @@ class {{.ClassName}} {
       this.asynclocalstore = options.asynclocalstore;
     }
 
+
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
     // hystrix implements a caching mechanism, we don't want this or we can't trust that clients
     // are initialized with the values passed in. 
@@ -435,7 +436,9 @@ const methodTmplStr = `
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 

--- a/clients/js/genjs.go
+++ b/clients/js/genjs.go
@@ -1398,7 +1398,6 @@ interface GenericOptions {
   circuit?: CircuitOptions;
   serviceName?: string;
   asynclocalstore?: object;
-
 }
 
 interface DiscoveryOptions {

--- a/samples/gen-js-blog/README.md
+++ b/samples/gen-js-blog/README.md
@@ -49,6 +49,7 @@ Create a new client object.
 | [options.circuit.requestVolumeThreshold] | <code>number</code> |  | The minimum number of requests needed before a circuit can be tripped due to health. Default: 20. |
 | [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
 | [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
+| [options.asynclocalstore] | <code>object</code> |  | a request scoped async store |
 
 <a name="module_blog--Blog+close"></a>
 

--- a/samples/gen-js-blog/index.d.ts
+++ b/samples/gen-js-blog/index.d.ts
@@ -37,6 +37,8 @@ interface GenericOptions {
   logger?: Logger;
   circuit?: CircuitOptions;
   serviceName?: string;
+  asynclocalstore?: object;
+
 }
 
 interface DiscoveryOptions {

--- a/samples/gen-js-blog/index.js
+++ b/samples/gen-js-blog/index.js
@@ -216,6 +216,7 @@ class Blog {
       this.asynclocalstore = options.asynclocalstore;
     }
 
+
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
     // hystrix implements a caching mechanism, we don't want this or we can't trust that clients
     // are initialized with the values passed in. 
@@ -313,7 +314,9 @@ class Blog {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -433,7 +436,9 @@ class Blog {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -551,7 +556,9 @@ class Blog {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 

--- a/samples/gen-js-blog/index.js
+++ b/samples/gen-js-blog/index.js
@@ -178,6 +178,7 @@ class Blog {
    * @param {number} [options.circuit.errorPercentThreshold] - the threshold to place on the rolling error
    * rate. Once the error rate exceeds this percentage, the circuit opens.
    * Default: 90.
+   * @param {object} [options.asynclocalstore] a request scoped async store 
    */
   constructor(options) {
     options = options || {};
@@ -210,6 +211,9 @@ class Blog {
       this.logger = options.logger;
     } else {
       this.logger = new kayvee.logger((options.serviceName || "blog") + "-wagclient");
+    }
+    if (options.asynclocalstore) {
+      this.asynclocalstore = options.asynclocalstore;
     }
 
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
@@ -309,12 +313,14 @@ class Blog {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "postGradeFileForStudent";
       headers[versionHeader] = version;
@@ -427,12 +433,14 @@ class Blog {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "getSectionsForStudent";
       headers[versionHeader] = version;
@@ -543,12 +551,14 @@ class Blog {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "postSectionsForStudent";
       headers[versionHeader] = version;

--- a/samples/gen-js-client-only/README.md
+++ b/samples/gen-js-client-only/README.md
@@ -60,6 +60,7 @@ Create a new client object.
 | [options.circuit.requestVolumeThreshold] | <code>number</code> |  | The minimum number of requests needed before a circuit can be tripped due to health. Default: 20. |
 | [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
 | [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
+| [options.asynclocalstore] | <code>object</code> |  | a request scoped async store |
 
 <a name="module_swagger-test--SwaggerTest+close"></a>
 

--- a/samples/gen-js-client-only/index.d.ts
+++ b/samples/gen-js-client-only/index.d.ts
@@ -37,6 +37,8 @@ interface GenericOptions {
   logger?: Logger;
   circuit?: CircuitOptions;
   serviceName?: string;
+  asynclocalstore?: object;
+
 }
 
 interface DiscoveryOptions {

--- a/samples/gen-js-client-only/index.js
+++ b/samples/gen-js-client-only/index.js
@@ -178,6 +178,7 @@ class SwaggerTest {
    * @param {number} [options.circuit.errorPercentThreshold] - the threshold to place on the rolling error
    * rate. Once the error rate exceeds this percentage, the circuit opens.
    * Default: 90.
+   * @param {object} [options.asynclocalstore] a request scoped async store 
    */
   constructor(options) {
     options = options || {};
@@ -210,6 +211,9 @@ class SwaggerTest {
       this.logger = options.logger;
     } else {
       this.logger = new kayvee.logger((options.serviceName || "swagger-test") + "-wagclient");
+    }
+    if (options.asynclocalstore) {
+      this.asynclocalstore = options.asynclocalstore;
     }
 
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
@@ -309,12 +313,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "getAuthors";
       headers[versionHeader] = version;
@@ -416,12 +422,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "getAuthors";
       headers[versionHeader] = version;
@@ -583,12 +591,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "getAuthorsWithPut";
       headers[versionHeader] = version;
@@ -693,12 +703,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "getAuthorsWithPut";
       headers[versionHeader] = version;
@@ -870,12 +882,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "getBooks";
       headers[versionHeader] = version;
@@ -1019,12 +1033,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "getBooks";
       headers[versionHeader] = version;
@@ -1219,12 +1235,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "createBook";
       headers[versionHeader] = version;
@@ -1333,12 +1351,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "putBook";
       headers[versionHeader] = version;
@@ -1451,12 +1471,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "getBookByID";
       headers[versionHeader] = version;
@@ -1590,12 +1612,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "getBookByID2";
       headers[versionHeader] = version;
@@ -1709,12 +1733,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "healthCheck";
       headers[versionHeader] = version;
@@ -1820,12 +1846,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "lowercaseModelsTest";
       headers[versionHeader] = version;

--- a/samples/gen-js-client-only/index.js
+++ b/samples/gen-js-client-only/index.js
@@ -216,6 +216,7 @@ class SwaggerTest {
       this.asynclocalstore = options.asynclocalstore;
     }
 
+
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
     // hystrix implements a caching mechanism, we don't want this or we can't trust that clients
     // are initialized with the values passed in. 
@@ -313,7 +314,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -422,7 +425,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -591,7 +596,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -703,7 +710,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -882,7 +891,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -1033,7 +1044,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -1235,7 +1248,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -1351,7 +1366,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -1471,7 +1488,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -1612,7 +1631,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -1733,7 +1754,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -1846,7 +1869,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 

--- a/samples/gen-js-db-custom-path/README.md
+++ b/samples/gen-js-db-custom-path/README.md
@@ -47,6 +47,7 @@ Create a new client object.
 | [options.circuit.requestVolumeThreshold] | <code>number</code> |  | The minimum number of requests needed before a circuit can be tripped due to health. Default: 20. |
 | [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
 | [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
+| [options.asynclocalstore] | <code>object</code> |  | a request scoped async store |
 
 <a name="module_swagger-test--SwaggerTest+close"></a>
 

--- a/samples/gen-js-db-custom-path/index.d.ts
+++ b/samples/gen-js-db-custom-path/index.d.ts
@@ -37,6 +37,8 @@ interface GenericOptions {
   logger?: Logger;
   circuit?: CircuitOptions;
   serviceName?: string;
+  asynclocalstore?: object;
+
 }
 
 interface DiscoveryOptions {

--- a/samples/gen-js-db-custom-path/index.js
+++ b/samples/gen-js-db-custom-path/index.js
@@ -178,6 +178,7 @@ class SwaggerTest {
    * @param {number} [options.circuit.errorPercentThreshold] - the threshold to place on the rolling error
    * rate. Once the error rate exceeds this percentage, the circuit opens.
    * Default: 90.
+   * @param {object} [options.asynclocalstore] a request scoped async store 
    */
   constructor(options) {
     options = options || {};
@@ -210,6 +211,9 @@ class SwaggerTest {
       this.logger = options.logger;
     } else {
       this.logger = new kayvee.logger((options.serviceName || "swagger-test") + "-wagclient");
+    }
+    if (options.asynclocalstore) {
+      this.asynclocalstore = options.asynclocalstore;
     }
 
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
@@ -307,12 +311,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "healthCheck";
       headers[versionHeader] = version;

--- a/samples/gen-js-db-custom-path/index.js
+++ b/samples/gen-js-db-custom-path/index.js
@@ -216,6 +216,7 @@ class SwaggerTest {
       this.asynclocalstore = options.asynclocalstore;
     }
 
+
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
     // hystrix implements a caching mechanism, we don't want this or we can't trust that clients
     // are initialized with the values passed in. 
@@ -311,7 +312,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 

--- a/samples/gen-js-db/README.md
+++ b/samples/gen-js-db/README.md
@@ -47,6 +47,7 @@ Create a new client object.
 | [options.circuit.requestVolumeThreshold] | <code>number</code> |  | The minimum number of requests needed before a circuit can be tripped due to health. Default: 20. |
 | [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
 | [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
+| [options.asynclocalstore] | <code>object</code> |  | a request scoped async store |
 
 <a name="module_swagger-test--SwaggerTest+close"></a>
 

--- a/samples/gen-js-db/index.d.ts
+++ b/samples/gen-js-db/index.d.ts
@@ -37,6 +37,8 @@ interface GenericOptions {
   logger?: Logger;
   circuit?: CircuitOptions;
   serviceName?: string;
+  asynclocalstore?: object;
+
 }
 
 interface DiscoveryOptions {

--- a/samples/gen-js-db/index.js
+++ b/samples/gen-js-db/index.js
@@ -178,6 +178,7 @@ class SwaggerTest {
    * @param {number} [options.circuit.errorPercentThreshold] - the threshold to place on the rolling error
    * rate. Once the error rate exceeds this percentage, the circuit opens.
    * Default: 90.
+   * @param {object} [options.asynclocalstore] a request scoped async store 
    */
   constructor(options) {
     options = options || {};
@@ -210,6 +211,9 @@ class SwaggerTest {
       this.logger = options.logger;
     } else {
       this.logger = new kayvee.logger((options.serviceName || "swagger-test") + "-wagclient");
+    }
+    if (options.asynclocalstore) {
+      this.asynclocalstore = options.asynclocalstore;
     }
 
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
@@ -307,12 +311,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "healthCheck";
       headers[versionHeader] = version;

--- a/samples/gen-js-db/index.js
+++ b/samples/gen-js-db/index.js
@@ -216,6 +216,7 @@ class SwaggerTest {
       this.asynclocalstore = options.asynclocalstore;
     }
 
+
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
     // hystrix implements a caching mechanism, we don't want this or we can't trust that clients
     // are initialized with the values passed in. 
@@ -311,7 +312,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 

--- a/samples/gen-js-deprecated/README.md
+++ b/samples/gen-js-deprecated/README.md
@@ -47,6 +47,7 @@ Create a new client object.
 | [options.circuit.requestVolumeThreshold] | <code>number</code> |  | The minimum number of requests needed before a circuit can be tripped due to health. Default: 20. |
 | [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
 | [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
+| [options.asynclocalstore] | <code>object</code> |  | a request scoped async store |
 
 <a name="module_swagger-test--SwaggerTest+close"></a>
 

--- a/samples/gen-js-deprecated/index.d.ts
+++ b/samples/gen-js-deprecated/index.d.ts
@@ -37,6 +37,8 @@ interface GenericOptions {
   logger?: Logger;
   circuit?: CircuitOptions;
   serviceName?: string;
+  asynclocalstore?: object;
+
 }
 
 interface DiscoveryOptions {

--- a/samples/gen-js-deprecated/index.js
+++ b/samples/gen-js-deprecated/index.js
@@ -216,6 +216,7 @@ class SwaggerTest {
       this.asynclocalstore = options.asynclocalstore;
     }
 
+
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
     // hystrix implements a caching mechanism, we don't want this or we can't trust that clients
     // are initialized with the values passed in. 

--- a/samples/gen-js-deprecated/index.js
+++ b/samples/gen-js-deprecated/index.js
@@ -178,6 +178,7 @@ class SwaggerTest {
    * @param {number} [options.circuit.errorPercentThreshold] - the threshold to place on the rolling error
    * rate. Once the error rate exceeds this percentage, the circuit opens.
    * Default: 90.
+   * @param {object} [options.asynclocalstore] a request scoped async store 
    */
   constructor(options) {
     options = options || {};
@@ -210,6 +211,9 @@ class SwaggerTest {
       this.logger = options.logger;
     } else {
       this.logger = new kayvee.logger((options.serviceName || "swagger-test") + "-wagclient");
+    }
+    if (options.asynclocalstore) {
+      this.asynclocalstore = options.asynclocalstore;
     }
 
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);

--- a/samples/gen-js-errors/README.md
+++ b/samples/gen-js-errors/README.md
@@ -48,6 +48,7 @@ Create a new client object.
 | [options.circuit.requestVolumeThreshold] | <code>number</code> |  | The minimum number of requests needed before a circuit can be tripped due to health. Default: 20. |
 | [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
 | [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
+| [options.asynclocalstore] | <code>object</code> |  | a request scoped async store |
 
 <a name="module_swagger-test--SwaggerTest+close"></a>
 

--- a/samples/gen-js-errors/index.d.ts
+++ b/samples/gen-js-errors/index.d.ts
@@ -37,6 +37,8 @@ interface GenericOptions {
   logger?: Logger;
   circuit?: CircuitOptions;
   serviceName?: string;
+  asynclocalstore?: object;
+
 }
 
 interface DiscoveryOptions {

--- a/samples/gen-js-errors/index.js
+++ b/samples/gen-js-errors/index.js
@@ -216,6 +216,7 @@ class SwaggerTest {
       this.asynclocalstore = options.asynclocalstore;
     }
 
+
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
     // hystrix implements a caching mechanism, we don't want this or we can't trust that clients
     // are initialized with the values passed in. 
@@ -314,7 +315,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 

--- a/samples/gen-js-errors/index.js
+++ b/samples/gen-js-errors/index.js
@@ -178,6 +178,7 @@ class SwaggerTest {
    * @param {number} [options.circuit.errorPercentThreshold] - the threshold to place on the rolling error
    * rate. Once the error rate exceeds this percentage, the circuit opens.
    * Default: 90.
+   * @param {object} [options.asynclocalstore] a request scoped async store 
    */
   constructor(options) {
     options = options || {};
@@ -210,6 +211,9 @@ class SwaggerTest {
       this.logger = options.logger;
     } else {
       this.logger = new kayvee.logger((options.serviceName || "swagger-test") + "-wagclient");
+    }
+    if (options.asynclocalstore) {
+      this.asynclocalstore = options.asynclocalstore;
     }
 
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
@@ -310,12 +314,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "getBook";
       headers[versionHeader] = version;

--- a/samples/gen-js-nils/README.md
+++ b/samples/gen-js-nils/README.md
@@ -47,6 +47,7 @@ Create a new client object.
 | [options.circuit.requestVolumeThreshold] | <code>number</code> |  | The minimum number of requests needed before a circuit can be tripped due to health. Default: 20. |
 | [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
 | [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
+| [options.asynclocalstore] | <code>object</code> |  | a request scoped async store |
 
 <a name="module_nil-test--NilTest+close"></a>
 

--- a/samples/gen-js-nils/index.d.ts
+++ b/samples/gen-js-nils/index.d.ts
@@ -37,6 +37,8 @@ interface GenericOptions {
   logger?: Logger;
   circuit?: CircuitOptions;
   serviceName?: string;
+  asynclocalstore?: object;
+
 }
 
 interface DiscoveryOptions {

--- a/samples/gen-js-nils/index.js
+++ b/samples/gen-js-nils/index.js
@@ -178,6 +178,7 @@ class NilTest {
    * @param {number} [options.circuit.errorPercentThreshold] - the threshold to place on the rolling error
    * rate. Once the error rate exceeds this percentage, the circuit opens.
    * Default: 90.
+   * @param {object} [options.asynclocalstore] a request scoped async store 
    */
   constructor(options) {
     options = options || {};
@@ -210,6 +211,9 @@ class NilTest {
       this.logger = options.logger;
     } else {
       this.logger = new kayvee.logger((options.serviceName || "nil-test") + "-wagclient");
+    }
+    if (options.asynclocalstore) {
+      this.asynclocalstore = options.asynclocalstore;
     }
 
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
@@ -312,12 +316,14 @@ class NilTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "nilCheck";
       headers[versionHeader] = version;

--- a/samples/gen-js-nils/index.js
+++ b/samples/gen-js-nils/index.js
@@ -216,6 +216,7 @@ class NilTest {
       this.asynclocalstore = options.asynclocalstore;
     }
 
+
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
     // hystrix implements a caching mechanism, we don't want this or we can't trust that clients
     // are initialized with the values passed in. 
@@ -316,7 +317,9 @@ class NilTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 

--- a/samples/gen-js-strings/README.md
+++ b/samples/gen-js-strings/README.md
@@ -47,6 +47,7 @@ Create a new client object.
 | [options.circuit.requestVolumeThreshold] | <code>number</code> |  | The minimum number of requests needed before a circuit can be tripped due to health. Default: 20. |
 | [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
 | [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
+| [options.asynclocalstore] | <code>object</code> |  | a request scoped async store |
 
 <a name="module_nil-test--NilTest+close"></a>
 

--- a/samples/gen-js-strings/index.d.ts
+++ b/samples/gen-js-strings/index.d.ts
@@ -37,6 +37,8 @@ interface GenericOptions {
   logger?: Logger;
   circuit?: CircuitOptions;
   serviceName?: string;
+  asynclocalstore?: object;
+
 }
 
 interface DiscoveryOptions {

--- a/samples/gen-js-strings/index.js
+++ b/samples/gen-js-strings/index.js
@@ -178,6 +178,7 @@ class NilTest {
    * @param {number} [options.circuit.errorPercentThreshold] - the threshold to place on the rolling error
    * rate. Once the error rate exceeds this percentage, the circuit opens.
    * Default: 90.
+   * @param {object} [options.asynclocalstore] a request scoped async store 
    */
   constructor(options) {
     options = options || {};
@@ -210,6 +211,9 @@ class NilTest {
       this.logger = options.logger;
     } else {
       this.logger = new kayvee.logger((options.serviceName || "nil-test") + "-wagclient");
+    }
+    if (options.asynclocalstore) {
+      this.asynclocalstore = options.asynclocalstore;
     }
 
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
@@ -310,12 +314,14 @@ class NilTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "getDistricts";
       headers[versionHeader] = version;

--- a/samples/gen-js-strings/index.js
+++ b/samples/gen-js-strings/index.js
@@ -216,6 +216,7 @@ class NilTest {
       this.asynclocalstore = options.asynclocalstore;
     }
 
+
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
     // hystrix implements a caching mechanism, we don't want this or we can't trust that clients
     // are initialized with the values passed in. 
@@ -314,7 +315,9 @@ class NilTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 

--- a/samples/gen-js/README.md
+++ b/samples/gen-js/README.md
@@ -60,6 +60,7 @@ Create a new client object.
 | [options.circuit.requestVolumeThreshold] | <code>number</code> |  | The minimum number of requests needed before a circuit can be tripped due to health. Default: 20. |
 | [options.circuit.sleepWindow] | <code>number</code> |  | how long, in milliseconds, to wait after a circuit opens before testing for recovery. Default: 5000. |
 | [options.circuit.errorPercentThreshold] | <code>number</code> |  | the threshold to place on the rolling error rate. Once the error rate exceeds this percentage, the circuit opens. Default: 90. |
+| [options.asynclocalstore] | <code>object</code> |  | a request scoped async store |
 
 <a name="module_swagger-test--SwaggerTest+close"></a>
 

--- a/samples/gen-js/index.d.ts
+++ b/samples/gen-js/index.d.ts
@@ -37,6 +37,8 @@ interface GenericOptions {
   logger?: Logger;
   circuit?: CircuitOptions;
   serviceName?: string;
+  asynclocalstore?: object;
+
 }
 
 interface DiscoveryOptions {

--- a/samples/gen-js/index.js
+++ b/samples/gen-js/index.js
@@ -216,6 +216,7 @@ class SwaggerTest {
       this.asynclocalstore = options.asynclocalstore;
     }
 
+
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
     // hystrix implements a caching mechanism, we don't want this or we can't trust that clients
     // are initialized with the values passed in. 
@@ -313,7 +314,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -422,7 +425,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -591,7 +596,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -703,7 +710,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -882,7 +891,10 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
+      console.log("combinedContext:", combinedContext)
 
       const timeout = options.timeout || this.timeout;
 
@@ -1033,7 +1045,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -1235,7 +1249,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -1351,7 +1367,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -1471,7 +1489,10 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
+      console.log("combinedContext:", combinedContext)
 
       const timeout = options.timeout || this.timeout;
 
@@ -1612,7 +1633,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -1733,7 +1756,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 
@@ -1846,7 +1871,9 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
-      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+      const storeContext = this.asynclocalstore?.get("context") || new Map();
+
+      const combinedContext = new Map([...storeContext, ...optionsBaggage]);
 
       const timeout = options.timeout || this.timeout;
 

--- a/samples/gen-js/index.js
+++ b/samples/gen-js/index.js
@@ -178,6 +178,7 @@ class SwaggerTest {
    * @param {number} [options.circuit.errorPercentThreshold] - the threshold to place on the rolling error
    * rate. Once the error rate exceeds this percentage, the circuit opens.
    * Default: 90.
+   * @param {object} [options.asynclocalstore] a request scoped async store 
    */
   constructor(options) {
     options = options || {};
@@ -210,6 +211,9 @@ class SwaggerTest {
       this.logger = options.logger;
     } else {
       this.logger = new kayvee.logger((options.serviceName || "swagger-test") + "-wagclient");
+    }
+    if (options.asynclocalstore) {
+      this.asynclocalstore = options.asynclocalstore;
     }
 
     const circuitOptions = Object.assign({}, defaultCircuitOptions, options.circuit);
@@ -309,12 +313,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "getAuthors";
       headers[versionHeader] = version;
@@ -416,12 +422,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "getAuthors";
       headers[versionHeader] = version;
@@ -583,12 +591,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "getAuthorsWithPut";
       headers[versionHeader] = version;
@@ -693,12 +703,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "getAuthorsWithPut";
       headers[versionHeader] = version;
@@ -870,12 +882,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "getBooks";
       headers[versionHeader] = version;
@@ -1019,12 +1033,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "getBooks";
       headers[versionHeader] = version;
@@ -1219,12 +1235,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "createBook";
       headers[versionHeader] = version;
@@ -1333,12 +1351,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "putBook";
       headers[versionHeader] = version;
@@ -1451,12 +1471,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "getBookByID";
       headers[versionHeader] = version;
@@ -1590,12 +1612,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "getBookByID2";
       headers[versionHeader] = version;
@@ -1709,12 +1733,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "healthCheck";
       headers[versionHeader] = version;
@@ -1820,12 +1846,14 @@ class SwaggerTest {
   
       const optionsBaggage = options.baggage || new Map();
 
+      const combinedContext = new Map([...this.asynclocalstore.get("context"), ...optionsBaggage]);
+
       const timeout = options.timeout || this.timeout;
 
       let headers = {};
       
-      // Convert optionsBaggage into a string using parseForBaggage
-      headers["baggage"] = parseForBaggage(optionsBaggage);
+      // Convert combinedContext into a string using parseForBaggage
+      headers["baggage"] = parseForBaggage(combinedContext);
       
       headers["Canonical-Resource"] = "lowercaseModelsTest";
       headers[versionHeader] = version;

--- a/samples/gen-js/package-lock.json
+++ b/samples/gen-js/package-lock.json
@@ -1,0 +1,905 @@
+{
+  "name": "swagger-test",
+  "version": "9.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "swagger-test",
+      "version": "9.0.0",
+      "dependencies": {
+        "async": "^2.1.4",
+        "clever-discovery": "0.0.8",
+        "hystrixjs": "^0.2.0",
+        "kayvee": "^3.13.0",
+        "request": "^2.87.0",
+        "rxjs": "^5.4.1"
+      },
+      "devDependencies": {
+        "typescript": "^3.3.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw=="
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+    },
+    "node_modules/clever-discovery": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/clever-discovery/-/clever-discovery-0.0.8.tgz",
+      "integrity": "sha512-o1x6v+p9+dt5S5Y2dk7yzI72JvwG3FQ14KsIYo+K7JSVk1VmLrRx92GKv6ZbrAFteYfBABm3Uvghk+ER2Bc0ng=="
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ=="
+    },
+    "node_modules/dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
+      "dependencies": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "node_modules/extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
+      "engines": [
+        "node >=0.6.0"
+      ]
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+    },
+    "node_modules/fast-stats": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/fast-stats/-/fast-stats-0.0.3.tgz",
+      "integrity": "sha512-GCDJBJEDccRpAuMcVe+OfMnovhXNPMTuiBl08ZysjcJdSfNNHn1exukCHGNp3q+vbKP2ZuDDhi6w03ad1vFTBw==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.0",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/har-validator": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "deprecated": "this library is no longer supported",
+      "dependencies": {
+        "ajv": "^6.12.3",
+        "har-schema": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.8",
+        "npm": ">=1.3.7"
+      }
+    },
+    "node_modules/hystrixjs": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/hystrixjs/-/hystrixjs-0.2.0.tgz",
+      "integrity": "sha512-IuyxI6MotAwZUfAdBVc7YRo79tu0RMqjdTGkw8DR7M/loWAjvQFLoqbBeUqpvOMiNesJ/E0NpsHYIDMwd396Ew==",
+      "dependencies": {
+        "fast-stats": "0.0.3"
+      },
+      "peerDependencies": {
+        "rxjs": "^5.0.0"
+      }
+    },
+    "node_modules/is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
+    },
+    "node_modules/jsonschema": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.5.0.tgz",
+      "integrity": "sha512-K+A9hhqbn0f3pJX17Q/7H6yQfD/5OXgdrR5UE12gMXCiN9D5Xq2o5mddV2QEcX/bjla99ASsAAQUyMCCRWAEhw==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jsprim": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
+      "dependencies": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.4.0",
+        "verror": "1.10.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/kayvee": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/kayvee/-/kayvee-3.18.0.tgz",
+      "integrity": "sha512-2kNl4IS+hOBh7/oim34GIGbwzMFPZvUMWYiBfsNPecCFLsWhisW2RGm8hHlurujcCZ9fLRTTzpvkaL58QKDNUw==",
+      "dependencies": {
+        "js-yaml": "^3.6.1",
+        "jsonschema": "^1.1.0",
+        "morgan": "^1.7.0",
+        "qs": "^6.9.4",
+        "split": "^1.0.0",
+        "underscore": "^1.8.3"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "dependencies": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
+      "dependencies": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/request/node_modules/qs": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
+      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "5.5.12",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+      "dependencies": {
+        "symbol-observable": "1.0.1"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "node_modules/sshpk": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
+      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
+      "dependencies": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-observable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+      "integrity": "sha512-Kb3PrPYz4HanVF1LVGuAdW6LoVgIwjUYJGzFe7NDrBLCN4lsV/5J0MFurV+ygS4bRVwrCEt2c7MQ1R2a72oJDw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "node_modules/tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "dependencies": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
+    },
+    "node_modules/typescript": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g=="
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
+    }
+  }
+}

--- a/samples/test/js/operations.js
+++ b/samples/test/js/operations.js
@@ -7,6 +7,35 @@ const mockAddress = "http://localhost:8000";
 const alternateMockAddress = "http://localhost:8001";
 
 describe("operations", function() {
+  it("properly combines store and options baggage", function(done) {
+    const context = new Map();
+    context.set("ClientIP", "123.123.123.123");
+    context.set("session_id", "1234567890");
+    store = new Map([["context", context]])
+    const c = new Client({address: mockAddress, asynclocalstore: store});
+    const params = {
+      bookID: "the-mediocre-gatsby",
+    }
+    const mockResponse = {hello: "world", headers: {}};
+    let baggageHeader = ""
+    const scope = nock(mockAddress)
+    .get(`/v1/books/${params.bookID}`)
+    .reply(200, function(uri, requestBody) {
+      baggageHeader = this.req.headers["baggage"];
+      return mockResponse;
+    });
+
+
+    baggage = new Map()
+    baggage.set("foo", "bar")
+    options = { baggage }
+    c.getBookByID({bookID: params.bookID}, options, function(err, resp) {
+      assert.ifError(err);
+      assert.strictEqual(baggageHeader, 'ClientIP=123.123.123.123,session_id=1234567890,foo=bar');
+      scope.done();
+      done();
+    });
+  });
 
   it("properly sets baggage headers", function(done) {
 
@@ -165,3 +194,5 @@ describe("operations", function() {
     });
   });
 });
+
+


### PR DESCRIPTION
## Jira
https://clever.atlassian.net/browse/INFRANG-6537

add asynclocalstore option to wag-js client

This was surprisingly simple to do but testing was annoying. 

## Testing
Tested locally by first making these changes in an imported district-view-service wag-js client in a local node app. Then creating and passing a store and seeing the baggage flow. 


## Checklist
- [x] Run `make build`
- [x] Run `make generate`
- [x] Update the current version in the `/VERSION` file. First line should be JUST the version e.g. `v10.13.1`. Then a blank line. Then release notes.
