### PR TITLE
version numbers skipped

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,3 +1,6 @@
+v9.9.2
+Update only the version to skip over used pre-release version numbers (v9.9.0, v9.9.1)
+
 v9.8.1
 Update go version in go.mod files for clients and models to 1.24 from 1.24.0
 


### PR DESCRIPTION
## Jira
https://clever.atlassian.net/browse/INFRANG-7056

## Overview
This PR only changes wag version. Skips to `v9.9.2` as `v9.9.0` and `v9.9.1` were used as pre-release versions for `aws-sdk-go-v2` testing phases.

## Testing
Just version file change

## Checklist
- [x] Run `make build`
- [x] Run `make generate`
- [x] Update the current version in the `/VERSION` file. First line should be JUST the version e.g. `v10.13.1`. Then a blank line. Then release notes.
