### PR TITLE
[INFRANG-6876] Downgrade submodules and code gen to 1.21 until WAG service upgrade is complete

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,9 @@ jobs:
       # Many of these may be bad tests, but we need to investigate.
       # Please run tests locally before merging.
       # - run: make test
+      - run:
+        name: vet
+        command: go vet -mod=readonly $(go list ./...)
       - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then make release && $HOME/ci-scripts/circleci/submodule-github-release $GH_RELEASE_TOKEN clientconfig; fi;
       - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then make release && $HOME/ci-scripts/circleci/submodule-github-release $GH_RELEASE_TOKEN logging/wagclientlogger; fi;
       - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then make release && $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN release; fi;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,8 @@ jobs:
       # Please run tests locally before merging.
       # - run: make test
       - run:
-        name: vet
-        command: go vet -mod=readonly $(go list ./...)
+          name: vet
+          command: go vet -mod=readonly $(go list ./...)
       - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then make release && $HOME/ci-scripts/circleci/submodule-github-release $GH_RELEASE_TOKEN clientconfig; fi;
       - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then make release && $HOME/ci-scripts/circleci/submodule-github-release $GH_RELEASE_TOKEN logging/wagclientlogger; fi;
       - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then make release && $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN release; fi;

--- a/VERSION
+++ b/VERSION
@@ -1,7 +1,10 @@
-v9.7.0
-Go 1.24 upgrade
+v9.7.1
+Downgrade generated modules and submodules to 1.21 until every wag service is upgraded
 
 Previously:
+
+v9.7.0
+Go 1.24 upgrade
 
 v9.6.0
 remove hystrix-go dependency from wag go clients, fix some tests.

--- a/clientconfig/go.mod
+++ b/clientconfig/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/clientconfig/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/Clever/kayvee-go/v7 v7.7.0

--- a/clients/go/gengo.go
+++ b/clients/go/gengo.go
@@ -207,7 +207,7 @@ func CreateModFile(path string, basePath string, codeTemplate clientCodeTemplate
 	modFileString := `
 module ` + codeTemplate.ModuleName + codeTemplate.OutputPath + `/client` + codeTemplate.VersionSuffix + `
 
-go 1.24
+go 1.21
 
 require (
 	github.com/Clever/discovery-go v1.8.1

--- a/logging/wagclientlogger/go.mod
+++ b/logging/wagclientlogger/go.mod
@@ -1,3 +1,3 @@
 module github.com/Clever/wag/logging/wagclientlogger
 
-go 1.24
+go 1.21

--- a/models/genmodels.go
+++ b/models/genmodels.go
@@ -73,7 +73,7 @@ func CreateModFile(path string, basePath, packageName, outputPath string) error 
 module ` + moduleName + outputPath + `/models` + versionSuffix + `
 
 
-go 1.24
+go 1.21
 
 require (
 	github.com/go-openapi/errors v0.20.2

--- a/samples/gen-go-basic/client/go.mod
+++ b/samples/gen-go-basic/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/samples/gen-go-basic/client/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/Clever/discovery-go v1.8.1

--- a/samples/gen-go-basic/models/go.mod
+++ b/samples/gen-go-basic/models/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/samples/gen-go-basic/models/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/go-openapi/errors v0.20.2

--- a/samples/gen-go-blog/client/go.mod
+++ b/samples/gen-go-blog/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/samples/gen-go-blog/client/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/Clever/discovery-go v1.8.1

--- a/samples/gen-go-blog/models/go.mod
+++ b/samples/gen-go-blog/models/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/samples/gen-go-blog/models/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/go-openapi/errors v0.20.2

--- a/samples/gen-go-client-only/client/go.mod
+++ b/samples/gen-go-client-only/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/samples/gen-go-client-only/client/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/Clever/discovery-go v1.8.1

--- a/samples/gen-go-client-only/models/go.mod
+++ b/samples/gen-go-client-only/models/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/samples/gen-go-client-only/models/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/go-openapi/errors v0.20.2

--- a/samples/gen-go-db-custom-path/client/go.mod
+++ b/samples/gen-go-db-custom-path/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/samples/gen-go-db-custom-path/client/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/Clever/discovery-go v1.8.1

--- a/samples/gen-go-db-custom-path/models/go.mod
+++ b/samples/gen-go-db-custom-path/models/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/samples/gen-go-db-custom-path/models/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/go-openapi/errors v0.20.2

--- a/samples/gen-go-db-only/models/go.mod
+++ b/samples/gen-go-db-only/models/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/samples/gen-go-db-only/models/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/go-openapi/errors v0.20.2

--- a/samples/gen-go-db/client/go.mod
+++ b/samples/gen-go-db/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/samples/gen-go-db/client/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/Clever/discovery-go v1.8.1

--- a/samples/gen-go-db/models/go.mod
+++ b/samples/gen-go-db/models/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/samples/gen-go-db/models/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/go-openapi/errors v0.20.2

--- a/samples/gen-go-deprecated/client/go.mod
+++ b/samples/gen-go-deprecated/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/samples/gen-go-deprecated/client/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/Clever/discovery-go v1.8.1

--- a/samples/gen-go-deprecated/models/go.mod
+++ b/samples/gen-go-deprecated/models/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/samples/gen-go-deprecated/models/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/go-openapi/strfmt v0.21.2

--- a/samples/gen-go-errors/client/go.mod
+++ b/samples/gen-go-errors/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/samples/gen-go-errors/client/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/Clever/discovery-go v1.8.1

--- a/samples/gen-go-errors/models/go.mod
+++ b/samples/gen-go-errors/models/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/samples/gen-go-errors/models/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/go-openapi/strfmt v0.21.2

--- a/samples/gen-go-nils/client/go.mod
+++ b/samples/gen-go-nils/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/samples/gen-go-nils/client/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/Clever/discovery-go v1.8.1

--- a/samples/gen-go-nils/models/go.mod
+++ b/samples/gen-go-nils/models/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/samples/gen-go-nils/models/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/go-openapi/strfmt v0.21.2

--- a/samples/gen-go-strings/client/go.mod
+++ b/samples/gen-go-strings/client/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/samples/gen-go-strings/client/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/Clever/discovery-go v1.8.1

--- a/samples/gen-go-strings/models/go.mod
+++ b/samples/gen-go-strings/models/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/samples/gen-go-strings/models/v9
 
-go 1.24
+go 1.21
 
 require (
 	github.com/go-openapi/strfmt v0.21.2

--- a/tracing/go.mod
+++ b/tracing/go.mod
@@ -1,6 +1,6 @@
 module github.com/Clever/wag/tracing
 
-go 1.24
+go 1.21
 
 require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.2 // indirect


### PR DESCRIPTION
## Jira
https://clever.atlassian.net/browse/INFRANG-6876

# About
Turns out my testing in the 1.24 upgrade PR was poor testing and it broke builds in everything that wasn't upgraded yet, so we need to downgrade for now.

## Testing
samples packages are correctly generated as 1.21

## Checklist
- [x] Run `make build`
- [x] Run `make generate`
- [x] Update the current version in the `/VERSION` file. First line should be JUST the version e.g. `v10.13.1`. Then a blank line. Then release notes.
